### PR TITLE
feat: Output RDF validation errors to Summary

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,10 +10,10 @@ export default {
   coverageReporters: ['json-summary', 'text'],
   coverageThreshold: {
     global: {
-      lines: 18.46,
-      statements: 18.46,
-      branches: 14.15,
-      functions: 16.32,
+      lines: 17.39,
+      statements: 17.39,
+      branches: 10.56,
+      functions: 15.68,
     },
   },
   transform: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,15 +27,16 @@ new Pipeline({
     },
     queryEngine
   ),
-  steps: [
-    new DistributionAnalyzer(),
-    new RdfDumpImporter(
-      new GraphDBClient({
-        url: config.GRAPHDB_URL as string,
-        username: config.GRAPHDB_USERNAME as string,
-        password: config.GRAPHDB_PASSWORD as string,
-        repository: `${config.GRAPHDB_REPOSITORY}-imports` as string,
-      })
+  analyzers: [
+    new DistributionAnalyzer(
+      new RdfDumpImporter(
+        new GraphDBClient({
+          url: config.GRAPHDB_URL as string,
+          username: config.GRAPHDB_USERNAME as string,
+          password: config.GRAPHDB_PASSWORD as string,
+          repository: `${config.GRAPHDB_REPOSITORY}-imports` as string,
+        })
+      )
     ),
     await SparqlQueryAnalyzer.fromFile(queryEngine, 'class-partition.rq'),
     await SparqlQueryAnalyzer.fromFile(queryEngine, 'object-literals.rq'),

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -2,7 +2,6 @@ import {SummaryWriter} from './writer.js';
 import {Selector} from './selector.js';
 import {Store} from 'n3';
 import {withProvenance} from './provenance.js';
-import {Importer} from './importer.js';
 import {DatasetCore} from 'rdf-js';
 import {Analyzer} from './analyzer.js';
 
@@ -25,7 +24,7 @@ export class Pipeline {
   constructor(
     private readonly config: {
       selector: Selector;
-      steps: (Analyzer | Importer)[];
+      analyzers: Analyzer[];
       writers: SummaryWriter[];
     }
   ) {}
@@ -36,7 +35,7 @@ export class Pipeline {
     for (const dataset of datasets) {
       console.info(`Analyzing dataset ${dataset.iri}`);
       const store = new Store();
-      for (const step of this.config.steps) {
+      for (const step of this.config.analyzers) {
         const start = new Date();
         const result = await step.execute(dataset);
         const end = new Date();

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -21,7 +21,7 @@ describe('Pipeline', () => {
         },
         queryEngine
       ),
-      steps: [],
+      analyzers: [],
       writers: [new FileWriter()],
     });
     await pipeline.run();


### PR DESCRIPTION
* Wrap Importer in DistributionAnalyzer because we need to share data
  between them.
* That allows to remove the direct dependency between Pipeline and
  Importer and attach only Analyzers (again) to the Pipeline.

Fix #46
