### PR TITLE
feat: select JSON-LD/zipped distributions and pass compressFormat through

### DIFF
--- a/queries/selection/dataset-with-rdf-distribution.rq
+++ b/queries/selection/dataset-with-rdf-distribution.rq
@@ -10,6 +10,7 @@ CONSTRUCT {
     ?distribution a dcat:Distribution ;
         dcat:accessURL ?distribution_url ;
         dcat:mediaType ?distribution_mediaType ;
+        dcat:compressFormat ?distribution_compressFormat ;
         dcat:byteSize ?distribution_size ;
         dct:conformsTo ?conformsTo ;
         dct:modified ?distribution_modified .
@@ -21,18 +22,18 @@ CONSTRUCT {
 
     ?distribution dcat:accessURL ?distribution_url .
     OPTIONAL { ?distribution dcat:mediaType ?distribution_mediaType . }
+    OPTIONAL { ?distribution dcat:compressFormat ?distribution_compressFormat . }
 #    OPTIONAL { ?distribution dcat:byteSize ?distribution_size . }
     OPTIONAL { ?distribution dct:modified ?distribution_modified . }
     OPTIONAL { ?distribution dct:conformsTo ?conformsTo. }
+    # The dataset register normalizes `+gzip`/`+zip` mediaType suffixes into a
+    # separate dcat:compressFormat, so only the plain RDF mediaTypes need to
+    # be listed here.
     FILTER(?conformsTo = <https://www.w3.org/TR/sparql11-protocol/>
         || ?distribution_mediaType = <https://www.iana.org/assignments/media-types/application/ld+json>
-        || ?distribution_mediaType = <https://www.iana.org/assignments/media-types/application/ld+json+gzip>
         || ?distribution_mediaType = <https://www.iana.org/assignments/media-types/application/n-quads>
-        || ?distribution_mediaType = <https://www.iana.org/assignments/media-types/application/n-quads+gzip>
         || ?distribution_mediaType = <https://www.iana.org/assignments/media-types/application/n-triples>
-        || ?distribution_mediaType = <https://www.iana.org/assignments/media-types/application/n-triples+gzip>
         || ?distribution_mediaType = <https://www.iana.org/assignments/media-types/text/turtle>
-        || ?distribution_mediaType = <https://www.iana.org/assignments/media-types/text/turtle+gzip>
     )
 
     # Exclude dataset descriptions that are no longer valid.


### PR DESCRIPTION
Refs #284.

Companion of ldelements/lde#397, which teaches `@lde/sparql-qlever` to handle JSON-LD and zip-compressed distributions. This PR is the consumer-side change here in the DKG.

## Changes

- Emit `dcat:compressFormat` in the CONSTRUCT so the LDE `Distribution` model receives the compression info it now uses to decide between `gunzip -c` (gzip), `unzip -p` (zip) and JSON-LD preprocessing.
- `OPTIONAL { ?distribution dcat:compressFormat ?distribution_compressFormat }` added to the WHERE.
- Drop the `application/{ld+json,n-quads,n-triples}+gzip` and `text/turtle+gzip` lines from the `FILTER`: the dataset register normalizes those suffixes into a separate `dcat:compressFormat` during ingestion, so those values never appear in `?distribution_mediaType`. The lines were dead.

## What it unlocks

Now selectable end-to-end:
- Gzipped JSON-LD — e.g. Nijmegen `LOD+Beelddocumenten.jsonld.gz` (`mediaType=application/ld+json` + `compressFormat=application/gzip`).
- Plain JSON-LD — already in the FILTER, now actually processable.
- Zipped JSON-LD when the publisher declares the inner format — i.e. `encodingFormat=application/ld+json+zip` on the schema.org side, which the register splits into `mediaType=application/ld+json` + `compressFormat=application/zip`.

## What it does NOT unlock

The Verhaal van Utrecht (`vvu_verhalen`) distribution mentioned in #284 declares `encodingFormat=application/zip` alone, with the inner format only in a free-text `description`. The pipeline intentionally rejects that — without a declared inner mediaType we can't safely process the archive. The publisher needs to update their schema.org to `application/ld+json+zip`.
