### PR TITLE
fix: Set base URI when storing summary

### DIFF
--- a/src/graphdb.ts
+++ b/src/graphdb.ts
@@ -32,7 +32,11 @@ export class GraphDBClient implements WriterSparqlClient, ImporterSparqlClient {
 
   async store(dataset: Dataset, summary: DatasetCore): Promise<void> {
     try {
-      await this.repository.putQuads([...summary], dataset.iri);
+      await this.repository.putQuads(
+        [...summary],
+        dataset.iri,
+        `<${dataset.iri}>`
+      );
     } catch (e) {
       console.error(
         'Write to GraphDB failed for dataset ' + dataset.iri,


### PR DESCRIPTION
Fix error `Unable to resolve URIs, no base URI has been set` when
storing summaries, caused by #66, which introduced relative URIs 
for classPartitions.
