### PR TITLE
Updating tagging to sort alphabetically for the latest

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.sha_short }}
+            ${{ steps.vars.outputs.docker_image }}:1.${{ github.run_number }}.${{ steps.vars.outputs.sha_short }}
             ${{ steps.vars.outputs.docker_image }}:latest
 
       - uses: digitalocean/action-doctl@v2


### PR DESCRIPTION
Changing the tagging in a way that leaves the old tags alone, but still be able to select the alphabetically latest tag (*.run-number.*) from a range (1.*.*) .