### PR TITLE
feat: detect IIIF Presentation manifests per dataset

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -17,3 +17,4 @@ jobs:
       - run: npm install
       - run: npm run lint
       - run: npm run compile
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -303,6 +303,24 @@ Licenses that apply to resources in the dataset.
     ].
 ```
 
+### IIIF Presentation manifests
+
+Datasets that expose [IIIF Presentation API](http://iiif.io/api/presentation/)
+manifests — detected by matching `schema:encodingFormat` literals against the
+[SCHEMA-AP-NDE](https://docs.nde.nl/schema-profile/) IIIF profile pattern — get
+a `void:subset` keyed on `dcterms:conformsTo <http://iiif.io/api/presentation/>`
+with a `void:entities` count of distinct manifests. v2 and v3 manifests are
+collapsed into a single, version-less subset; the `\d+` in the regex makes the
+detection forwards-compatible with future Presentation API versions.
+
+```ttl
+<https://example.com/dataset> a void:Dataset;
+    void:subset [
+        dcterms:conformsTo <http://iiif.io/api/presentation/> ;
+        void:entities 42 .
+    ].
+```
+
 ### Distributions
 
 All declared RDF distributions are validated:

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -41,7 +41,7 @@ module.exports = [
       parserOptions: {
         ecmaVersion: 2018,
         sourceType: 'module',
-        project: './tsconfig.json',
+        project: './tsconfig.eslint.json',
       },
     },
     rules: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "rdf-dereference": "^5.0.0"
       },
       "devDependencies": {
+        "@comunica/query-sparql-rdfjs-lite": "^5.2.3",
         "@eslint/js": "^10.0.1",
         "@rdfjs/types": "^2.0.1",
         "@types/n3": "^1.16.4",
@@ -34,7 +35,8 @@
         "prettier": "^3.8.3",
         "tsc-watch": "^7.2.0",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.60.0"
+        "typescript-eslint": "^8.60.0",
+        "vitest": "^4.1.7"
       },
       "engines": {
         "node": ">=22"
@@ -66,13 +68,13 @@
       }
     },
     "node_modules/@comunica/actor-abstract-mediatyped": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-5.2.2.tgz",
-      "integrity": "sha512-Qw86hIMPOab5u7KrGT5bJ3JwDUbPX4j8LnlZxCFQZTgUYS1tAUisLoEGH+WDTuo5Ou41A5+0U3jHY0PvNp/h7g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-5.2.3.tgz",
+      "integrity": "sha512-9zgeR4U8cdB10Mb9VSOuhzJGiufSmjb1N+CwVMQY65gOjXPmfXcybFjzGFKPFbmYOsB2mmL1aht/AXzODlJcaQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0"
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -94,18 +96,18 @@
       }
     },
     "node_modules/@comunica/actor-abstract-path": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-5.2.2.tgz",
-      "integrity": "sha512-uv076i9kkedqBNy5HbDMHYb54USA57SUdka0u3Egcu80uBQG6AeuFj26tQjqy80R4t8ZcAIYh8uaIa0LsZeyfA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-5.2.3.tgz",
+      "integrity": "sha512-E/+3d9hU0Ks7JDlyvNkoARKNmY/71cW22rBGJq0UxUfrNrK0SjHALREyOcGAOKNDdGcbOzbs6cbpDPXAK/N9DQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-bindings-factory": "^5.2.2",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "rdf-string": "^2.0.1"
@@ -116,122 +118,122 @@
       }
     },
     "node_modules/@comunica/actor-bindings-aggregator-factory-average": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-average/-/actor-bindings-aggregator-factory-average-5.2.2.tgz",
-      "integrity": "sha512-FqZ1i4x/0b6PupSUo8PZdyuIPzdYKgeKkNWjhnIgtkbwJ3Hx/+d+ZMC4Or1Vi1dn0NHD8Kx4m5iL3/XSf6GU0Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-average/-/actor-bindings-aggregator-factory-average-5.2.3.tgz",
+      "integrity": "sha512-HS7ETQmtwIFTOkRP3mRD8PKvp3ZsSTXRpn76Poo17a9VdNhLMoP0vEBTdSH/4SXWiBtvyY7W30etsX+/VPRDdw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^5.2.2",
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
+        "@comunica/bus-bindings-aggregator-factory": "^5.2.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@comunica/actor-bindings-aggregator-factory-count": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-count/-/actor-bindings-aggregator-factory-count-5.2.2.tgz",
-      "integrity": "sha512-PNgzMwi6xhScFnT4nkBizWw8UVq0BiEFCKnNxMgqSZQJ0wiTxphYf8NOhqTvyFJdjpy+XstecGT9Q4ZHbO0G8w==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-count/-/actor-bindings-aggregator-factory-count-5.2.3.tgz",
+      "integrity": "sha512-Ne1LJOEhZyYmGj7xynagGUm5BoGow4sM3b0UaxaChKOdEdWI1kBdXdknatonL5jXEL168AcYNafxlGgSJwEU9w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-bindings-aggregator-factory": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@comunica/actor-bindings-aggregator-factory-group-concat": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-group-concat/-/actor-bindings-aggregator-factory-group-concat-5.2.2.tgz",
-      "integrity": "sha512-XimN9cYdx6tq59y9lUFyi1kTu0wPjcKUfkATFOWJEviNRN8x4zC2oRKiJtMpSQ4Y3dEU5XkUDf3W3jXHjVoHkQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-group-concat/-/actor-bindings-aggregator-factory-group-concat-5.2.3.tgz",
+      "integrity": "sha512-+JAaj+ZCAiaqsilN7/EqIFvjK3NFWnmksNOJyppNOgaSF3GwRVbyTsP6i9YOudHoZBAl+nPzyclApLKURpwkkw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
+        "@comunica/bus-bindings-aggregator-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@comunica/actor-bindings-aggregator-factory-max": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-max/-/actor-bindings-aggregator-factory-max-5.2.2.tgz",
-      "integrity": "sha512-w3nhc8/oJZ1bogTUOYoAjRUu5taUuxK9l3WacPnUx3EBmHY+qDU4toZaExvmrXA1THIdc+TbvBvRPGygevYSYQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-max/-/actor-bindings-aggregator-factory-max-5.2.3.tgz",
+      "integrity": "sha512-fN602hX2gZuPFUjuQByriHz/FGY3+s5QobXoHSJbZF8EjtoecIUelKDr0czQBmyMsl1k4zUjc9JfkPGOFn9YCg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-bindings-aggregator-factory": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@comunica/actor-bindings-aggregator-factory-min": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-min/-/actor-bindings-aggregator-factory-min-5.2.2.tgz",
-      "integrity": "sha512-8ZyPyIedNgjdfYAoWpsuG0lBDYzNrCo08FQBnHeN7YKDj5bzzwcyvLta3W2IwL8MdhTieQoV61XrUo+CRXRCxQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-min/-/actor-bindings-aggregator-factory-min-5.2.3.tgz",
+      "integrity": "sha512-nnKlgNhpVYJ0GRvDprVsf/p8kKgd0sJBBFdwGSUvN1mvzuC8nXyDQOTun3EoUqBjaKjSGCevMBIyVyu4RQtKlQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-bindings-aggregator-factory": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@comunica/actor-bindings-aggregator-factory-sample": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-sample/-/actor-bindings-aggregator-factory-sample-5.2.2.tgz",
-      "integrity": "sha512-oJ7Ly+00jBl9QmeEZilVFq17HsMxRiKXz0u1xzCa6fp4TQlONR8YgodKUmx9+MQlEODA+WS2yVYMnKXqkkNuFA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-sample/-/actor-bindings-aggregator-factory-sample-5.2.3.tgz",
+      "integrity": "sha512-XKYvKOS3Byaye7P+IE1vs6VmE7d3IVZ2+Sh3wv0NCE8Du8jQrkHkIA7JJsIN/UPEP8DG4hSaH9IFGKgjJ26+Hg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-bindings-aggregator-factory": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@comunica/actor-bindings-aggregator-factory-sum": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-sum/-/actor-bindings-aggregator-factory-sum-5.2.2.tgz",
-      "integrity": "sha512-UMcu/muh1VLHYQpIdtfjY1RWjVuqcwgpLF54ehonTID5acFEfF3S1qFx32LMxZ3issmXBHA7tYBZ3IeYwUfqhg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-sum/-/actor-bindings-aggregator-factory-sum-5.2.3.tgz",
+      "integrity": "sha512-emSKR/i4L9nQ4eBI5BXIyNz8vlBHLyyTD7BONOQnqQLY/jn0Y/AUqgGet0nGxI2X2+dUEaDDYVvvwhkbo5XrZw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^5.2.2",
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
+        "@comunica/bus-bindings-aggregator-factory": "^5.2.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@comunica/actor-bindings-aggregator-factory-wildcard-count": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-wildcard-count/-/actor-bindings-aggregator-factory-wildcard-count-5.2.2.tgz",
-      "integrity": "sha512-gsIzz8+Txbu6XQlyA7rc5IMPNe+dLIkjCF9M5NV5hhtSFGdgBU26pHJYm0cCsgUb2v9tv4V9YyExHvxuzxVOSw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-wildcard-count/-/actor-bindings-aggregator-factory-wildcard-count-5.2.3.tgz",
+      "integrity": "sha512-KnvpJ1VjOAVp1HtmG7xOJpHnj2InWBPoq5CBidmo/AB9Ppq0q8ES3Rh38qKH+lIaumZze5cd5ZCpo85LOUqjLA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
+        "@comunica/bus-bindings-aggregator-factory": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "@rdfjs/types": "*",
         "rdf-string": "^2.0.1"
       }
     },
     "node_modules/@comunica/actor-context-preprocess-convert-shortcuts": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-convert-shortcuts/-/actor-context-preprocess-convert-shortcuts-5.2.2.tgz",
-      "integrity": "sha512-NlVnibV4MSnUPpVg90lg/FX3GNpCykWPvYyKH+UP1q8QSEKolBlK0ROEmdbdr54n90qOEFvcWPb0v/caFTtc4w==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-convert-shortcuts/-/actor-context-preprocess-convert-shortcuts-5.2.3.tgz",
+      "integrity": "sha512-UwAUHluJYLlu7N9dAYpM0/aLzIzWOM5cBd6YNELQkuSIBkUxpofOtZ/zQvwuhgwbsOxPQFusT6IXjrIOPX9mLQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-context-preprocess": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0"
+        "@comunica/bus-context-preprocess": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -587,15 +589,15 @@
       }
     },
     "node_modules/@comunica/actor-context-preprocess-set-defaults": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-set-defaults/-/actor-context-preprocess-set-defaults-5.2.2.tgz",
-      "integrity": "sha512-At90JB1YW0M9dG26Nci/PU8m6a+WyVUL3u8rnojxDwh7V/J7GKCdn39qr6AD1rt4CRY6x9G4DLJLi3AkR6i/rw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-set-defaults/-/actor-context-preprocess-set-defaults-5.2.3.tgz",
+      "integrity": "sha512-77RyL6xbmeltmtAfEBHz9FUtHlZ4dbXt3xK9wXXsK4pzDl42xbNUlFNiodlakyZxna40H/qAjbWzsiyJG1/4Aw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-context-preprocess": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-context-preprocess": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*",
         "rdf-data-factory": "^2.0.0"
       },
@@ -618,15 +620,15 @@
       }
     },
     "node_modules/@comunica/actor-context-preprocess-source-to-destination": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-5.2.2.tgz",
-      "integrity": "sha512-f0sVIN1X3iZ/BAK1+pJrb460H37xyOcqvEQHff0LWSxsz4eZ4EceFCol2AZOiDYeKg9bjfxpDFue6xT3Ta0EcA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-5.2.3.tgz",
+      "integrity": "sha512-F17yPV2YzFtOWsfz9Ake7yHZHwnMdWqPm7xbHTIWpmN9aEbfcDmjcDWLTilFDNjMhIRQE/7b+HUXUuXDu/3IyQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-context-preprocess": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0"
+        "@comunica/bus-context-preprocess": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -696,81 +698,81 @@
       }
     },
     "node_modules/@comunica/actor-expression-evaluator-factory-default": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-expression-evaluator-factory-default/-/actor-expression-evaluator-factory-default-5.2.2.tgz",
-      "integrity": "sha512-Ccv01/TscSm009fiLxtiakaCedNVpVToKFfnxJbPM5mlZOc2VAv5dUj+kWZSQNL3lWQbpenVRNXSZvSaSYYt8Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-expression-evaluator-factory-default/-/actor-expression-evaluator-factory-default-5.2.3.tgz",
+      "integrity": "sha512-1qruJBABB0L42z6UlvrrUbX6hVHkIqzXwgGWwBgqMsb089nHzzwEt4aH9BltWI0HHA/Q40x4owS4JHlFiOJWVg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-expression-evaluator-factory": "^5.2.2",
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-expression-evaluator-factory": "^5.2.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-bindings-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@comunica/actor-function-factory-expression-bnode": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-bnode/-/actor-function-factory-expression-bnode-5.2.2.tgz",
-      "integrity": "sha512-joe+Qi3mswWsWbRnOxMSb/jFKVCASOXVU2AAQVsYCHpXyvCHGIazfV+r9D/ZD5+1YR2iQ9A8OaGgrfdmKfTzzg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-bnode/-/actor-function-factory-expression-bnode-5.2.3.tgz",
+      "integrity": "sha512-6vqoL3QvSefjwA8rfElpOOVipB8VyE3npSSRXO/XiDr1Z4C7Sm5DoptR84bpaWOiuNvpNba3sLU9O61vyFu1SQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-data-factory": "^5.0.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-expression-bound": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-bound/-/actor-function-factory-expression-bound-5.2.2.tgz",
-      "integrity": "sha512-+kAw3x5j2Bz99asNTv8JZ9D1wRZGI+TjhM42SoePWiV55oe4iA0dPzpdFeIMS68L3e2tJ22XXlTlMot+NLZunA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-bound/-/actor-function-factory-expression-bound-5.2.3.tgz",
+      "integrity": "sha512-+GlgEPq8mqTC2MPPPgmiTWLBci5I6zAL+EaIM5jEaAMFDWSW5Qo8GpZgGasQgD+p9wElrCNPm0mj6XFxUE76Lw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-expression-coalesce": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-coalesce/-/actor-function-factory-expression-coalesce-5.2.2.tgz",
-      "integrity": "sha512-QeB/ifYPNERg+9qXgQXIRsh8Zk+sabxFi/DRsSAqomW1BiHAlvkVzMN5qoNFPeCUBy6VtMCv/plwLcGROV9RMQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-coalesce/-/actor-function-factory-expression-coalesce-5.2.3.tgz",
+      "integrity": "sha512-NOmvfI3pBmlW9v5ERrIio6zTSahpBnTrRWryn/68BQIRlv+Rf6Fqjd2xgzWpfWR9eWkxrzLCarL2n6afNa48nQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-expression-concat": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-concat/-/actor-function-factory-expression-concat-5.2.2.tgz",
-      "integrity": "sha512-mhwrlrLt/hBXWVuYC6ODrJFaTOrp7hMus6HlMpKr1bKPsOlzG1SnUnK/a8NyGktFyN5DzsDWI862fYW1KrVWaw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-concat/-/actor-function-factory-expression-concat-5.2.3.tgz",
+      "integrity": "sha512-B7XD9A+PtHsOvmFSAFcg1Q+NeVJJoaA91SGojAyvkEs/zOVP5bn1PjE/xH5PcL1XUSEONImD5dRrFOzDBH571A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-expression-extensions": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-extensions/-/actor-function-factory-expression-extensions-5.2.2.tgz",
-      "integrity": "sha512-J11dLXaDPByTSqhSbkYBEqi5fR+/UXxoCFJk9UftNlEXDHhvyZLcBE9O7VUoJtveW4x7l4p1kQIvylGbIoAAFg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-extensions/-/actor-function-factory-expression-extensions-5.2.3.tgz",
+      "integrity": "sha512-OBO4V0nOCRPR/wvC63/X5lUUHBJ86hBfmI4lTgTLfjEwVTNjxeqIDxE3H4JhuoXQ5U/mzFakB+MeOIyXkJ3VMA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "rdf-data-factory": "^2.0.0"
       }
     },
@@ -788,890 +790,890 @@
       }
     },
     "node_modules/@comunica/actor-function-factory-expression-if": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-if/-/actor-function-factory-expression-if-5.2.2.tgz",
-      "integrity": "sha512-V8GVIAswXxcsxZ0plVAAZ2Pf2neEygQDhgRdV8ARBstcPzSvXToJths3qbb3qEMyRTVjw8IFnwGe7bQVB4+h9A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-if/-/actor-function-factory-expression-if-5.2.3.tgz",
+      "integrity": "sha512-6tG9rAqNX76mobQNHC9bj6I7kPGj3SdvCMTg9PmRRox86su7RBhT7Ig3jDFvvIG3/fX5IuV37C05L+pm+GJ48Q==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-expression-in": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-in/-/actor-function-factory-expression-in-5.2.2.tgz",
-      "integrity": "sha512-hAj3ah1o2UfoEFcUn+o1MigQA05XUUA9S1f9ojRjq8XMGwt5c1FDpj+q16FqRS4yGJi8UWeVh+p6NEd9p9Z2GQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-in/-/actor-function-factory-expression-in-5.2.3.tgz",
+      "integrity": "sha512-EUmSFVmM/fwntDnex+TCGWvlA2vNpo0gsPvs2D91rKjrw//pZR4hDYT2EdfG0tb5E8WRN0dOdnUm+9H01WOITA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-expression-logical-and": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-logical-and/-/actor-function-factory-expression-logical-and-5.2.2.tgz",
-      "integrity": "sha512-DMdA7DjYA5H35xGHekuGAIgbIaU7dKrwMW3nwWnYtP8Yf8JmlxVnepdshkjb9xgY5Tzw4msXJfUJaU3DQj9Glw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-logical-and/-/actor-function-factory-expression-logical-and-5.2.3.tgz",
+      "integrity": "sha512-i0c4Q0OJIxpQzgzmInrGf1geQG4uVUEE000U9ovA22QVOUzaBE+NpM57MDnNZzvXr/I3TiAotqtUWANA9qBIMA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-expression-logical-or": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-logical-or/-/actor-function-factory-expression-logical-or-5.2.2.tgz",
-      "integrity": "sha512-6iFkxv2VamG8xjWS3WTbC6WNXQCfv2ci1Vx1lLC5sJL+WrpBzIKCELRjcVzmBzvc9a6ZRQEhGsLixFPGz3QBkw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-logical-or/-/actor-function-factory-expression-logical-or-5.2.3.tgz",
+      "integrity": "sha512-s1gGKE/pA3/cBl7GwPYtO4zUFOVvO9WJuX/+zpFpxUiO0hhrqgMo9P8eUaDijuuy1iexCewfznI7bWWSK5lw+Q==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-expression-not-in": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-not-in/-/actor-function-factory-expression-not-in-5.2.2.tgz",
-      "integrity": "sha512-MjK6wlZTpNSSSo39EfB8PfHRN7x35inAv3d+VvQc89xYWzoLmlM38C+1CkTs6ZRInPzCzHBj339RvBMr7IFlsA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-not-in/-/actor-function-factory-expression-not-in-5.2.3.tgz",
+      "integrity": "sha512-M+QnT3fLMtiYZYc8zuGuNTxWeZSH3RV36y2PFZkXN1+Ait6omgwOjcr6FEzAQPD0QzDfu7oNuCej0Vp54BOphQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-expression-same-term": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-same-term/-/actor-function-factory-expression-same-term-5.2.2.tgz",
-      "integrity": "sha512-LXpGjTRD2G1EGxf0UEwFZRnry8pFTatpi3/zmthSu3AAcdM1YwpO23w/35D3FVhWoXpNL9h/bcaFyr2egPLpEw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-same-term/-/actor-function-factory-expression-same-term-5.2.3.tgz",
+      "integrity": "sha512-ZlosA74V5T0MMLhLYpbRVTYiFheZTAa2oiGNl/OCOMxm96mNnNDMnlTGUDGU+BIUhsoiy2cwveTorXUZseAm2A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-abs": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-abs/-/actor-function-factory-term-abs-5.2.2.tgz",
-      "integrity": "sha512-Lm8GLGS+dwn8CnfgLSMPVnsMU7607wbSP/Kx04lrCD9rGwJy/+R3LSfyfq/nQ45T4SQkiZ1sGRuqc1ohOOqIVA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-abs/-/actor-function-factory-term-abs-5.2.3.tgz",
+      "integrity": "sha512-J5BX1N9l188NV4epgXyZNesVLSZEd1RONneXi34gSNIb2zTui+2J6XhcdrbVnZr/rlI647no0qpGsCDlp2x4SQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-addition": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-addition/-/actor-function-factory-term-addition-5.2.2.tgz",
-      "integrity": "sha512-oFXeSbcrEsdq/8jrK8Jcjt6wc6fiBhbPVnfTEB0B/O5ftcjvQE4g0Gfp38L7UNw23l00yWZSeNoaS8P8j5EOuw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-addition/-/actor-function-factory-term-addition-5.2.3.tgz",
+      "integrity": "sha512-oX91XZJLo+YKeq26fMkFRwpTJLofm9G5Ip7ctDwYGHTJRwq5XEd3bL4faeOlEmTShRiAB3cbUokMirVHzn8lFw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "bignumber.js": "^11.0.0"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-ceil": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-ceil/-/actor-function-factory-term-ceil-5.2.2.tgz",
-      "integrity": "sha512-2ohFT0Q1AgdFUqvPhMNJNUIMulky0dtUM1/PhgHW25gw2rXT1s0FEQfS7C3PUbYvm4QGXGQBDMbzGX4pxIn8BA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-ceil/-/actor-function-factory-term-ceil-5.2.3.tgz",
+      "integrity": "sha512-3HId+H3bJwys+DADJz+j9QMm8y4NTPEZ7Sz6+Kkmx6ncZV5T5Md86dTOpU1xyP5NYBPB9/98NUBlOecH9CpXVQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-contains": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-contains/-/actor-function-factory-term-contains-5.2.2.tgz",
-      "integrity": "sha512-F/Eb0w775aFwANJoWFG9JUmLfAwmIH/u4ykJndKcs8gzyrafmqyhs/VOcCHnkZx+LwVpHZOcwas9O64CBrQDmw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-contains/-/actor-function-factory-term-contains-5.2.3.tgz",
+      "integrity": "sha512-t7/KSsnRUTCNlvVChVVi/L3IcmA7CDE+CryNHCygo5czrxGAt0GvAuHJ6JqAfhOdcjoGCdZ7MpWVbhPzGoE31Q==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-datatype": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-datatype/-/actor-function-factory-term-datatype-5.2.2.tgz",
-      "integrity": "sha512-Impmi4SjmWmX2mitzbOwzUJs9xCHVaF9Xi6XCz1lSzbVmdxlYq0VMdJzAWxhAVQ9dKzOu9KAHQ/rVInh5wkc5w==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-datatype/-/actor-function-factory-term-datatype-5.2.3.tgz",
+      "integrity": "sha512-tEidXD12PIFJ5qFHcw9A/8650tr0RnL9frt7WhZfnh5eqDumDNAugbFD1VNLouJ9Q/yIYFA4AQfGQUE/wItmjw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-day": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-day/-/actor-function-factory-term-day-5.2.2.tgz",
-      "integrity": "sha512-9BRX4mshiAqMgjQlGqcVK31gQEVc/39/6WLDDcTCRtSVEyoXNAK4dXSKKbZFSKgttwAxWaPMT8vcNUwm8JXYpQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-day/-/actor-function-factory-term-day-5.2.3.tgz",
+      "integrity": "sha512-D399Dke60415JRCFyuV2tglwRNjjc90I/HaFTagrViWerTwyHj7ew4+poJwcnqzITburp/k43GpB+7FTgTaNzQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-division": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-division/-/actor-function-factory-term-division-5.2.2.tgz",
-      "integrity": "sha512-Tu9bPPyZZCZslXbX7oSCBKGs9VIkb37c+cvifJj8nv9tJiBUluuFts3gVmu8qGGiNwsHejpiZkh8y3bJs2Gt8g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-division/-/actor-function-factory-term-division-5.2.3.tgz",
+      "integrity": "sha512-YMMwJPld3uJ6VYPcvAr+nNL00yfi68KunDwwawz8b1iJ1edcYgGBn039dP53y05FEPa2z91pLLUkJqDDzXVn0A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "bignumber.js": "^11.0.0"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-encode-for-uri": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-encode-for-uri/-/actor-function-factory-term-encode-for-uri-5.2.2.tgz",
-      "integrity": "sha512-5m5kybJDEuPQ+tVvZTP5hv+Y6pOrKFThhIo/uszQVHcsaHIyT75+MuxLWVX2/uqZAjrc25MCt9vy+UAcTjpfGw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-encode-for-uri/-/actor-function-factory-term-encode-for-uri-5.2.3.tgz",
+      "integrity": "sha512-ZTdT256QHCriLdGhEHKo8Id2UV1Bb64Zse01NETX4mG6Sozftxk4lTjswbrDIgwJiHhkqOGjpOwx6rlvOAa5Tw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-equality": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-equality/-/actor-function-factory-term-equality-5.2.2.tgz",
-      "integrity": "sha512-HuHgTtCA9RKKvzjPDtN2mMx3BxZhv+fxzWo7fDUG1fRNBVe+dLv1QYxldi7GhGQPYETp1VT53qH3/Zy/Jj4y+A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-equality/-/actor-function-factory-term-equality-5.2.3.tgz",
+      "integrity": "sha512-3cHGE4i2kMnAAj1xO+68HxQOU0BB6uohDasCZp5q7GDsz+pjBbYJdnC2cekprNkwX6xT9THD82xa0+ro8bAQOA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-floor": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-floor/-/actor-function-factory-term-floor-5.2.2.tgz",
-      "integrity": "sha512-wEeh/cnD7GWudsPRAAjmVlC/dufVW9ytcHw2t9TL3OpwaOb9J8oZzFFY2gGQWuaa0aM/cOWO9lRjQ5zl/5KOWA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-floor/-/actor-function-factory-term-floor-5.2.3.tgz",
+      "integrity": "sha512-BhnBFknVSWdsxlmmJTeofdAdXvmc9r9coazdjtaRKncHhX8OFI/imxm/gaRkvto2WNpzturTrlDR8iNCwkRfEw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-greater-than": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-greater-than/-/actor-function-factory-term-greater-than-5.2.2.tgz",
-      "integrity": "sha512-410RZtuJjyMdv5xmxmvEFZ4BOueAq8LaJbgv4KsYDOD/dtfWpAfaCU5IBO93YWpDHlIT/cNXQF70j/LSWqpjmw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-greater-than/-/actor-function-factory-term-greater-than-5.2.3.tgz",
+      "integrity": "sha512-9p/pO2c2e17e65KeOK0sSfjBK1EJmYvne9IolZrC7NYVxYlUv+wGa2H3yGacZ+0A7q5UfgXxGBfAAJmlTzisaQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-greater-than-equal": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-greater-than-equal/-/actor-function-factory-term-greater-than-equal-5.2.2.tgz",
-      "integrity": "sha512-zk6rDWf3tQGIgcWhmgGJrn6DfARLJVW4r/rqcGIV1mfdtxMkhLuscNROokTbTCIJJnENTJNBcgWvaETsBSW6vA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-greater-than-equal/-/actor-function-factory-term-greater-than-equal-5.2.3.tgz",
+      "integrity": "sha512-bhhZU2eOvtW0DOvTUz3fCEUFV6zR6YrhLFKZqAmoYJI21umL6CySDSC6OuyiMGGFiqoAGC+3Wlc+rNV5PM/xqw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-has-lang": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-has-lang/-/actor-function-factory-term-has-lang-5.2.2.tgz",
-      "integrity": "sha512-n8KTxxsVD1oLQ1PgX7uWYZ1k4qjthq/lWIozfKia2DpszQpwGig1TSvCI+d0YMks1kPHqsdnQ8PF0Bjhx2GuXw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-has-lang/-/actor-function-factory-term-has-lang-5.2.3.tgz",
+      "integrity": "sha512-NVHZD2nVqeiQDJCaLqlLa4dVwtWGyQmcrrcaJc+rej+alszJu0L+5J6zBO8SV3uJQGWlrQlM01mIkNb+vVZkXg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-has-langdir": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-has-langdir/-/actor-function-factory-term-has-langdir-5.2.2.tgz",
-      "integrity": "sha512-/aX91BOCinnPWB7KvhjFOQqGpOtgsWNIywm0pr/7ZXFa+9WJgBfzz8Xr62J2aae1Iot80AZXyexcoIO8Z7hseA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-has-langdir/-/actor-function-factory-term-has-langdir-5.2.3.tgz",
+      "integrity": "sha512-hig9Uux5aULHm69BxjVBomZwKj6O2FPVETq2QGgYcsb4TuQ1BzQgCLg+DvB88WTQ4Cw9ADn7yitITV/HH6vzTw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-hours": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-hours/-/actor-function-factory-term-hours-5.2.2.tgz",
-      "integrity": "sha512-YAmXxfYVcQvFSQaHQ07fl8lpsKJaBgJgPZl+KwKpaAMn5G+2qL6hUbt9r+I9NU63s4DRp0vBDl3bUGc0sLOBog==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-hours/-/actor-function-factory-term-hours-5.2.3.tgz",
+      "integrity": "sha512-+I9GECZWDB7iHEynaTMJWYp9YWp+Ng1ITH3Q4SoXymeA5N4sXkYMn43ImAee5nyPcJqDl/K8wl+SzlEvrIdHDw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-inequality": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-inequality/-/actor-function-factory-term-inequality-5.2.2.tgz",
-      "integrity": "sha512-N7peiDns/TIa3z8xRVsJm1iB4ZNT4B4kb4wNS5YjEv+icrByPqgcv+eqgaS2EoSqZXwonFXAkNqFFDyN+RQzxw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-inequality/-/actor-function-factory-term-inequality-5.2.3.tgz",
+      "integrity": "sha512-g+GRZlYBlKYPiBukNGWii7V7REo6arjZixK3VvIWMDMp1OKiXyBgw+TsSP0qL2oRp1QOeqZ+vn4xYbQt31VAgA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-iri": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-iri/-/actor-function-factory-term-iri-5.2.2.tgz",
-      "integrity": "sha512-tMxyGb47QJeIkwmRu17SnhqJ7tdIj+QEbE8AI3kORm7z51LbiZDiNytX3VL48GWPOXdDJZPhexMxPfPe61pGWQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-iri/-/actor-function-factory-term-iri-5.2.3.tgz",
+      "integrity": "sha512-LK/W7/+QBfQe9gRaVkD0NpuIjBQpNS17r6FOXUVY+ltBQiEosJ7ruR0EoRq8OKKowSTj0SNBF9LzgFbBuRGvTA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "relative-to-absolute-iri": "^1.0.7"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-is-blank": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-blank/-/actor-function-factory-term-is-blank-5.2.2.tgz",
-      "integrity": "sha512-X5UTZuXN/PARUrlL+gSqTACr9hEffvObXcv2fAAgzOOblSO2AY7Qn59rlr/Rz6EucrQEs5aoZndW36ek7PwuTA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-blank/-/actor-function-factory-term-is-blank-5.2.3.tgz",
+      "integrity": "sha512-YMg3ILzc/anvWMQdh57wX/d+S35y6GFGOhLe8VB0i1krVYh7WZ7/cXv0TdDU93Z+9lfhUP/mwNLCVeAikQBujw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-is-iri": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-iri/-/actor-function-factory-term-is-iri-5.2.2.tgz",
-      "integrity": "sha512-v5HSfwyLt5uc+k+6SstmD7eNKxBa15kDJ2i98ZhuxYIZ/PwyWBxUXKCBf0RydCxHVSA2t85vSqSXx1pEAtXQGA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-iri/-/actor-function-factory-term-is-iri-5.2.3.tgz",
+      "integrity": "sha512-vuQSOszkwraqlfME5fkYZ3mIq5VHmpqXsvWdqM+eggdmKV8QCrgLzOqYXigzp89Zi9Z0PZHNyEcNikb6tm35RA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-is-literal": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-literal/-/actor-function-factory-term-is-literal-5.2.2.tgz",
-      "integrity": "sha512-xDGym7ox4h0En2wdI/adCtUM90/iyaxqhS0QMIgx19BuuEiv8h4f4Z+OBSpGRo8CNFA8AQGPvGLy4xZHxKpKlQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-literal/-/actor-function-factory-term-is-literal-5.2.3.tgz",
+      "integrity": "sha512-cUyfzT+F+BdX416Sg+xjJaMxRBc9uXSnQMcu3VIWKzf/KsxIHcwkn0OJ+6wS5kIJ9sCGKQvg1d2+TqGOeG0c+w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-is-numeric": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-numeric/-/actor-function-factory-term-is-numeric-5.2.2.tgz",
-      "integrity": "sha512-yqXx3NNlA4SgPtd3eZCbb5673To1700ilF588ca7TE0Py6U4hwBfrztp1WSOcnq/blxbuA9NoJHabT/lJWYNFw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-numeric/-/actor-function-factory-term-is-numeric-5.2.3.tgz",
+      "integrity": "sha512-VfCSqgusBPy1YcOGePhxqPDuTNTIh93BkWdH7Pf+pWvaD0ZXCYamWKzU9Vs3tzJWpLxX21C3S232und2hF/Lsw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-is-triple": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-triple/-/actor-function-factory-term-is-triple-5.2.2.tgz",
-      "integrity": "sha512-S6kJpNk+bjFIHcIIr3tE3SHvZR44HNO3p6gn5gTIjyxZI2VYMdNpAQo56rd7UPHYkir7h6/CuY6hIPgXQ0b74g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-triple/-/actor-function-factory-term-is-triple-5.2.3.tgz",
+      "integrity": "sha512-oFMvktwb3nELeYF8GdS//T+4mIRK7T2jYNwiPrtdyCX7CbO1lVc9HpogAYrjAqVi7uUjo0Y7vqhywTEvMA5Wcg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-lang": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lang/-/actor-function-factory-term-lang-5.2.2.tgz",
-      "integrity": "sha512-7M9gdGF34+8+EYquyMUcvBOcl5rt4eTlBQ43ZjqPXIr5aNapOytNQXfwNvpVktuarl+9MA08HtcBuHTAJ7d+qg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lang/-/actor-function-factory-term-lang-5.2.3.tgz",
+      "integrity": "sha512-Gn6WwApJcRPhkY5gzzdAt3HIbp68PbfEeuaQJ6JT4IM5dn2F76RqFKrv1vc3k8wp8mytMBBIXPloLV/TXSYgbA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-langdir": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-langdir/-/actor-function-factory-term-langdir-5.2.2.tgz",
-      "integrity": "sha512-0X/i7YCExLVaEs9mpX1PEi7SU0WKQvUe9p35BA94y7PozW9PKZVGwkJs63gG3laD+sgWgg7JtsWMilNJono0kg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-langdir/-/actor-function-factory-term-langdir-5.2.3.tgz",
+      "integrity": "sha512-8Kt2DYkShnCyR0Y9wJioQ0naQs/73yPHp+4cAGxXTKL/ScUvZElGzbzmmKx3gSbClFVKZaxKEbuw8YUhlGTXQQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-langmatches": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-langmatches/-/actor-function-factory-term-langmatches-5.2.2.tgz",
-      "integrity": "sha512-zSpH6UMfWVlmyzp8GNWkGzhLnDHLFofFbYINI0btShO1YWS4wCrwjTNtUk861ydlxTSuSOgUkbay7x/6TSwXgg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-langmatches/-/actor-function-factory-term-langmatches-5.2.3.tgz",
+      "integrity": "sha512-a0BC0ruzOFeqMj+D37Io9F+9IpeVpXf7ba81CQEHIn4Eogmw5hC3uIihbVz9n9ez1tTe35syS+x400TDoEVxaQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-lcase": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lcase/-/actor-function-factory-term-lcase-5.2.2.tgz",
-      "integrity": "sha512-eB2wVVsdJqY/NO5aZTcWnze11dDws4pJKcEPO2Id2I3jBi9L2ZvNd/i+ddldLY0A+5dvjQI9oweZnJyuZcMfMQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lcase/-/actor-function-factory-term-lcase-5.2.3.tgz",
+      "integrity": "sha512-HuWHt2udsrWUToRvjJrQ1x1jPXOlCCPKTGmih36tg2VLOnMKclxbNLaXF3tdk37Cz3f8HxDdhMd49psRpXyAgA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-lesser-than": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lesser-than/-/actor-function-factory-term-lesser-than-5.2.2.tgz",
-      "integrity": "sha512-MkuuFTw1RC7e1gsW4P3omzy+/Z3HZDDlWiFMTpT3bUk/tRRJZXo2fGVOaPn3sUri9NrVhzssjqnMEBQongQjPw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lesser-than/-/actor-function-factory-term-lesser-than-5.2.3.tgz",
+      "integrity": "sha512-4RBsGziZtNIC8VSerZBCauKU7GXpJwgW6x/BcU4jBNEnJpV3dPUmLUQYC4ml5BAJKJVI5zrDASdQEtB7+Fmo2w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-lesser-than-equal": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lesser-than-equal/-/actor-function-factory-term-lesser-than-equal-5.2.2.tgz",
-      "integrity": "sha512-ma/ydJ2bLMWc/kb1ZtB2pLvPzcE13DYfc0iSTZIHGvy+LKUFfAYbfzkX5q2rsPEVvV94Jqjwl8MHQBmzAQM6HA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lesser-than-equal/-/actor-function-factory-term-lesser-than-equal-5.2.3.tgz",
+      "integrity": "sha512-e6NFM5Hjz1OMRjB8TL+eRHLuymytsJhBfI/DtZu9rMRv1IWyHHzbJzGdEsvyTnRMnrH5R3IwNociOAwixjmb7A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-md5": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-md5/-/actor-function-factory-term-md5-5.2.2.tgz",
-      "integrity": "sha512-5IS2rlMpRYXtCr2HF5M2GJ6Zr+FQ4GMnrTdoVpgNZ0/GSPDd7Dfiw3U+dZ9KrzUw6qGRMW5g7zXTBW51dflaug==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-md5/-/actor-function-factory-term-md5-5.2.3.tgz",
+      "integrity": "sha512-Vh6SAunNRAAr3XKXZXo12ZwXXsbq/7eKCY9O7ru9nEbbNTp86QeUpvkJ5KgwOG/dSNhLcJyM1CRGDJYD/DQG6A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "@types/spark-md5": "^3.0.1",
         "spark-md5": "^3.0.1"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-minutes": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-minutes/-/actor-function-factory-term-minutes-5.2.2.tgz",
-      "integrity": "sha512-5cbc2Y1/BsBnfgkg0uJuqRIsNgk64Zs92Bi02YVqXo7Ca28BDxqiGM/+E6hgC+6i7jVEAALBvSdkE18Sa02tJA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-minutes/-/actor-function-factory-term-minutes-5.2.3.tgz",
+      "integrity": "sha512-L4PrKkhwf86rzFT3E17xlbqcPnalZByGitk50l0Sh+Bpu3NYjmJ+FGpoUyVbeLhEyaP2DypbyYfCNHM62t8rPw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-month": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-month/-/actor-function-factory-term-month-5.2.2.tgz",
-      "integrity": "sha512-O3rGb7VZWz001Dw66jccmT2Curzpla4acyxeViH4hpK9eGd6/XNdQSucq46wZG0bDNMl3kb1n60MEPptZWLvUw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-month/-/actor-function-factory-term-month-5.2.3.tgz",
+      "integrity": "sha512-WZKkBz1grvZ8u3Bc+C7wOP4CelZip0M6/VMdckZQM5cSAnyW/0ckRL9l+6jKuqtbnqrQZ6vtDHhbBLQdpH1tIw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-multiplication": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-multiplication/-/actor-function-factory-term-multiplication-5.2.2.tgz",
-      "integrity": "sha512-gIUCDTFRZd6pQHX1soA8ozFRwD70umJBjqhAkk9tIAUpAWzutBM9B4CyAzABCIhfTUUobvzmAXX5PJG6XDZztw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-multiplication/-/actor-function-factory-term-multiplication-5.2.3.tgz",
+      "integrity": "sha512-EzStbRZXuQ6qOu2AdmNs0nld8hn80dyELvlKVp3gZa6mTcnSjgFJVHQvuxKJ+OPgvXL2QHjH9Y5jy7S6Wjx6bQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "bignumber.js": "^11.0.0"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-not": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-not/-/actor-function-factory-term-not-5.2.2.tgz",
-      "integrity": "sha512-kLjOeZHiVcN1Iif/TNyAis4LZ+2BJXTcb8EVqOCf03RPBJRrdV29zOiCG5Dh6UqjfGv4xQrs2sAGZqIa3qjrYg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-not/-/actor-function-factory-term-not-5.2.3.tgz",
+      "integrity": "sha512-6HJ16o9gdgzGrK6ze3Y1MKArswlcOTnyMal5WwMZSmu+LxD5iArRjLI6kwDxjh5+WOKeF6cgrTuCYA7obevWMg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-now": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-now/-/actor-function-factory-term-now-5.2.2.tgz",
-      "integrity": "sha512-EsbifVks4ldHh5K+lneSuW5vmBssjE2hoKXiMhIrXZc3ZRBeyqDVr86xKAqOOd8D27uWfLU6KeI6+0dbrNwKnw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-now/-/actor-function-factory-term-now-5.2.3.tgz",
+      "integrity": "sha512-bQXfC/pr2PkVbMRy76HLXVAbG1n244QQAOc8ft+Wxc59NrCm+427DWEuCPWk/8N/o20mEw6fih0zZYPDfhRlDA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-object": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-object/-/actor-function-factory-term-object-5.2.2.tgz",
-      "integrity": "sha512-Tw6Rah0PNx+JPJgmEM6q3E+3ITVWPfDy9K3VtyhVx2+LkBDaWhe0clHuY0kgSL2hhzeAB3WQ76P+VIHHaieLdg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-object/-/actor-function-factory-term-object-5.2.3.tgz",
+      "integrity": "sha512-IbW3BQkKqCNu7O24DpAIVk6KqiZBD5329tPj9vNQDp+g2iHXS88ajnBC1e8J9/7uhEegTLvVTDYAD68FC/dY3A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-predicate": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-predicate/-/actor-function-factory-term-predicate-5.2.2.tgz",
-      "integrity": "sha512-GVc4Rcrm3jEeO0vYsS8hhOCs0dkX5EFyWoWUtd+yKHUp450GfvQoHU9EiJkRABe4K+aTeS+RLs6lxqKXYr6ejw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-predicate/-/actor-function-factory-term-predicate-5.2.3.tgz",
+      "integrity": "sha512-jci4vVP4mtaYIQksbMV1fkJJ+1gpQjbPiSjgjK9CrdXyNZC1tgGa+31bn13CXV7gsVw4+mtyGAGtiB6Oba3H3w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-rand": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-rand/-/actor-function-factory-term-rand-5.2.2.tgz",
-      "integrity": "sha512-PTc8wjltOcZdgV9fx91G5oamwiVdQ6e70JluJpucIm29h4j1JUh/LSOUNQGKKzwKXe4EqIa/tkSn+usDohGbyw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-rand/-/actor-function-factory-term-rand-5.2.3.tgz",
+      "integrity": "sha512-IvAgZkq95Zs4GzueH1yi7EW4wgsFJg2FF8VF4FHH/eMHToh2hNh+W/LktUCLVv+hv+VVDf7JVM6Y7zmffJPpFg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-regex": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-regex/-/actor-function-factory-term-regex-5.2.2.tgz",
-      "integrity": "sha512-PEvY+5s/OwJZaVTzdgygXw2MO97gq+aX0bGHujQKziNK4muolIVS45ekMbvEHpX8Q+Bb060V1IpngOFw/lHt5g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-regex/-/actor-function-factory-term-regex-5.2.3.tgz",
+      "integrity": "sha512-hhGUhVcOm8hyD2Nsa7Gc0YEONbS0p9FgcyZD/vrv6gJPp146g3o8xOX6BFmHSUqMqTSRPfF1gyuJ+8mxzRVZRA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-replace": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-replace/-/actor-function-factory-term-replace-5.2.2.tgz",
-      "integrity": "sha512-uSgjnvvouJD+mHZAvULmmnZDacHXBEe2WXwDBKLXOwHoXq8zF5VBdtgW7uN1ft0eRBrvDpdZIZPCCqhW0nfH6A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-replace/-/actor-function-factory-term-replace-5.2.3.tgz",
+      "integrity": "sha512-+wEb4iQqTU1/3atOPhDh3eH2/AJkJeFtBH0evNlcF4EhBindJSnIm0GTbtBuav9YA6u4sed9+riDgu3Ce/WumA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-function-factory-term-regex": "^5.2.2",
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/actor-function-factory-term-regex": "^5.2.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-round": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-round/-/actor-function-factory-term-round-5.2.2.tgz",
-      "integrity": "sha512-t3fDTiM/dNunkT6BhjCwGZL2Az8TAH6foPc8oiG6xSItu4LlEnTtF48BE0B6FKkjZEZWt4jEN44cwkTlP1wzrQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-round/-/actor-function-factory-term-round-5.2.3.tgz",
+      "integrity": "sha512-e1avFDjHJLm2vR1BeR+RISy+IwEsjNnooRaLZvCoe/t1ymtmapMuvzd77x46Jp79TGdLcDvOqQ3OcbHH8/PZCA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-seconds": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-seconds/-/actor-function-factory-term-seconds-5.2.2.tgz",
-      "integrity": "sha512-ywmwxrKFzIi3eK9E5cP5DjVEao27RSfFG4Beuo/RdaTJfV1U/+6Jv/bK0aDeFf9Ez1tSDS8wJYUFDhiP89X+Ow==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-seconds/-/actor-function-factory-term-seconds-5.2.3.tgz",
+      "integrity": "sha512-7nQ59A4zFs/Nu6pm2gwk0e7uUyeV034XnS3WRgJn+KjG2w/TsFSv0SSdcCf2Dn3tar4gBkA0FcHBFDFsXp3/jw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-sha1": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha1/-/actor-function-factory-term-sha1-5.2.2.tgz",
-      "integrity": "sha512-G5sTQxvFUhqTPYDlRQUuaZWnvXz6mY7/oYf7dDFoBiUfyqWj4DFrfJDzs+kkRi2c9+fS4RuvPprE3HNXP92n9g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha1/-/actor-function-factory-term-sha1-5.2.3.tgz",
+      "integrity": "sha512-Brf2d2/Rh4LlbNHKKvfXXt/G4KTCfoY4BVhlZeXDBU6MidST1EycMz0BNRm8ypaoJUpoQsyVXVWwx0UpECTAPQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "hash.js": "^1.1.7"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-sha256": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha256/-/actor-function-factory-term-sha256-5.2.2.tgz",
-      "integrity": "sha512-gvo6IwMTQQGslefQInjUnOv4ia/+I+CmaYf/k0UgRuw2CmWwISlAf8ByfipEa1JqPm6n2p0A1+zNPmgYIblRuA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha256/-/actor-function-factory-term-sha256-5.2.3.tgz",
+      "integrity": "sha512-THYYNtAktmzD9/CNoV8P3mNX491fC4ZRJRZsC5TdKk/N9E7o7wAsNuMjc0C2iL9lgIOEXX0CTu50mhYCvmZQsw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "hash.js": "^1.1.7"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-sha384": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha384/-/actor-function-factory-term-sha384-5.2.2.tgz",
-      "integrity": "sha512-AVizex8D6W+ouluLF4ydKXWijYluEvnQOIzRdiaLYjsSh1hbpJStdRrLxiiEdnlvhRwhktYoUAPT7iT6p3btIw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha384/-/actor-function-factory-term-sha384-5.2.3.tgz",
+      "integrity": "sha512-4CRgRUPD2ZRekVJbKe8WbuRAfITueMz5xGc2vh5fNZ1rXwVCAZMKrivNWXFJ2vhG6PoYLhETfdqIVjX+fcx3hw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "hash.js": "^1.1.7"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-sha512": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha512/-/actor-function-factory-term-sha512-5.2.2.tgz",
-      "integrity": "sha512-itPZTuooOxOertIha0sLkGe/lRi3PmeX3dif1NRs3d2Uilr/WmARrATTnK+TGp2SkNX7S38CHqKODm/8sEImFw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha512/-/actor-function-factory-term-sha512-5.2.3.tgz",
+      "integrity": "sha512-DhtC3OvBbgNbipJAMufdFUi5z9V99OHqSzrBt2635OV/1/jlypYCJlxStfmW23YoL92TGBRGfAw0jPuA9iUsbg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "hash.js": "^1.1.7"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-str": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str/-/actor-function-factory-term-str-5.2.2.tgz",
-      "integrity": "sha512-9BjZ7mRt1j+KeTUcDv5MQSA5teD1iRQBp1IYPj4mY8D83VKej9EZxxfOA1wRcEJVLOL/Lkfeqa40ZQkZiJCBmw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str/-/actor-function-factory-term-str-5.2.3.tgz",
+      "integrity": "sha512-Z56Bj49vrwHZESVkaH1NwOMd5A4YotSXcpn5Y/le18rF0oHhrvtyCOam8/oii6NIdEYMu549WZoA3AGL4WWNlQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-str-after": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-after/-/actor-function-factory-term-str-after-5.2.2.tgz",
-      "integrity": "sha512-bLg45Oh3F6QteiOhcr6hl7oBNjpBFZAh8E1jEs3En3sZtmW/VCyAyo1BSQ0kJLxBP8ZUALauzJ/L32ftZPT8Zg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-after/-/actor-function-factory-term-str-after-5.2.3.tgz",
+      "integrity": "sha512-4GSvMd2v5ziHs8kxGJmghYJBnMeieBJjzAjKX1IsX8osIpYbw91zZ7/rVYZHFQI5C05Wsww0LLOuu9G1GVJgnA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-str-before": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-before/-/actor-function-factory-term-str-before-5.2.2.tgz",
-      "integrity": "sha512-i9W/ibMfYma257P9SmBTN5vs2xB6/bXSS2pJY0gi88utIpo64m44coGFOHAwGrxi5BZcFkH/1bqDwBGnp3kULw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-before/-/actor-function-factory-term-str-before-5.2.3.tgz",
+      "integrity": "sha512-2bqaNg5Z/8gMhtPttLQTq60lfZE+l1QcqB8bBBQeyUEbia6nTQNnaSGaHsHMbhdD0JQ5wegCNerD68YzP45DeQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-str-dt": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-dt/-/actor-function-factory-term-str-dt-5.2.2.tgz",
-      "integrity": "sha512-eGYh6mcSdDZPt1mEd9jG6br8CL3AOO8QUqjxuaC4/wBcOwD3cjFmJOUjrqoePYTUjLiYs686HMM4ivBwt0Ss7g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-dt/-/actor-function-factory-term-str-dt-5.2.3.tgz",
+      "integrity": "sha512-UqZhYuaQbBKIh3rgxDynEY43/jMT/Q/WKjI+HiKAwbsBJWcbzGYIP3zuAbAlOYS9fRgBCUFnsfNhbSxY3MFkOg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-str-ends": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-ends/-/actor-function-factory-term-str-ends-5.2.2.tgz",
-      "integrity": "sha512-8uLFRkqwDzQ/NKvu3/F0nSWxVaEI4iGDxlm/31WbShPZ/ZVyhMf5l6CM+Zlgs6QcsEGzcYmCbkSUTbjF8mgqAw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-ends/-/actor-function-factory-term-str-ends-5.2.3.tgz",
+      "integrity": "sha512-VKBNRWNJkTiQJUmgeEwc+6H/obgVfM7nR9LGi2trUTyl+R3jdM4GECf5VuO6hGb6nOWZ4ctBNUBg3esm24TJ6A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-str-lang": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-lang/-/actor-function-factory-term-str-lang-5.2.2.tgz",
-      "integrity": "sha512-RJBnbpJq83KIrmoke8s1zmRhU1FZB8dRYeS5dgxf6c6Fb1q6r+Bf+ppJp+UIo9sFd66mRAEoBxSyThnseQuX0Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-lang/-/actor-function-factory-term-str-lang-5.2.3.tgz",
+      "integrity": "sha512-r01Ivtcca1AwVdC8aVkJ2r2xblSWdtqFNVr6FxPSDGO+7lpSwxXSJC+sim0oEZv/ps2MUN4Hzk2ezP689Kj2bw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-str-langdir": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-langdir/-/actor-function-factory-term-str-langdir-5.2.2.tgz",
-      "integrity": "sha512-FqbTFvGd/SEJWCdyHEnAiZt13SAqFW16LNHh4Bl66iSIVCY3L0L11AMXYHUPj/zzyXPnamETxhHL3JXiRK1P2Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-langdir/-/actor-function-factory-term-str-langdir-5.2.3.tgz",
+      "integrity": "sha512-eE6/kHkF4C3z4GiOTYL6CrbtoOnpJjJHE0R9I49wne9BxBKc4/y+PamLQDOlLQKaGa6NveN7ZRO2vjl+VLLacg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-str-len": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-len/-/actor-function-factory-term-str-len-5.2.2.tgz",
-      "integrity": "sha512-tp90XEhiln8LYx+8+D6+OptqBcT+Xwr+u72nMUMEPuUeClJJIW8xWgupYdmeTs4phvOF7/Zqffzuj7Da/15/og==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-len/-/actor-function-factory-term-str-len-5.2.3.tgz",
+      "integrity": "sha512-bxfm/l3pksJxysTioXP26meyu+S0XOqPhFpftDubH9zy2WG/FNPbyZ5quFRzl+DYu6zjskrX0IhEcvZSHvWsfA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-str-starts": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-starts/-/actor-function-factory-term-str-starts-5.2.2.tgz",
-      "integrity": "sha512-REPytCO+7cr9ph9QkYLNFYLoWiju5+W+QU3u7svIpmqjIViRCorhkam6OAhzO/fe/bx+xYMsBv0zog88BqnIMw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-starts/-/actor-function-factory-term-str-starts-5.2.3.tgz",
+      "integrity": "sha512-YKPpEaK37RgtBJVyWsyKe02YwEBN5n2EAaSCp5YmtjGRqUgadgM+vL4ct1B/jUsof6hmkLkcj4VluPLwp0Rv6Q==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-str-uuid": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-uuid/-/actor-function-factory-term-str-uuid-5.2.2.tgz",
-      "integrity": "sha512-h3jGn74qEfs19hS/+lSlmqTZQzTWMo73As9TNc6hCJ9LLfEwuGwTkE/sVcOHf2UNJvj4t8ZN9QWobIJN/C2JTQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-uuid/-/actor-function-factory-term-str-uuid-5.2.3.tgz",
+      "integrity": "sha512-MxLR8UCG8W9sGJNCpe2rZIodjigPZlQpBePfr9VvYPjytnJ4lw3CibyxGvVQxo2tXwJ58umyi4Po1R/n0EucPA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "@types/uuid": "^10.0.0",
         "uuid": "^11.0.0"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-sub-str": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sub-str/-/actor-function-factory-term-sub-str-5.2.2.tgz",
-      "integrity": "sha512-cQWq43SwMWDZgo6hzAOqmXQ67wI2CS4rUU/wCReTmoKnBLgl4zRrDKN0gRxFEmmdrwocwGu/AZqqisPGWWasYA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sub-str/-/actor-function-factory-term-sub-str-5.2.3.tgz",
+      "integrity": "sha512-HyJfcw80ATurSVLplrZDePDSJubcVKTAxOaVwpH0qZQj8dM3PyayEjDQQL3zbX11S0EQeb2D2YUy4tH4sQxnhA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-subject": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-subject/-/actor-function-factory-term-subject-5.2.2.tgz",
-      "integrity": "sha512-yfCWrZkOl2+Q+FBCs9F1OSSGHdjAc1erhTUIbaYnhkBN3iEqJ6vnfiiZiv5vBKTsBNMZDeo6RHIEZd8Qtl5mzQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-subject/-/actor-function-factory-term-subject-5.2.3.tgz",
+      "integrity": "sha512-nIndDG6cuvkJyjkGOiV/8hwZ9jAUTYd/zIDPNCHQ4HwwX8zccD844YzkGsNZWrD4ytSqUvX5E4C5x5LFEWq8Gw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-subtraction": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-subtraction/-/actor-function-factory-term-subtraction-5.2.2.tgz",
-      "integrity": "sha512-jZd/gnLtRbAqhlf84S4f73Wow060LrW1h0TZzHztnPkpH7gvzPpZaq3RvXwIu2/PbyMh2bV08Ebt6D96qTKVjg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-subtraction/-/actor-function-factory-term-subtraction-5.2.3.tgz",
+      "integrity": "sha512-3NaMrmuQdaPn3HR+JAeYFxI3vE6cM92iu9vVJ5mMZuDfpPXwRUoRIFZfNUw7WEcvP2UVRqPzFp5HvRxbBsSUNQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "bignumber.js": "^11.0.0"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-timezone": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-timezone/-/actor-function-factory-term-timezone-5.2.2.tgz",
-      "integrity": "sha512-dQa8CN8VHF86IuPH4gnY66RhddDyUmc4Cj0x4SrzhLnNOI6DkM5FBSVgA+qbgzepBigwpXJQlKG73dEBDjV9rg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-timezone/-/actor-function-factory-term-timezone-5.2.3.tgz",
+      "integrity": "sha512-mDVGVx0OX1NiRkLQqg95qRaq0R6xwv8LMa018R6AiwW0DZZXcOdbhy7QXShM1QW/uZCi/oE+ByM2iZwO3m8DCg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-triple": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-triple/-/actor-function-factory-term-triple-5.2.2.tgz",
-      "integrity": "sha512-MGZASc/Ic7HKOuBWilh2p4YeRj+QoA5eUdLuoLSKjcyMB+37EmlQRxf4hnwKTMI2iV7VOq+N2KbBi7jYu+Nadg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-triple/-/actor-function-factory-term-triple-5.2.3.tgz",
+      "integrity": "sha512-BGc8sQoafDTNes41wqotd5KoDsTfKT7rrPqqwE1fN9woqSXKu8U8RZi268Mei2VSDejMsZwppZcgXYb7c+WMYQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-tz": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-tz/-/actor-function-factory-term-tz-5.2.2.tgz",
-      "integrity": "sha512-BHP4ndtIMXQz7s6c3OEMg8hRC14zK0ewjj/X8shFweq6ZMZkfHoSrtvLOe8rn5gpiR4/FdS34KKaGxXU4XMX9A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-tz/-/actor-function-factory-term-tz-5.2.3.tgz",
+      "integrity": "sha512-fPXxtqxqXgGvoCiYQtRsj62XCk/EkHAsZnfsrstooVRJevs4nvODEXDAQgyX8O3GKz+Px7eDU5t/wPafHdP6FA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-ucase": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-ucase/-/actor-function-factory-term-ucase-5.2.2.tgz",
-      "integrity": "sha512-vJot13vOOijKmC7+fPfN3X0YTACrQe5iK9oEjJDff3hwZZy1wldvmrt14ox+cL8cIqhi7VM1+xfGGBJD0bakNg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-ucase/-/actor-function-factory-term-ucase-5.2.3.tgz",
+      "integrity": "sha512-NnC9lO3rTQp69ZYMLkdGDDUpG4hDDQmrhaf2797AmwH6grS+erIYX0ZSoTZHO/vlPK1kvcfJq1TK3Yz+a3BZQg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-unary-minus": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-unary-minus/-/actor-function-factory-term-unary-minus-5.2.2.tgz",
-      "integrity": "sha512-yxaszMSfDZCfLIqF4EjrHBv6YvlUrpyshRUmJocLxvcRYlagS6xyBXW0PBV+H7nGzG95OFPXb2U+iYX4neTWyA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-unary-minus/-/actor-function-factory-term-unary-minus-5.2.3.tgz",
+      "integrity": "sha512-0MlqACFeDSl9nNfMKWR7jYwRMBmS8XMxSTf40VPvb4Z4+6q5wsvbOHMGmCESjr3PuWtxzlpZll6i+NjivCCYXA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-unary-plus": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-unary-plus/-/actor-function-factory-term-unary-plus-5.2.2.tgz",
-      "integrity": "sha512-Coez4Irhbkup3/Q6UhBd1r0WoWhfflz09fss1oT0TPuCW93f4mpf40yEJy4+/I5nA9WWmBRP8akIk0G0tvMLAw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-unary-plus/-/actor-function-factory-term-unary-plus-5.2.3.tgz",
+      "integrity": "sha512-3+D8e3KFKwQOcTBDsAPS6KW9wNzTAGbF3AVb4By81Mz0LIFeBoUWUKZ+2Sfg49fforHjv33Avs7Tw4CtAZrUKA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-uuid": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-uuid/-/actor-function-factory-term-uuid-5.2.2.tgz",
-      "integrity": "sha512-B9aRx3XNW3gCDbTCTR1NlkbmFAOZPBOD8W4vCA6Z/w0zBmYFea7q5dVvuktI7Bgq/C1fmtn9ivVEnvIbHvfWPw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-uuid/-/actor-function-factory-term-uuid-5.2.3.tgz",
+      "integrity": "sha512-HCS7Q2hXanEMfxE/ovRSLOEu+0SSDwUlYQTOB3HCf4Mi4UNkjtQ/0Q0LImQ9qtfcs/6D8OPVC1rJyOpotpHaQw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "@types/uuid": "^10.0.0",
         "uuid": "^11.0.0"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-boolean": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-boolean/-/actor-function-factory-term-xsd-to-boolean-5.2.2.tgz",
-      "integrity": "sha512-dl9DZsM9H6yRJu/i2m0KWRJ1+vcSijo/t/9b+yG7PsPiQMdfPPBZz0dZmVuxDbg8+I11qaY6DtrrYbifo/Z/6Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-boolean/-/actor-function-factory-term-xsd-to-boolean-5.2.3.tgz",
+      "integrity": "sha512-p/puRFYcgFEw6oXeL8nMrdUl/Kp2fmoc3vT+mlmqwmDFsB7DBnn6r7WzvXVYkNnTAYZCBr1op2e+yk0XpXtHqw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-date": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-date/-/actor-function-factory-term-xsd-to-date-5.2.2.tgz",
-      "integrity": "sha512-rBD/kBYmbW805xUT+xa22QXP0oCiC3R2rOpLbMV8B4ITfSntM24fQ6GOrqCG7kCrJ1zsDoNzJKG4XQH4TFXAfw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-date/-/actor-function-factory-term-xsd-to-date-5.2.3.tgz",
+      "integrity": "sha512-k4mfJr3lwVOi0EEMrkjWEXIe8dznFffP7vaFTTh2B0XbOE210p2T83731Y1aiTEa31TwdAOR2dku3N40tTwnKw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-datetime": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-datetime/-/actor-function-factory-term-xsd-to-datetime-5.2.2.tgz",
-      "integrity": "sha512-HEGt1cPc82t6y6svJzG8mBr+joT5E7JeiKZAMjv14rhvHVWHA5aaDbm+HQmgEtp+/uNj5W5scjbpHQ/h8Vq5uw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-datetime/-/actor-function-factory-term-xsd-to-datetime-5.2.3.tgz",
+      "integrity": "sha512-48Ecpp11HHiKKzErkYteYOouzt/XtYwp1zwfM/gpe+JbYv9RfUdfCECXvPHGluyA+fhJDqkUpEhGWOzwIxI7JA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-day-time-duration": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-day-time-duration/-/actor-function-factory-term-xsd-to-day-time-duration-5.2.2.tgz",
-      "integrity": "sha512-kVkRIQvrxVs1LzljqVJgL2PkCKvcwQ87tkCgc0UHkVPc3DCVsZhAbB84SRu1FCWimchP9rDYSI0WUAIRjO2xDQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-day-time-duration/-/actor-function-factory-term-xsd-to-day-time-duration-5.2.3.tgz",
+      "integrity": "sha512-J+XHLC7s2+Xd2tMPMSjJ2wSCU3u/vnM+044kAor0w5EBiPML2cRmdZKyvSwIAy2c7aXuxdvrZOXwtwZiTqgD1w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-decimal": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-decimal/-/actor-function-factory-term-xsd-to-decimal-5.2.2.tgz",
-      "integrity": "sha512-0J1JCWE8v0HzKLjVWQJQMPAPj/klt+QBBIOMrRs/ZmfPvth3vuam6oYyB3mBUmLGAbxxFPPcLpcmYNZVL26OtQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-decimal/-/actor-function-factory-term-xsd-to-decimal-5.2.3.tgz",
+      "integrity": "sha512-toM74B9LdOMYaeUXimtCJlZbccFwf2ccL8Rf32QuGfNpPGvZjZUB6arrhxIb3W743maRWUTntgujKI4vcRqNpA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-double": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-double/-/actor-function-factory-term-xsd-to-double-5.2.2.tgz",
-      "integrity": "sha512-MBey6qwX/8S0iuOv6To9d32BerP1W2YqmcO0pZqNH1LeQbMCAQKtmR5hu28a3lF9oY69HgVraKbrzmoE6exvaw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-double/-/actor-function-factory-term-xsd-to-double-5.2.3.tgz",
+      "integrity": "sha512-XHIMhrp5eJkWyuWK0khQOVoGA5YtMOk/SY7PQZgsLR+VTXVjHpPu0CKhry/ST6xLKUsSekzXxm47TwAXLVPjbQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-duration": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-duration/-/actor-function-factory-term-xsd-to-duration-5.2.2.tgz",
-      "integrity": "sha512-v8rkiylYpPslCX34nEL4QCucxxuKHJFMqImFYiNCcF71I/FoyfYFQRn58LImSNXiI+ABmeT0gYRi6QWx2mg2hA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-duration/-/actor-function-factory-term-xsd-to-duration-5.2.3.tgz",
+      "integrity": "sha512-Gtlor9JeyuTkw9KaEJVf/QgZ4/mkvlbFxDZ0wTQi89pl03ZS5v4JCeP7NICiyFfWQzSoeD/6hbCSK+rrJL5t4A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-float": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-float/-/actor-function-factory-term-xsd-to-float-5.2.2.tgz",
-      "integrity": "sha512-/YQ05VlVXGSJFr7QYSK+aWAVizTfsvSomeBErhEdGdSAeteQTgdd3FEVlbCRoiDW3m4jxnpFroj7xrA8+FznyA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-float/-/actor-function-factory-term-xsd-to-float-5.2.3.tgz",
+      "integrity": "sha512-qlnK7tjv74QZdmAepv0wjO45U5cOf20dKe7b/iepBEKw8V1JAsSY9jJlehpXYrBwHlW0tYw7iTYc22hVlZCVtQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-integer": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-integer/-/actor-function-factory-term-xsd-to-integer-5.2.2.tgz",
-      "integrity": "sha512-cj6+0CQuMzrLfMxfKDKc2cSynXtapb5K35yBlLMB8557SoYpZ0TmvgW956j0GBSSINGXeISzMDKxlqC8bqMScA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-integer/-/actor-function-factory-term-xsd-to-integer-5.2.3.tgz",
+      "integrity": "sha512-wa97A20obKuGtxWVzpAm2kj6MzxaNbeBf8bYgFZyN5+RUbmcBA2MhIvv0QooOKgvXu9T9vvoB84q7bXdLc6m3w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-string": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-string/-/actor-function-factory-term-xsd-to-string-5.2.2.tgz",
-      "integrity": "sha512-JOWEEzpVDtN4E62KRQjNSIgEIV/VD+SMKRoJM4kKlPsr51nAcoHST94Nxoh2amZwabIT6NorzDSAP95GpCvAUg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-string/-/actor-function-factory-term-xsd-to-string-5.2.3.tgz",
+      "integrity": "sha512-MUe3xtDjqmamDDOKApZEYmzJiGac7lEGKoZwFDnJKJKJvkbcxw4L+o1QSAhrD/vE02LEl+86+i6G8QtJ8if30w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-time": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-time/-/actor-function-factory-term-xsd-to-time-5.2.2.tgz",
-      "integrity": "sha512-5WAO4LJt8G9mSQx8T0WFd/MCgFrb72GcWGgANJfzNB7LErtsON3A0nL+XJlM4xKtFL8GhJChvr94MaM5QRdngA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-time/-/actor-function-factory-term-xsd-to-time-5.2.3.tgz",
+      "integrity": "sha512-djZi5eQj4uvF6ctKtY+tE+McW6WVA4Cc0LKHHmGjoAaAkMmoFbw2jnQNvAlIuFbpD/phGvZ398NTfP0jPLS9jQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-year-month-duration": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-year-month-duration/-/actor-function-factory-term-xsd-to-year-month-duration-5.2.2.tgz",
-      "integrity": "sha512-6tdRSmmGFsc7TrZ4jwWZurJ/rHelbmyBN749Xa+CFZAd0ONBC+EDyitSUWy052JgRqR9WSudy5jCqXuHGIMq8g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-year-month-duration/-/actor-function-factory-term-xsd-to-year-month-duration-5.2.3.tgz",
+      "integrity": "sha512-j+68WyVJyt56p5dVLcjjN+eQTuHh6nsoubG9jflZwr04dAsLhfMOiuceIJvwVomQ2f9T7pG7lazq2/tk9Gy3nQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-year": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-year/-/actor-function-factory-term-year-5.2.2.tgz",
-      "integrity": "sha512-NyL+UiGj6UdckjwPR4kbK+m9Ukwjl1dmHimzCNRICfXIGzu7sPVbWdXBIZshX4ZABIu636v8Ciry3xJ0U1L7fA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-year/-/actor-function-factory-term-year-5.2.3.tgz",
+      "integrity": "sha512-iL+ghG1CMG6Ud+l1wOvDnjg+LpACC7dugEwoB9jy9s11GnmchsQKt28o0bNU/qmVgi5eqpfANC5bsNM9yY6UGA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-hash-bindings-murmur": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-hash-bindings-murmur/-/actor-hash-bindings-murmur-5.2.2.tgz",
-      "integrity": "sha512-hFXeql6iPXeUgC+A2dwgRdeDiLvzkpYQd3VR5nhrlba5gD9Kf8OVAVal5g3fSKpSN8CC66AFBPWluM9WkfHwyA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-hash-bindings-murmur/-/actor-hash-bindings-murmur-5.2.3.tgz",
+      "integrity": "sha512-SHYxt2r9Idv/OjN4Ssd0/P7/7ULay09UyvjgC/iY/LSROde4A22nOUkU5rD+jpR1hYyNmyClgfvf+HvB+ODXLw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-hash-bindings": "^5.2.2",
-        "@comunica/core": "^5.2.2",
+        "@comunica/bus-hash-bindings": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "@types/imurmurhash": "^0.1.4",
         "imurmurhash": "^0.1.4"
       },
@@ -1681,13 +1683,13 @@
       }
     },
     "node_modules/@comunica/actor-hash-quads-murmur": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-hash-quads-murmur/-/actor-hash-quads-murmur-5.2.2.tgz",
-      "integrity": "sha512-lm4B1Z5vieQZSPTV2HSPEiPQTrXkjIoFyH0qOjKse0Bc2let0rh3i8RyJT8ywAFwAjtQS/HZVkzdgAuc8rndWQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-hash-quads-murmur/-/actor-hash-quads-murmur-5.2.3.tgz",
+      "integrity": "sha512-4qUspwxQny7IOCB3+GLkwVUN93ahd9I5JA7AYQD947zELTwhB3pf71x4b0QaqFKuYYKZGfKMAOjUKBdpTa8lzQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-hash-quads": "^5.2.2",
-        "@comunica/core": "^5.2.2",
+        "@comunica/bus-hash-quads": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "@types/imurmurhash": "^0.1.4",
         "imurmurhash": "^0.1.4"
       },
@@ -1730,16 +1732,16 @@
       }
     },
     "node_modules/@comunica/actor-http-proxy": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-5.2.2.tgz",
-      "integrity": "sha512-j2qoOQfI6tyAjOJIB/RlAk+tUsAV5EQ//aaboVUhXcVW+d+cOI+gp+oqg/A56kDo0bjS66/KHm4H/HDtCYqi3A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-5.2.3.tgz",
+      "integrity": "sha512-x32prW0HYDBcl+b183twO6+XcC5I0jy2R5DuXRB2L1t57FMz60BLzmbjehPMHLb8XGPNY3gx5cNaezfFpbaoUQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-http": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/mediatortype-time": "^5.2.2",
-        "@comunica/types": "^5.2.0"
+        "@comunica/bus-http": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-time": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -1789,21 +1791,21 @@
       }
     },
     "node_modules/@comunica/actor-init-query": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-init-query/-/actor-init-query-5.2.2.tgz",
-      "integrity": "sha512-vBhvkgyXq4C1mhzScjewb9C3nEpDSImdfx5Prk1akvuB3X8zW+BvIT7S8FWU2nZOiXMqdFlPbJWhudtYiQk7ag==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-query/-/actor-init-query-5.2.3.tgz",
+      "integrity": "sha512-S6VZOlUxpvwPETWN4hWDPpgeNf5YyP2/6X62A5qv5zUIPwr01ZyL7kpm9jjnLE4dZQG2DVhbW4LEI9GqEJiJgw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-http-proxy": "^5.2.2",
-        "@comunica/bus-http-invalidate": "^5.2.2",
-        "@comunica/bus-init": "^5.2.2",
-        "@comunica/bus-query-process": "^5.2.2",
-        "@comunica/bus-query-result-serialize": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/logger-pretty": "^5.2.0",
-        "@comunica/runner": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/actor-http-proxy": "^5.2.3",
+        "@comunica/bus-http-invalidate": "^5.2.3",
+        "@comunica/bus-init": "^5.2.3",
+        "@comunica/bus-query-process": "^5.2.3",
+        "@comunica/bus-query-result-serialize": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/logger-pretty": "^5.2.3",
+        "@comunica/runner": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
         "@rdfjs/types": "*",
         "@types/yargs": "^17.0.24",
@@ -1822,17 +1824,17 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-assign-sources-exhaustive": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-assign-sources-exhaustive/-/actor-optimize-query-operation-assign-sources-exhaustive-5.2.2.tgz",
-      "integrity": "sha512-fDbD1yVPUSrTOKz1NcptC0MURqZmJUjCAMlBiNHU7CXS65nsUaDEJJWXHLm7z37yxEDOvP8ACpywI8I5Ri2ZfA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-assign-sources-exhaustive/-/actor-optimize-query-operation-assign-sources-exhaustive-5.2.3.tgz",
+      "integrity": "sha512-j1+npLHR0vwd325DI4I27ogCNIRnMWcUVNwGIdn1LUQS3axMhwVuLEw7e+XpenQNnlIqsC9cPRps/98SyCedGA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2"
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -1840,14 +1842,14 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-bgp-to-join": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-bgp-to-join/-/actor-optimize-query-operation-bgp-to-join-5.2.2.tgz",
-      "integrity": "sha512-kw3CZjhRorkAoDFZQa6ZvRYk+JK0H85hqkAZMX1uX1HdhFrZlNnFx+1Q2PBYVum3WX3i6oyzhd6T3OweMlP9Ww==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-bgp-to-join/-/actor-optimize-query-operation-bgp-to-join-5.2.3.tgz",
+      "integrity": "sha512-KOS4beFLxS/qDh43PEkbueOc+z546dWYzAJH3BOEbUxnc/sGQh95yIrOW46CmL4ebCuZePxoRuqZ7PHt0L2YcQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
@@ -1856,14 +1858,14 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-construct-distinct": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-construct-distinct/-/actor-optimize-query-operation-construct-distinct-5.2.2.tgz",
-      "integrity": "sha512-xjjbu63c6IuPQ7xpQc2tlLCVCuAGrzi4SFk9ejUkdYy3UThKdGTaA7duPLXoxwVBtnMp+64PzaIRyHFNh4KWiA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-construct-distinct/-/actor-optimize-query-operation-construct-distinct-5.2.3.tgz",
+      "integrity": "sha512-a7hj3llIYCKtrYHEagqq/NWAD1fw+9ZWPY+Htq4CdcSqOnAdNcnn3P3TW704gBZsNOqCFCxjU1vEC/6sQYHXmg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
@@ -1872,14 +1874,14 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-describe-to-constructs-subject": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-describe-to-constructs-subject/-/actor-optimize-query-operation-describe-to-constructs-subject-5.2.2.tgz",
-      "integrity": "sha512-mCxqy1/tZLL8KrGqC9SIRvyXJkVGTGH1A2rxzRCDnomCO0V011RBEP0/QrIEU3XH7doGM33YI3HQUtjsYdD80Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-describe-to-constructs-subject/-/actor-optimize-query-operation-describe-to-constructs-subject-5.2.3.tgz",
+      "integrity": "sha512-NEBicKiWS+lsC3Eco7+MJ25bCgurHyoB0p5gExSSRSplNYPd1QUtE9y0v5PyONAM463bg07b6pMwdJC7dDnPQA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
@@ -1888,17 +1890,17 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-distinct-terms-pushdown": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-distinct-terms-pushdown/-/actor-optimize-query-operation-distinct-terms-pushdown-5.2.2.tgz",
-      "integrity": "sha512-lhGrSjpa9Gglmc3z1XQCaoQdr0yXGe/RBL++/2wyXRrrjXOTBbvveG/uRt++uWlMf6PNE85F8H/E27aDFFBsMg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-distinct-terms-pushdown/-/actor-optimize-query-operation-distinct-terms-pushdown-5.2.3.tgz",
+      "integrity": "sha512-yelHnP4uaZaDc16+EXTVrSNfn02QTVmrgx6ZZYs6ejDljrNQqJBUehpvXzl9zd3B3j4vBfaa72BNE/XSN6kvFg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2"
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -1906,17 +1908,17 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-filter-pushdown": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-filter-pushdown/-/actor-optimize-query-operation-filter-pushdown-5.2.2.tgz",
-      "integrity": "sha512-B605PlKqVLEPoUcaLRX8iuhBCFcmxWHhNlcsmXjdeic8CGjfM1vx6qaeHAJCIcBIQEzUO9CiokL8XNw4JHMYtA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-filter-pushdown/-/actor-optimize-query-operation-filter-pushdown-5.2.3.tgz",
+      "integrity": "sha512-6DyGx3qRa3dS/yNhQaiEUqKRXrARaX7pvFC4LHl8nct89qhcqUMCkP3fgCIyC5Btc3sUiYaLlyie6ioiZfh9fQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*",
         "rdf-terms": "^2.0.0"
       },
@@ -1926,15 +1928,15 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-group-file-sources": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-group-file-sources/-/actor-optimize-query-operation-group-file-sources-5.2.2.tgz",
-      "integrity": "sha512-4QKDaBosu6joWYoiHdeB1RUeaayVlQlesQmrT6SNeYV8tSwTJYg3bZP1rdd4+1MNz2F6hYnJt96yjuTt2tLWLA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-group-file-sources/-/actor-optimize-query-operation-group-file-sources-5.2.3.tgz",
+      "integrity": "sha512-GI5a8s0tKPByhT4yeX733sYI4ph9XFaInVqekG9iyRId4O2fwAND/J8ZKZ7yxQtUnAoeUnri5mUV0tRTmHnUzg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.2.2",
-        "@comunica/bus-query-source-identify": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2"
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/bus-query-source-identify": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -1942,17 +1944,17 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-group-sources": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-group-sources/-/actor-optimize-query-operation-group-sources-5.2.2.tgz",
-      "integrity": "sha512-PCPUzmsBGOKH/LUfQvcF0bpBOVKskBhwKRGdY/2e6QzU1uR2NPdGs4u3zM+aaHGK3V4wqnW5abzUK0JJN3yzXQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-group-sources/-/actor-optimize-query-operation-group-sources-5.2.3.tgz",
+      "integrity": "sha512-qBo1P1HiKZDfq9KeCIRKmLjRqSzGYPnSKCloOcVTritwTBIKKpV/axpfgOoASpgMMB93qMELoiAVQfG6gECNzQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2"
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -1960,14 +1962,14 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-join-bgp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-5.2.2.tgz",
-      "integrity": "sha512-3+n8lNXf5VIo/X914SkMlw2jX0e85nRCv9cs1tJuhZ8d5vb7dUH3MVu+I40bbphdjpc1oNShyGUBx10KWgkVzg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-5.2.3.tgz",
+      "integrity": "sha512-Ccq8yfWp0XWd5D/McciSCSjcPIJ84aRjhAp4N1cumRSYJ4sjCcnQ3dkY5d0XEezvtCG2BUFV3abgvRnnYiwruA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
@@ -1976,15 +1978,15 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-join-connected": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-connected/-/actor-optimize-query-operation-join-connected-5.2.2.tgz",
-      "integrity": "sha512-ZVhlS5VKxejB52EfFW9AEw21uZKxsdl/fuZ67pSawp2CfCAOksNPo4MM/T2H7MnAdtj70tjHJPb3+AH73ic+2g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-connected/-/actor-optimize-query-operation-join-connected-5.2.3.tgz",
+      "integrity": "sha512-KGiEKNegvUf+Q/Cki9M5zeSr2JtsuU087RPuGwOyLAr2v76L7/Ll9Q4D1Qeq+tVEpkZGq1NjrrWO4DvmhZLapw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
@@ -1993,17 +1995,17 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown/-/actor-optimize-query-operation-leftjoin-expression-pushdown-5.2.2.tgz",
-      "integrity": "sha512-YP0zD83rmqS+DtMZbjWF7EpvdtmkDIzdVV9TT5jdfaCeDRuMdXyn+eIpKa7lOUNK0Tvf9YyH1AgFKU9hfnR6XA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown/-/actor-optimize-query-operation-leftjoin-expression-pushdown-5.2.3.tgz",
+      "integrity": "sha512-CesCgPEk1jwyZqEg9a3pQqflHM0YI9Hm97x93HJbT+tEjqXwxGVvPV/S4zQ5BVSIhHo8WBwdryx0M5mI6hG5eg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -2012,17 +2014,17 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-prune-empty-source-operations": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-prune-empty-source-operations/-/actor-optimize-query-operation-prune-empty-source-operations-5.2.2.tgz",
-      "integrity": "sha512-EmT2pynCP1abkTl92/ZpJjC4kmjmgIvx8qWuMjd3hTdjbtar7aYdl1ihkZVUPwC2rP3lOMviiCteFSxj1yajLg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-prune-empty-source-operations/-/actor-optimize-query-operation-prune-empty-source-operations-5.2.3.tgz",
+      "integrity": "sha512-s6J7VpslGVGMidP4T2e7xgka9kakhio3apMYrF7hBUFfVIfbUkR6P0DIQWVzvBLRIO2OEfxfgl0hFbYARDCXWA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2"
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -2030,20 +2032,20 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-query-source-identify": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-query-source-identify/-/actor-optimize-query-operation-query-source-identify-5.2.2.tgz",
-      "integrity": "sha512-jE3v6aHhUboHByGu5d9M94c4XKhsp+ZtBc/tCV1FP7VFkrfKc9+tUTn98zUSHjVprgWrfmAQiaR82B2EMILysg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-query-source-identify/-/actor-optimize-query-operation-query-source-identify-5.2.3.tgz",
+      "integrity": "sha512-TpueX8wdpwQp2Vy+2EGEVWgea9qW8YLVXbydHMYRNLX7UIGdu+iJKiWjrn/2uEDAr5+MUSpV+hTXpHtApc40sA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-context-preprocess": "^5.2.2",
-        "@comunica/bus-http-invalidate": "^5.2.2",
-        "@comunica/bus-optimize-query-operation": "^5.2.2",
-        "@comunica/bus-query-source-identify": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-context-preprocess": "^5.2.3",
+        "@comunica/bus-http-invalidate": "^5.2.3",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/bus-query-source-identify": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-query-operation": "^5.2.3",
         "lru-cache": "^11.2.2"
       },
       "funding": {
@@ -2052,18 +2054,18 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-query-source-skolemize": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-query-source-skolemize/-/actor-optimize-query-operation-query-source-skolemize-5.2.2.tgz",
-      "integrity": "sha512-aqGiXk+MKVwdSFdVWrVHIKg99fggkc02AQ8OYILLSBreOeroIT5gJ4N4cNIQHc3XqkJ3W+JIAiyIUCCgsLE/Aw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-query-source-skolemize/-/actor-optimize-query-operation-query-source-skolemize-5.2.3.tgz",
+      "integrity": "sha512-j9ouJ30S2uc8sEXvcfxxH3pMfIfVSmL/Xee7/Rc4cdGy27XwaKuMLXveDlybtpiPjnFer06EL/EoMxyNdRlR9w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
         "@comunica/utils-data-factory": "^5.0.0",
-        "@comunica/utils-metadata": "^5.2.0",
+        "@comunica/utils-metadata": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "rdf-terms": "^2.0.0"
@@ -2074,15 +2076,15 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-rewrite-add": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-add/-/actor-optimize-query-operation-rewrite-add-5.2.2.tgz",
-      "integrity": "sha512-FNyrfdVyVZIuSJwScaGS8G+pKy6fsPcwmYH6cZ6l5nu1E+2E7qFoK0nROs9GpAvfdcLb3yLgA78wYw/mkydeog==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-add/-/actor-optimize-query-operation-rewrite-add-5.2.3.tgz",
+      "integrity": "sha512-c9DYYzRHTEsD7Jy9R+8zchC2nZmV/3y2qKtwAxkHW30CdQSUijUBS2tHxUit5QSd/U2nQFG6qHViax3gZ7cdhA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
         "@rdfjs/types": "*",
         "rdf-data-factory": "^2.0.0"
@@ -2106,15 +2108,15 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-rewrite-copy": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-copy/-/actor-optimize-query-operation-rewrite-copy-5.2.2.tgz",
-      "integrity": "sha512-lqHaXO2X/dLbsUsN8Sg9y2+K1bUE/p/YL/jaJZ3oq7iUEjt2OCrF93HVgOk5DKUCRCSaMmkBW6WY59/MAyCzzg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-copy/-/actor-optimize-query-operation-rewrite-copy-5.2.3.tgz",
+      "integrity": "sha512-19WBXW+lcpZhacRUCRzfd1UwPqE6auXf46x93xdU9QDIlLWiWFnd4L55pNLYZvvEYnyVc0+pzlwS0D6bcvF8kg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
@@ -2123,15 +2125,15 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-rewrite-move": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-move/-/actor-optimize-query-operation-rewrite-move-5.2.2.tgz",
-      "integrity": "sha512-jhs4JCPOuBU2js8+JJOQ833Z/t3vnVtRpYCptNWSVqwgujvEEBEfTmcdQLMKZ+gLvXA+rPkYw1drc+x2za/VoQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-move/-/actor-optimize-query-operation-rewrite-move-5.2.3.tgz",
+      "integrity": "sha512-aWQWF0vUg6nII1Bx6kfwLUtr1Nol+aRWr3JXIoVd68g051z4XZz46nrJgdB232+Ql2LKc35++Jyz8mSHeaHgHw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
@@ -2140,16 +2142,16 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-ask": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-5.2.2.tgz",
-      "integrity": "sha512-czlC3f960U6HJXXADPqsNAFCBppiPyyezL+15pqNasce472wCxv2emI3Rgljg9qdJtYetB2za+CJZ+Rj9kR//A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-5.2.3.tgz",
+      "integrity": "sha512-JpwU59vbWicl9Rnk0G+UrZu8HdLyAeTthtFX1V+DmotFNf50vzwJ39ICzIYa5Q0maXVDmdiEoi5MkWFXHBz8pQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2"
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -2157,15 +2159,15 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-bgp-join": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-join/-/actor-query-operation-bgp-join-5.2.2.tgz",
-      "integrity": "sha512-kPGWiJAWi7TUd3lu2qtI4NOeviFG+b5KiQT9It/4WQ0Lj/fgFoUPSr0OwUJsRWZ50fLrAsx8uJeqrqUD+epyPw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-join/-/actor-query-operation-bgp-join-5.2.3.tgz",
+      "integrity": "sha512-A0y2aIjcfJDQyDF/GNy4WbQajo8Rf0c30CI7NNP/WP2/Gv28mjrcOpijQRrdWI50Hv/2vqeXcG5BFBRpMT5gRw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
@@ -2174,17 +2176,17 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-construct": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-5.2.2.tgz",
-      "integrity": "sha512-c+3VE88OamDyxm1mj1FhXsKsEXxgqhSXToZYOZkSJB34JCQuUnNJOHWtZ5HdO9+6gfC11Me08HBpOf5ffbATIA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-5.2.3.tgz",
+      "integrity": "sha512-d7ozBZyK03EZeOyRG7L71VqT5FjfZAH2ryoRCmkIKvEg6PHpv8NadPA5P4IKWmEW3B42WJFwbvylmF++xo2CNA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "rdf-terms": "^2.0.0"
@@ -2195,16 +2197,16 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-distinct-identity": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-identity/-/actor-query-operation-distinct-identity-5.2.2.tgz",
-      "integrity": "sha512-fjGCE0IKW5Zj2pJjpg7V+ZYeMG0YzzxcZ4elonx5hzvjXKmj+KCFj4xy8UTTIwisvHe9q8SyQeIs5ImwNR9tYg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-identity/-/actor-query-operation-distinct-identity-5.2.3.tgz",
+      "integrity": "sha512-k1vZeFZYQ1foGuhznKIkg37brwxapevLFKmKJ9CbG7Nb+7WW3Mw202NDw1awr+m/+CZ0QCZiLF6IUlgQOFfrcA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "rdf-string": "^2.0.1"
@@ -2215,19 +2217,19 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-extend": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-5.2.2.tgz",
-      "integrity": "sha512-KjHHZ6O5N23jIRcHN5sZxiTkvjSyPIk4xF4EcgJMXYh4K9SRY8yi+eaBPG5i3p13tbBBga/G0e02l7u6cW9OCw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-5.2.3.tgz",
+      "integrity": "sha512-Cpmc0ISIyWX16sd7NXcNWSGzEOgGo8YMw08fimURG9oe+l2CGGkGDsj2AtngFyTVQvSOgEqbM5WyrG+qc70ouQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-expression-evaluator-factory": "^5.2.2",
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-expression-evaluator-factory": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-bindings-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
-        "@comunica/utils-query-operation": "^5.2.2"
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -2235,19 +2237,19 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-filter": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter/-/actor-query-operation-filter-5.2.2.tgz",
-      "integrity": "sha512-7MN84fi4YXqzslyqfDudnLQKNg4pUToFJ9RIRCpUDQj+NpA4phPCicWTptkeDcDkz2zukjYt3KoWUz76PWD69A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter/-/actor-query-operation-filter-5.2.3.tgz",
+      "integrity": "sha512-NRnwAiF9ZfsNh0Rv1CBGIRMm/CvX5Dvy4iXTAzEMV9n/WWwRjrNrJjpN6vJUtGgFpF7A+Mu7GZxDf9qucKKvGw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-expression-evaluator-factory": "^5.2.2",
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-expression-evaluator-factory": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-bindings-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
-        "@comunica/utils-query-operation": "^5.2.2"
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -2255,15 +2257,15 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-from-quad": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-5.2.2.tgz",
-      "integrity": "sha512-A+j4sdAcVDoIAILgm2MfXL20t0eAueJFCHxYI5q3LMxcsPxBmd19o/FHs7fPAvBO/Cvp+hQoQzEkaYFnbV6Cfg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-5.2.3.tgz",
+      "integrity": "sha512-peMws9f2ldijeJKf+Rnh3xXgwDBxvyd/wS3Mbfxu2fDFeXFQXB7AnNebFS2PTRF4K9uQqRrh/U7hoQtUcWGTGg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
         "@rdfjs/types": "*"
       },
@@ -2273,20 +2275,20 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-group": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-5.2.2.tgz",
-      "integrity": "sha512-GV1GbtJpICjIzpTR0VqZGE2/7mZRsX6K+hdnG6ghX4KjTzYCaKIMDExYHiz7pLcNamMAWkurYHLopIU1A9qbdA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-5.2.3.tgz",
+      "integrity": "sha512-EkLEoH3Eid4q2+3GnCTjClbwv0ROfhPuTe6EilSG9JO/Hrv4/Pj4WHtRQu6T1xzmCeXZbTZwTZ7LWBUnengm7g==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^5.2.2",
-        "@comunica/bus-merge-bindings-context": "^5.2.2",
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-bindings-aggregator-factory": "^5.2.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-bindings-factory": "^5.2.2",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0"
       },
@@ -2296,18 +2298,18 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-join": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-5.2.2.tgz",
-      "integrity": "sha512-smP4dtkoCtq7toIyIXiUCebcO7cp0JKlFe5KVEEnCSjn7AQ+ussoFWp9iZMryOaILBz4uv2rLfRIVoYPQxx7sg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-5.2.3.tgz",
+      "integrity": "sha512-XnBTOlED7+NimckkRXIb61pv3r4u9NbmAPvDkw/bBAcKnoKvvSW1eQYOjKWKKgTBnOboeCHONIGvn/M9pLWUBQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/bus-rdf-join": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-metadata": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-metadata": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "rdf-data-factory": "^2.0.0"
@@ -2331,18 +2333,18 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-leftjoin": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin/-/actor-query-operation-leftjoin-5.2.2.tgz",
-      "integrity": "sha512-BkHL0VS+cKMF6XMs3q69XbSIYAwpIz4ZNCF/SeTWLd8yO9hIlEtXhtI/W8YcBH7goezICt34Y+UQvisEdwCBrw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin/-/actor-query-operation-leftjoin-5.2.3.tgz",
+      "integrity": "sha512-M21jw/st6H/YpqS7Rn6Iyn/c5mdLJovMGGTLVUVz0EDXVofGktAnP6RGvDSlvcSm8Wzu/kypJGQPCy4qnf4rLg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/bus-rdf-join": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2"
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -2350,17 +2352,17 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-minus": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-5.2.2.tgz",
-      "integrity": "sha512-77vKvp54/q5CX4YfzttiHI1lJEl/jYfnVCyVGrPfV+3Cei6plxp2Dcx6TR6YIA3XWsdn081pKZLIB5rZClhdxA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-5.2.3.tgz",
+      "integrity": "sha512-8K0nq++Xkni+f2jIZUAFOyFFmi81Q4H3JaI6icFzA6Ml+6H2tSW27IxmwGVJFKDnNcQGYWeqMEFRJPHmpMi2YQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/bus-rdf-join": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2"
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -2368,17 +2370,17 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-nodes": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-nodes/-/actor-query-operation-nodes-5.2.2.tgz",
-      "integrity": "sha512-ohm4Zhnhq35lmUJPbe7lB2wuP7Eq9PXTLv+jgVgvAOJc7SeqVVMR3rAr3PTQttI2mDGJdmhD/ryWiW69xhTIDA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-nodes/-/actor-query-operation-nodes-5.2.3.tgz",
+      "integrity": "sha512-TLzkQB3F4co+Xvnjcy7tLP4WXgHo2Bvy8NeFRd5VHQpXYYmwgv6wrd/NduIQBvHyLcHnlWBJRfD0ciVfflZ8nw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2"
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -2386,19 +2388,19 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-nop": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-nop/-/actor-query-operation-nop-5.2.2.tgz",
-      "integrity": "sha512-bQzLn6A8Tqnnu9BjBds3Gg2chclNocuag43tD2bx1An3WYYtoOMw5o9SupEt9epHom0YkzzUOYvm4e7MmJVjjg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-nop/-/actor-query-operation-nop-5.2.3.tgz",
+      "integrity": "sha512-lcq01cDhotaOb50WX7jBL0t+8OYZOqsDwN1xVbEf1AgDHz/InsRalUsuibpMPOunwM1iQcHx7fVMXd4SeCl/KA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-merge-bindings-context": "^5.2.2",
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-bindings-factory": "^5.2.2",
-        "@comunica/utils-metadata": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-metadata": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0"
       },
@@ -2408,19 +2410,19 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-orderby": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby/-/actor-query-operation-orderby-5.2.2.tgz",
-      "integrity": "sha512-k1nbMpzomTi2gcRDt88B0Jd6oIoW34YumJIlML8WlaCmB1pCfOZIKOClnnZk3S1bN9JeqHpBKNe3+1w2tC4jSA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby/-/actor-query-operation-orderby-5.2.3.tgz",
+      "integrity": "sha512-A9DVAicDITKXSkS4B2LaNga3hhSt8V67tNnJvSJhkGiE8MXKUYnPmht5uuoUU/4hQDgLGQEC5FZ7zMHMcszzEA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-expression-evaluator-factory": "^5.2.2",
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/bus-term-comparator-factory": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-expression-evaluator-factory": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-term-comparator-factory": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "asynciterator": "^3.10.0"
       },
       "funding": {
@@ -2429,19 +2431,19 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-path-alt": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-5.2.2.tgz",
-      "integrity": "sha512-PrxvG4U1dCeP6faYJQbbwcbaRfYBamhy1JHU7pgkXt6q2wdXFqUuRkP4CtHSjk1FHHOPssxsItCFYmoPzBZxlg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-5.2.3.tgz",
+      "integrity": "sha512-hWijZHABPKFmnQoAxo2Uy9PEgMs5oHFs7rFGy4ShUzF0hYxWErUSKl3J3+RRi0gwkUGXgVv1azoOPeKPj0aBTA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-abstract-path": "^5.2.2",
-        "@comunica/actor-query-operation-union": "^5.2.2",
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/bus-rdf-metadata-accumulate": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/actor-abstract-path": "^5.2.3",
+        "@comunica/actor-query-operation-union": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-metadata-accumulate": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-query-operation": "^5.2.3",
         "asynciterator": "^3.10.0"
       },
       "funding": {
@@ -2450,15 +2452,15 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-path-inv": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-5.2.2.tgz",
-      "integrity": "sha512-4LEHjvqlbajPIuqbBQAE4mOCu0tn2rSLCGeU+OMuYoKU5x3sg1fvngmBq1Uy9ITR7XvH+0C8K5D4QEBIToFIrA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-5.2.3.tgz",
+      "integrity": "sha512-KxBTetLr2kKQ7Hwz1LDmMvwxpvQJqCFOYmgvnEgm6rsg+WGY7J3cLhhHx0Et0w26LAz2MB3qfyt+vFzyBrZ7kw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-abstract-path": "^5.2.2",
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/actor-abstract-path": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
@@ -2467,15 +2469,15 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-path-link": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-5.2.2.tgz",
-      "integrity": "sha512-vNp/iRn7vhptixLE/ZTL7HAdp2TOjafinLiCI/IdH2pTDe1kC59IUP4V786KDTBKDk7lH2omG5rQl483xBUyew==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-5.2.3.tgz",
+      "integrity": "sha512-ymkeLF/sjKhuD9bjFgJM91UgAnShNA/qjtyajc0INO+X0QI/VA75713W/HCMFNTrj27DoXhQc8WUnDCO7oOmnQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-abstract-path": "^5.2.2",
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/actor-abstract-path": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
@@ -2484,17 +2486,17 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-path-nps": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-5.2.2.tgz",
-      "integrity": "sha512-/GZvzLMVCfNC9C3RL1qN79JNBTZCgrhsnoD2FurVFXglg5X2nH5tOnZBAIOuLIxANNPJ6d1PqXg313/Uoy50qA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-5.2.3.tgz",
+      "integrity": "sha512-4GwukJfxqPW14YabmVLajVtljMgrFPVMiOSP3zhj8e9KLzD+Evbr4eqc9dK2JZbYZYAKEmOZqHXPwx9SSNqegw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-abstract-path": "^5.2.2",
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/actor-abstract-path": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2"
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -2502,19 +2504,19 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-path-one-or-more": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-5.2.2.tgz",
-      "integrity": "sha512-h1MYXUJ+bKxjyqQ1TJKEy+cAK6usYE//ugfjBdcVDAyAFKLiH+RmXpk+fOxUy5DxNnO0VKiJIKTdl1a0v21mzg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-5.2.3.tgz",
+      "integrity": "sha512-h1W0q1huLJJtiwVykazOjxEryJUKwsHfcYHKMkMtWpG880oNqIFASSio/sFaps4vxhubeaWVtQuoVr5EhDSYFg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-abstract-path": "^5.2.2",
-        "@comunica/bus-merge-bindings-context": "^5.2.2",
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/actor-abstract-path": "^5.2.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-bindings-factory": "^5.2.2",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "asynciterator": "^3.10.0"
       },
       "funding": {
@@ -2523,18 +2525,18 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-path-seq": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-5.2.2.tgz",
-      "integrity": "sha512-pCK7tEbLRa58+F+KuOKBd/tSk9bnQlIYjI/X5zdgd+AM2c2uewBMO/EjmN/6cGhWDIyEUaxxOVYXW5kO618SRA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-5.2.3.tgz",
+      "integrity": "sha512-HMyL+387KaP+u4VCoPJmi2iVtxgSwy0DxXZSUuMZlwrn1rDxVojzIucBMZUH0XlhahHQzkpVQ8g+vgeZGJ7viw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-abstract-path": "^5.2.2",
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/bus-rdf-join": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/actor-abstract-path": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2"
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -2542,18 +2544,18 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-path-zero-or-more": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-5.2.2.tgz",
-      "integrity": "sha512-l/jxIykajp+j2C6ObEdjAApiIXGPbw1mea6qx6HbTpIkoDUnVq02q68v+bN19+yQdu8FsmqbBBDcH0ypwxxzDA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-5.2.3.tgz",
+      "integrity": "sha512-iRi1gG7koIKzHMZT8Q6wGmPxMFMJcBY8kPAHeeP8FZYU/cVscqRr5di+Ne3oGBmstQpQGkhp02YO4pK707sWzw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-abstract-path": "^5.2.2",
-        "@comunica/bus-merge-bindings-context": "^5.2.2",
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/actor-abstract-path": "^5.2.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-bindings-factory": "^5.2.2",
+        "@comunica/utils-bindings-factory": "^5.2.3",
         "asynciterator": "^3.10.0"
       },
       "funding": {
@@ -2562,20 +2564,20 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-path-zero-or-one": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-5.2.2.tgz",
-      "integrity": "sha512-6wk8SfZJvpjORpzCnSYhnZh9o3RCG3Tapd8lK0PMl89pRnaoWf0jri/m3GlJbmdLwy56elcTQLBGUJMcr06rqg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-5.2.3.tgz",
+      "integrity": "sha512-0a2fLpzuCm2r6c3sknjIhThU7hefL1izQ0/GyEpZaqaMU154ldvQMWOLJq/d2WQp8N3kYfNrEpCnXRSi6CTRtA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-abstract-path": "^5.2.2",
-        "@comunica/bus-merge-bindings-context": "^5.2.2",
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/actor-abstract-path": "^5.2.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-bindings-factory": "^5.2.2",
-        "@comunica/utils-metadata": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-metadata": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "asynciterator": "^3.10.0"
       },
       "funding": {
@@ -2584,18 +2586,18 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-project": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-5.2.2.tgz",
-      "integrity": "sha512-hOpwyaRtBhGt03B59mQ79IkvtVVxYMxRW582av479NAH6Ams2HQckI+GDIUPEnA5LzMFxOL8QMQYsU0+oO7iLg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-5.2.3.tgz",
+      "integrity": "sha512-CfMEUuYOT/Y/T4aCYG0ZhSxPXi/6YDI2uOIYAlOjeud7Bb5n+3SxnvVd6r/rihiFWJLXykSeYsppWvVY5ElwWQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
         "@comunica/utils-data-factory": "^5.0.0",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -2604,17 +2606,17 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-reduced-hash": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-5.2.2.tgz",
-      "integrity": "sha512-zoV33XPbs0Sx03zs5UesFpxPwusmL+iPBKbMLLhYaRwvtWcw/tRqIL5KObH08Ho1Y9i2HsRDKjU90Q6R+onBFA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-5.2.3.tgz",
+      "integrity": "sha512-gX23UrR5e/6zyO+MGuRru3OEr62Ty7S0iTxykI52YenGf+gsEGnkLQDBclOriMs7XNemJ+YHncsJ2v6HCSahhg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-hash-bindings": "^5.2.2",
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-hash-bindings": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*",
         "lru-cache": "^11.2.2"
       },
@@ -2861,15 +2863,15 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-slice": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-5.2.2.tgz",
-      "integrity": "sha512-3MdcJUDobhn62JusRX6VPCr/iKpDVCrgAiJesvJwcJQiweg9/CNhqJZ8OOkUT/kCZKRjYa7yypw9LdCb9/Qkpg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-5.2.3.tgz",
+      "integrity": "sha512-taXSk/xTXKHoWxQXv1J6XwKPrRNUShIjGuLi10MmfKqje3adNSrVDr9dKEaIUK0iKxdJFP6ZHXgRjdqiYb99Dw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
@@ -2878,18 +2880,18 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-source": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-source/-/actor-query-operation-source-5.2.2.tgz",
-      "integrity": "sha512-Zh5tuH2Pb466VEcEf4Usv2zVOvZEkddCUFJsDDYuJbGfpB2o/JKIIWZkRrtjKKserEmkgOZnoPAd79l0M+yKRw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-source/-/actor-query-operation-source-5.2.3.tgz",
+      "integrity": "sha512-3jsxiAqZXMwHJObQ36sYrh+3vnOeimGlil3jo30C2uAGRiD5M3+bNb+SHp74VXEgOeeMG9gwB33W44qolYqS7Q==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-metadata": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2"
+        "@comunica/utils-metadata": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -2897,18 +2899,18 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-union": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-5.2.2.tgz",
-      "integrity": "sha512-XaY98TuQ2ga86vZEWfsOOk8LegDST9oRUa5pZBHuFzG1gxiFfn2lz3aM4hvFsL0KAZ90aOloUbzYIasC9Igi1Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-5.2.3.tgz",
+      "integrity": "sha512-HzaQ/KK4/3XPJ9Dc40Ngn7FWvzAyH+iWpVl9cvOwGgI92ndICzDtbHNgC7ZXJ34pRqwU/Oc5O09FUqP6T2VnzQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/bus-rdf-metadata-accumulate": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-metadata-accumulate": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-metadata": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-metadata": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "asynciterator": "^3.10.0"
       },
       "funding": {
@@ -2917,18 +2919,18 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-update-clear": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-5.2.2.tgz",
-      "integrity": "sha512-lbOl3TSNYXOgf2XSP9Bi63YTPmnp/hJC+vSejIj05XnlO6CB61kW+lvcjHpCMx7783ylQNHX9w9IX/2RXi7yzA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-5.2.3.tgz",
+      "integrity": "sha512-4MqGN+8kTj5cCsLppQRbdbqjRW66ST2ELGHPN9HScI8gEHjh+xKDgY/poKVPvgxUYOylpNkMRN0e4nF6O0lhmQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/bus-rdf-update-quads": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-update-quads": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -2937,16 +2939,16 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-update-compositeupdate": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-5.2.2.tgz",
-      "integrity": "sha512-zvPSvg2JI1cLJSxm4DxzJh55PhomRUpcT/Gv0zZcvZrVeP1HomcKIyDJic03rhmYVyTIrGYXGFUnjMqjvuPlbQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-5.2.3.tgz",
+      "integrity": "sha512-LXwD13/O/LQ1MIsxpnVj4Exk/tHdtw16kmwydWH61Wpd0a6glStygKdyuumNBMoKtefS8VF9tC57zDy67X7TXA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2"
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -2954,17 +2956,17 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-update-create": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-5.2.2.tgz",
-      "integrity": "sha512-2mCQ2B+9T3/5VWZP5D+hBnjC1CC51vvxEnDPJbKLIVUaIESCSMXxLBA9cKfiQ0pyrk+IhlNcUlStQNW6+BIdnA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-5.2.3.tgz",
+      "integrity": "sha512-vn1sZBNUih4L5vKUQpa+cS0yNjElnA9MtlCq5Xr80GM911i7DKUvwdqdBuGMWlivQQKQUsRaOWnF+WrlZXSlzQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/bus-rdf-update-quads": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-update-quads": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2"
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -2972,21 +2974,21 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-update-deleteinsert": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-5.2.2.tgz",
-      "integrity": "sha512-eNKfh7Shf03662zgUNk+yBdyj8KUfso4LrnTWlGFZAtu4U6pd7Av2HgSIv6M66MeHRSXg5VqqEFnxsPktWf7hQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-5.2.3.tgz",
+      "integrity": "sha512-9pLqGUPeCQsv6rfotaf9ly5Y6Oft4CforMHnL5wmAZUGkm73m0aBdX8Q+9M1tNop3w++J9eK6tovcbXWPBFtBA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-query-operation-construct": "^5.2.2",
-        "@comunica/bus-merge-bindings-context": "^5.2.2",
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/bus-rdf-update-quads": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/actor-query-operation-construct": "^5.2.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-update-quads": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-bindings-factory": "^5.2.2",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0"
       },
@@ -2996,18 +2998,18 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-update-drop": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-5.2.2.tgz",
-      "integrity": "sha512-rzchGldhuqfZytQmuVv60AmhEkYCcHn3foyIjMndlE932J+16o6KLDL8QEoZzvxMXs96XxSFRoDJnX2irlH+PQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-5.2.3.tgz",
+      "integrity": "sha512-oGyD4MmHjVJ84bZNhgorIGkcUsQxe4GV0qZSSVbQE0sGrSXD7xHaRRphVE+O31qKnQ5VWznge8vJ637HZZMIQA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/bus-rdf-update-quads": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-update-quads": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -3016,19 +3018,19 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-update-load": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-5.2.2.tgz",
-      "integrity": "sha512-cvI8TpkPaQzofJYQY5Ko6qKZFXv2nHSYZE2zWpSZGR3H0IYZbqUwGSzpagIKH3v5y9AoUuvuWRdEIyA+H8eFkQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-5.2.3.tgz",
+      "integrity": "sha512-ryXy+fd53bOnd9bcPjQxo8amyQHwTiQr2o0/uLbeaYppimsfH5nf+FKDWWP9mkewNCUueOnFzqSI6i/plPheJQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/bus-query-source-identify": "^5.2.2",
-        "@comunica/bus-rdf-update-quads": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-query-source-identify": "^5.2.3",
+        "@comunica/bus-rdf-update-quads": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2"
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -3036,19 +3038,19 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-values": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-5.2.2.tgz",
-      "integrity": "sha512-U/3rOeRu8l6mYwBx6MAXNIZBEWv4dmlU87kig0x40bxQRPWlRodNATQCsKSOoXZRNI8yVqJPJySlLrGvq79H5w==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-5.2.3.tgz",
+      "integrity": "sha512-kOuH8JQ8PeeKFWe8ni2LbA5KD4PAP1weq/vYwanpBk7/sJVjVI2ieQMF8pHUri0uh8RnmTZT7y4t+QbzxpVuSg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-merge-bindings-context": "^5.2.2",
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-bindings-factory": "^5.2.2",
-        "@comunica/utils-metadata": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-metadata": "^5.2.3",
         "asynciterator": "^3.10.0"
       },
       "funding": {
@@ -3073,15 +3075,15 @@
       }
     },
     "node_modules/@comunica/actor-query-parse-sparql": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-parse-sparql/-/actor-query-parse-sparql-5.2.2.tgz",
-      "integrity": "sha512-84JMlz4bSvXchXMw49Am7Ne/wHUsIPpuu8wBmvUnL5bHca9qmn/bobEj5WYH3QQgNS2yuqJc93C7nTzHVlTLqg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-parse-sparql/-/actor-query-parse-sparql-5.2.3.tgz",
+      "integrity": "sha512-zRhPm9D9Yj8/2aMKCeDWPLq6Wdo4nmNBs5EC3QYDtxdHOlTCtwdfYyJabJ2J77IZ/PY2dZJXGI4veujjSk/UOA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-parse": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-query-parse": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@traqula/algebra-sparql-1-2": "^1.0.1",
         "@traqula/parser-sparql-1-2": "^1.0.1",
         "@traqula/rules-sparql-1-2": "^1.0.1"
@@ -3160,23 +3162,23 @@
       }
     },
     "node_modules/@comunica/actor-query-process-sequential": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-process-sequential/-/actor-query-process-sequential-5.2.2.tgz",
-      "integrity": "sha512-nHPgkBNxVHH6KaY+g1SXsvtyJ+G6ys0p8B1s0Amv/D1vWhEntv3ZX1nQ1kVLg/XWKOlxZDopOkeu7tSZxwgXcA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-process-sequential/-/actor-query-process-sequential-5.2.3.tgz",
+      "integrity": "sha512-pFtjUhtqkVQRh24q7GmCrZT9kZ/P+A7alzI2AbVqurRNPUuTSQoGzkpzqE6Od/IYvPqRGp4bgZSXy4Ew56GocQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-context-preprocess": "^5.2.2",
-        "@comunica/bus-merge-bindings-context": "^5.2.2",
-        "@comunica/bus-optimize-query-operation": "^5.2.2",
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/bus-query-parse": "^5.2.2",
-        "@comunica/bus-query-process": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-context-preprocess": "^5.2.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-query-parse": "^5.2.3",
+        "@comunica/bus-query-process": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-bindings-factory": "^5.2.2",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -3552,19 +3554,19 @@
       }
     },
     "node_modules/@comunica/actor-query-source-identify-rdfjs": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-rdfjs/-/actor-query-source-identify-rdfjs-5.2.2.tgz",
-      "integrity": "sha512-QNEDuwLCTU1sKkea0CSedZip/fNhvwIhO+gH1lrXMbnMM/r5g4IvxgSZP6U/LhlZnKyj+dQyEMwtv8XQWyVQAQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-rdfjs/-/actor-query-source-identify-rdfjs-5.2.3.tgz",
+      "integrity": "sha512-eX3ZyBU32L1B8iXPf/jerHqnD73ooxKW0ThXRQClLuSEJZCQ1Zo0GZ0tQv4tVg4XnK+f3u2K1QfUOAmwTMLbMg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-merge-bindings-context": "^5.2.2",
-        "@comunica/bus-query-source-identify": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-source-identify": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-bindings-factory": "^5.2.2",
-        "@comunica/utils-metadata": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-metadata": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "rdf-terms": "^2.0.0"
@@ -3594,13 +3596,13 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-entries-sort-cardinality": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-entries-sort-cardinality/-/actor-rdf-join-entries-sort-cardinality-5.2.2.tgz",
-      "integrity": "sha512-KE610hFWMb4P53KhawOoOT395Hp8lQu+r6kdaEDkNs6kxbET4fAv6ZaMz6sw0qRHuZo0QG2UEVyRmblEwL8vTA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-entries-sort-cardinality/-/actor-rdf-join-entries-sort-cardinality-5.2.3.tgz",
+      "integrity": "sha512-zt03Wl/clFxdMGvBeoPSVhlaRV8R/j1ZbDagYCvq+AczsJcVlxuAyMVnKRjdmnBaW5thbnGkXKwBgCZaSlDaTQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join-entries-sort": "^5.2.2",
-        "@comunica/core": "^5.2.2"
+        "@comunica/bus-rdf-join-entries-sort": "^5.2.3",
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -3608,15 +3610,15 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-entries-sort-selectivity": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-entries-sort-selectivity/-/actor-rdf-join-entries-sort-selectivity-5.2.2.tgz",
-      "integrity": "sha512-lsKgcuE0n3aGTY7eTZiKNRW4OjAJpER5a1CBUGAH3Z/9IEd2jdQkuj44fGeBWojuRO1qJeduwB3IhecBZRGkaw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-entries-sort-selectivity/-/actor-rdf-join-entries-sort-selectivity-5.2.3.tgz",
+      "integrity": "sha512-oO/buzYYczMG3PC6aH04TBCqgjF3lG/4bF0DxxwHKa+7z2BfoJNhil1xmzI0NVWcg3ULhfeyFDjirxQ5+DtqDw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join-entries-sort": "^5.2.2",
-        "@comunica/bus-rdf-join-selectivity": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0"
+        "@comunica/bus-rdf-join-entries-sort": "^5.2.3",
+        "@comunica/bus-rdf-join-selectivity": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -3624,17 +3626,17 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-hash": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-hash/-/actor-rdf-join-inner-hash-5.2.2.tgz",
-      "integrity": "sha512-jScLC3UDOPDK9HsHKDN8PoISqa7sEc0a3r/qCvrkEBu3pzZrXrCASH2UoYv3Jczr8ueYMBZniXCZR13Yzo+dvA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-hash/-/actor-rdf-join-inner-hash-5.2.3.tgz",
+      "integrity": "sha512-bOrLb92YCUTCAck1Fbri/wxHYJNPjbgtuXXQoUbS5jolaaYfvjw0m3gVdsFTNXHWzwnwzGzpf7AbK//fAIBUTQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-hash-bindings": "^5.2.2",
-        "@comunica/bus-rdf-join": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/mediatortype-join-coefficients": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-bindings-index": "^5.2.0",
+        "@comunica/bus-hash-bindings": "^5.2.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-bindings-index": "^5.2.3",
         "@comunica/utils-iterator": "^5.0.0",
         "asynciterator": "^3.10.0",
         "asyncjoin": "^1.2.4",
@@ -3646,22 +3648,22 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-multi-bind": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind/-/actor-rdf-join-inner-multi-bind-5.2.2.tgz",
-      "integrity": "sha512-J0UG2UtZ7fpo7nRZqxymyT9y/39MdDARdgS5ayHnaWxfBBbE6ubAeLeYfq1Rf/BYA+rwxGiOmNGPNCdopD95aQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind/-/actor-rdf-join-inner-multi-bind-5.2.3.tgz",
+      "integrity": "sha512-k/R3/Z027Ra/wFP1zmpArhtbLFVnvExoLfrPBz8ggUvQnF/d0fi6r+GY8qs3CZi9+PlGSISJ7/rcxx+b2VyUNw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-merge-bindings-context": "^5.2.2",
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/bus-rdf-join": "^5.2.2",
-        "@comunica/bus-rdf-join-entries-sort": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/mediatortype-join-coefficients": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/bus-rdf-join-entries-sort": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-bindings-factory": "^5.2.2",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "asynciterator": "^3.10.0"
       },
       "funding": {
@@ -3670,20 +3672,20 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-multi-bind-source": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind-source/-/actor-rdf-join-inner-multi-bind-source-5.2.2.tgz",
-      "integrity": "sha512-4NQHmmJ9hkuR2v30meGnQSPmwu4kcrA2E+sOHYyNLp8c+lw8xGHA7bKFFgUVGmSKxspWqgRYurCwbo6hvdecEg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind-source/-/actor-rdf-join-inner-multi-bind-source-5.2.3.tgz",
+      "integrity": "sha512-7s+uRuhvB0q5rAsbgQjkHZz6Mcdu0/1GYYfsSVw2e33RQvNPWMviHZNb8DV5rJ7szOTLbtPO9UT1JOKYgQeYVg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join": "^5.2.2",
-        "@comunica/bus-rdf-join-entries-sort": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/mediatortype-join-coefficients": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/bus-rdf-join-entries-sort": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
         "@comunica/utils-iterator": "^5.0.0",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-query-operation": "^5.2.3",
         "asynciterator": "^3.10.0"
       },
       "funding": {
@@ -3692,17 +3694,17 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-multi-empty": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-empty/-/actor-rdf-join-inner-multi-empty-5.2.2.tgz",
-      "integrity": "sha512-7mcAcyCnRHqGE2A5emxJz2R4mXsk79nOYE+Fa42G2Q7k3yUcdZ+kvEYMd4TRL3abvZ4hw3eW6i6lztRzYLY6ng==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-empty/-/actor-rdf-join-inner-multi-empty-5.2.3.tgz",
+      "integrity": "sha512-UDgeb995HKoBMHVtAopnncKwMS1UwEkYRaJ+NtHlaPzVFJ9nyC73nQ+KJZNRGcTv3PE0r87nyIeLhvlr5+S92Q==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/mediatortype-join-coefficients": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-metadata": "^5.2.0",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-metadata": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0"
       },
@@ -3712,19 +3714,19 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-multi-smallest": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest/-/actor-rdf-join-inner-multi-smallest-5.2.2.tgz",
-      "integrity": "sha512-+6ie0He9o2gIe9XVPrAT9hOzpCm66ja+UW4fx/Y46u2tvnQgZb4hbW9EeKE6/Hq4ElwT7qzIib62/WPAUabjeQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest/-/actor-rdf-join-inner-multi-smallest-5.2.3.tgz",
+      "integrity": "sha512-rLmr+9roj2llyZnmy0xz2ls/FfmfO/RHUQchXJuiLSGURjpoE0jDT/CREbyRFEJCPI7BFHg9Jko3H+Vzhh7N0g==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join": "^5.2.2",
-        "@comunica/bus-rdf-join-entries-sort": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/mediatortype-join-coefficients": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/bus-rdf-join-entries-sort": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2"
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -3732,21 +3734,21 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings/-/actor-rdf-join-inner-multi-smallest-filter-bindings-5.2.2.tgz",
-      "integrity": "sha512-EwLkF7sugj5QIzHZq6ZlRRGJ/WYmrnOu/XNB2phR8ZAMZAH6gqzAp2wUF/3QvbMv51hjC7mhvHHdCxDq+E2ohQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings/-/actor-rdf-join-inner-multi-smallest-filter-bindings-5.2.3.tgz",
+      "integrity": "sha512-wD2XpYeOfNAYIjeX8eqNQDvFYWCjEO0x7YKI5oxoxJHrLYCgMTaqXyC0f563f9smINIwBdylQE/tRJXu3Tcl5A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join": "^5.2.2",
-        "@comunica/bus-rdf-join-entries-sort": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/mediatortype-join-coefficients": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/bus-rdf-join-entries-sort": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-bindings-factory": "^5.2.2",
+        "@comunica/utils-bindings-factory": "^5.2.3",
         "@comunica/utils-iterator": "^5.0.0",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/utils-query-operation": "^5.2.3",
         "asynciterator": "^3.10.0"
       },
       "funding": {
@@ -3755,14 +3757,14 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-nestedloop": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-nestedloop/-/actor-rdf-join-inner-nestedloop-5.2.2.tgz",
-      "integrity": "sha512-/R3jggmr2bpgIGQJHrg0k/rlfATmYMHjSJlHb3QL3DCQJ8eNQhdsUfaKd3Bhg5oNFICXBR84cpVxZSTk9Nshmw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-nestedloop/-/actor-rdf-join-inner-nestedloop-5.2.3.tgz",
+      "integrity": "sha512-9PN+wkmoMzHv792VEGJa1nKDEmnfwMun76WQo25EEimchHkqdbz5nLKKbo4ecNmkx7aJ4B7us0QrZ0/lILmMDg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/mediatortype-join-coefficients": "^5.2.2",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
         "asyncjoin": "^1.2.4"
       },
       "funding": {
@@ -3771,19 +3773,19 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-none": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-none/-/actor-rdf-join-inner-none-5.2.2.tgz",
-      "integrity": "sha512-/FbwfcY/ixz1pxnUO04TQyww/ekfltsi+If9GvVI6OtO6NgYe7X8AjKY/X0j64Hmd1P9B+4NSB4sSiyHjjU/zA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-none/-/actor-rdf-join-inner-none-5.2.3.tgz",
+      "integrity": "sha512-93jA81M6iJd9Ut89pusfwCLAXZNjmCs+/e18V3wiW9YvDAKQNbTS+wxh1/fGy5WTTWEtQvbf65NgC5mvDBi8dQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-merge-bindings-context": "^5.2.2",
-        "@comunica/bus-rdf-join": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/mediatortype-join-coefficients": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-bindings-factory": "^5.2.2",
-        "@comunica/utils-metadata": "^5.2.0",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-metadata": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0"
       },
@@ -3793,14 +3795,14 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-single": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-single/-/actor-rdf-join-inner-single-5.2.2.tgz",
-      "integrity": "sha512-kKYMQpY8jPlGajzdvoyO0nz8ew24yLAlahtAOl2tbm5kygTgPlDPlUTc6Om0aqBuDMe/50bWEPfUO08Cew/nFg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-single/-/actor-rdf-join-inner-single-5.2.3.tgz",
+      "integrity": "sha512-4i/Z5PXa7EFdztHAQAA0zXVIQppTEpBscZ/RSw5sDx9baRLSazAU9k3SuXkr+06aUefW8xNJt2zJXwKgTBGC8w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/mediatortype-join-coefficients": "^5.2.2"
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -3808,15 +3810,15 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-symmetrichash": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-symmetrichash/-/actor-rdf-join-inner-symmetrichash-5.2.2.tgz",
-      "integrity": "sha512-43Y9+pduselCIBMjFbCLH73YXkMKny4ehVmiaoiWdYZnVTx63Q6PPCh8o+KtrXv6pTi5hxLIgRyu7CeONiyOng==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-symmetrichash/-/actor-rdf-join-inner-symmetrichash-5.2.3.tgz",
+      "integrity": "sha512-rA6hwJ7OfL8O8pJwsQsYy28tFnqkoUpqqBB5vFfUBaZLepYhwkZD4oLvJsa9EcWumDaJsrV0GACEHr9jnfVfEQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-hash-bindings": "^5.2.2",
-        "@comunica/bus-rdf-join": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/mediatortype-join-coefficients": "^5.2.2",
+        "@comunica/bus-hash-bindings": "^5.2.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
         "asyncjoin": "^1.2.4"
       },
       "funding": {
@@ -3825,17 +3827,17 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-minus-hash": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-minus-hash/-/actor-rdf-join-minus-hash-5.2.2.tgz",
-      "integrity": "sha512-x/YC/wbv1aZpIfct/iBNPj/mRt0xR+Lq1UQ3TV8aamHjlEBUtjQoF2bXDROHvlzKNmN4yoaK2Awj3nY29rDp3A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-minus-hash/-/actor-rdf-join-minus-hash-5.2.3.tgz",
+      "integrity": "sha512-4v1tPTyPe0/nsbmaBf3TdpCBR37/O69JyeEcr6n1S87yyWOkktlOm2SbHJ6m8+TFRYkMSWr2aZ01P4s0glpkDA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/mediatortype-join-coefficients": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-bindings-factory": "^5.2.2",
-        "@comunica/utils-bindings-index": "^5.2.0",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-bindings-index": "^5.2.3",
         "@comunica/utils-iterator": "^5.0.0",
         "@rdfjs/types": "*",
         "rdf-string": "^2.0.1"
@@ -3846,22 +3848,22 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-optional-bind": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-bind/-/actor-rdf-join-optional-bind-5.2.2.tgz",
-      "integrity": "sha512-bs9sL4E79gn9Lic5v9GhqXdH/M3XjyrAdBuQJbWO3lYkaOBXOMZWEMnSWlneS/nxJ7RGfwT8Sxd5MtWUA+n7ag==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-bind/-/actor-rdf-join-optional-bind-5.2.3.tgz",
+      "integrity": "sha512-5T1D0+t5Ghs/mNC4HXeDXbfhzL6sG4aYuihTB8E/PRowaEQITDuyw4LKUj6wc3xPojNP1niFWdokULFsXUfvPw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-rdf-join-inner-multi-bind": "^5.2.2",
-        "@comunica/bus-merge-bindings-context": "^5.2.2",
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/bus-rdf-join": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/mediatortype-join-coefficients": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/actor-rdf-join-inner-multi-bind": "^5.2.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-bindings-factory": "^5.2.2",
-        "@comunica/utils-query-operation": "^5.2.2"
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -3869,17 +3871,17 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-optional-hash": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-hash/-/actor-rdf-join-optional-hash-5.2.2.tgz",
-      "integrity": "sha512-Zftnro+ZpLTEc6NwYZ2JFWSO75P9+yHthKYgzpQA8xVhN/Xzuj6Sb5Xmm14AiBosYD7rYaKjeujMs8V7GZRsEQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-hash/-/actor-rdf-join-optional-hash-5.2.3.tgz",
+      "integrity": "sha512-RqW28QO62yw3RYmQkT+pWcEVcQhKF1HFjwhcLwdhi6zP8ENRtQSlBaUW0wUAhdyT46YH5/tlOJYnVyDut5c9NA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/mediatortype-join-coefficients": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-bindings-factory": "^5.2.2",
-        "@comunica/utils-bindings-index": "^5.2.0",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-bindings-index": "^5.2.3",
         "@comunica/utils-iterator": "^5.0.0",
         "asynciterator": "^3.10.0",
         "rdf-string": "^2.0.1"
@@ -3890,14 +3892,14 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-optional-nestedloop": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-nestedloop/-/actor-rdf-join-optional-nestedloop-5.2.2.tgz",
-      "integrity": "sha512-1Sl89ObfU71+X80VdYLlrefAEvAjnXqzvh4/W0ys0M7ZpNKrda0DDGWYQjM9po3Iboh1plP8oHYLmm+oiLLwZg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-nestedloop/-/actor-rdf-join-optional-nestedloop-5.2.3.tgz",
+      "integrity": "sha512-hd5XEUa+i7jTXk35A0a/rD+8+pCnK0pGKFCIQFq/fTZNqCK0waKhyok5AMOhRSVngwPiJ01I3aqO3INTwoLY+A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/mediatortype-join-coefficients": "^5.2.2",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
         "asyncjoin": "^1.2.4"
       },
       "funding": {
@@ -3906,14 +3908,14 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-selectivity-variable-counting": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-selectivity-variable-counting/-/actor-rdf-join-selectivity-variable-counting-5.2.2.tgz",
-      "integrity": "sha512-H7z4A1fz8Pd9hS+UzBQLOEEQCcfhdSwOJW5PoQQf6Mb3PEFyyG5J0Se+SKBh7oePLoU72AgMKhpMRzFl89f7Kg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-selectivity-variable-counting/-/actor-rdf-join-selectivity-variable-counting-5.2.3.tgz",
+      "integrity": "sha512-/4McTKrrhNBcvIxCta3G30btrDartN+U6JQFOSb0HBdUTGz5PnzQRWCgQo9iVlEjK68pZ3AZRXYQFlfoU5Spqw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join-selectivity": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/mediatortype-accuracy": "^5.2.2",
+        "@comunica/bus-rdf-join-selectivity": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-accuracy": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
@@ -3922,14 +3924,14 @@
       }
     },
     "node_modules/@comunica/actor-rdf-metadata-accumulate-cardinality": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-cardinality/-/actor-rdf-metadata-accumulate-cardinality-5.2.2.tgz",
-      "integrity": "sha512-Pv4z3eW8vCeY2/hwwS4Tp9Fn17rPh5l6jP823NE31dEnuUGvuCvkQHG9r7B8keNq73WvQ/WAb7Fr+wRNBp/lRw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-cardinality/-/actor-rdf-metadata-accumulate-cardinality-5.2.3.tgz",
+      "integrity": "sha512-ZW3EvYKI+JgU28ORyxG0hjfRgR/fya6bXf4tVJW4kwMCJpqPeCBP9sZp2DyMN5gUJgyEF9OCjsFivOXRhE7qSA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-metadata-accumulate": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0"
+        "@comunica/bus-rdf-metadata-accumulate": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -3937,13 +3939,13 @@
       }
     },
     "node_modules/@comunica/actor-rdf-metadata-accumulate-pagesize": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-pagesize/-/actor-rdf-metadata-accumulate-pagesize-5.2.2.tgz",
-      "integrity": "sha512-gayIrgk+77CCMO2TMMWPLITpvPpt6DkjKzOp8PdiBynbaAf9ZXyqcO+dFAXGd4zEUOrnuY1TxBNeHzFhIdpu/Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-pagesize/-/actor-rdf-metadata-accumulate-pagesize-5.2.3.tgz",
+      "integrity": "sha512-yWWBeqviOxQ1E0m55PrYZu0UccUvCLkzKuc77nh0Ok6sr2fmScr5UDZGT5guhtK9mdPooiza/5wX185CZLwPzg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-metadata-accumulate": "^5.2.2",
-        "@comunica/core": "^5.2.2"
+        "@comunica/bus-rdf-metadata-accumulate": "^5.2.3",
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -3951,13 +3953,13 @@
       }
     },
     "node_modules/@comunica/actor-rdf-metadata-accumulate-requesttime": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-requesttime/-/actor-rdf-metadata-accumulate-requesttime-5.2.2.tgz",
-      "integrity": "sha512-BvVCJuSXq0M3wpTe//axW6WqKjBH/jpKCqaQh3G6Gi3QpHJm0zwO9CDMdQS70R+lxFARaoiCJvrBUGLpYwe+zg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-requesttime/-/actor-rdf-metadata-accumulate-requesttime-5.2.3.tgz",
+      "integrity": "sha512-aW+DBzRaWc4FuSM8gE8NpcNsLsJP8oee5jadx7/rNZO18e1Lq69G8m2QivD8dBNUZObMKNB5f1tqn5b5jSED1A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-metadata-accumulate": "^5.2.2",
-        "@comunica/core": "^5.2.2"
+        "@comunica/bus-rdf-metadata-accumulate": "^5.2.3",
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -4469,16 +4471,16 @@
       }
     },
     "node_modules/@comunica/actor-rdf-update-quads-rdfjs-store": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-5.2.2.tgz",
-      "integrity": "sha512-TZV6yLkD5IK7Hn+VSHWXxd57DKYKUnXCGq+Pr76Lo7GbxKzn2mrq7BZ+aUi+5U89IJKD/5ZPn2REOOBgK0JcBQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-5.2.3.tgz",
+      "integrity": "sha512-EOgxs96QZCA4Ksb85P9GhMcV0ToPuKOTmPNtVJw0UwXxRRN6AhhhIlMWyTK4Jw3SxTFm4OtUes+eRioCTcMdwQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-update-quads": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
-        "@comunica/utils-query-operation": "^5.2.2",
+        "@comunica/bus-rdf-update-quads": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "event-emitter-promisify": "^1.1.0",
@@ -4490,45 +4492,45 @@
       }
     },
     "node_modules/@comunica/actor-term-comparator-factory-expression-evaluator": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-term-comparator-factory-expression-evaluator/-/actor-term-comparator-factory-expression-evaluator-5.2.2.tgz",
-      "integrity": "sha512-72L5yQua/TujKtJIyH+4KEcNqEdj2lRzrgFaZ6Zs10X2kVtWc8up5bkljMxYbYihfNG0wMvESA5i/XkjWm8ONQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-term-comparator-factory-expression-evaluator/-/actor-term-comparator-factory-expression-evaluator-5.2.3.tgz",
+      "integrity": "sha512-hpsO5FyC/3cv/yxmNA0PXFEmjZkUEWZwW/Dijl1HQXK0KzrNDffpIKEt8Y6704h7oWnPjaGAxlzoi+e7gwztqg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-expression-evaluator-factory-default": "^5.2.2",
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/bus-term-comparator-factory": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/utils-bindings-factory": "^5.2.2",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
+        "@comunica/actor-expression-evaluator-factory-default": "^5.2.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/bus-term-comparator-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@comunica/bus-bindings-aggregator-factory": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-bindings-aggregator-factory/-/bus-bindings-aggregator-factory-5.2.2.tgz",
-      "integrity": "sha512-xIOPdiuCuRyK7mbeINUx3fCDl588jx4dHb8bIKj2t5k78IK6J9Bkjhn7pr5Y42ivVNqXadLSy2PbUJNXtPj9kA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-bindings-aggregator-factory/-/bus-bindings-aggregator-factory-5.2.3.tgz",
+      "integrity": "sha512-qURcsSJeijscCPmLLZdKKQ/33sks3gEFr3JoXM97B8ZS4ZnhmE4JSiSHKE4cYN+osXHXVFRHQuHDd1cIlxjO0w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-expression-evaluator-factory": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-expression-evaluator-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "@rdfjs/types": "*",
         "rdf-string": "^2.0.1"
       }
     },
     "node_modules/@comunica/bus-context-preprocess": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-5.2.2.tgz",
-      "integrity": "sha512-GXdUhKtVkXLNNYvUYwUoPdjtsIWqBoXVfreHJux27ri+rJaby3vrgy934S+7iMbgzoj2fw4qgGoVl2tH81jfiA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-5.2.3.tgz",
+      "integrity": "sha512-LtoQGPHjT+OJb5E9+0ykpDyaWlyi9nbhQjH5xlZyvdl3xVoFiA+uzpbOug9LWS2WIPwzlfFWhLHl+iuFCIwc7w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0"
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -4570,40 +4572,40 @@
       }
     },
     "node_modules/@comunica/bus-expression-evaluator-factory": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-expression-evaluator-factory/-/bus-expression-evaluator-factory-5.2.2.tgz",
-      "integrity": "sha512-fbYhmy/AecVOKOdWzmEJrvME2AA1elDWbaXr3gVpzRbtSvNfTozYxceUa/nbMB45NBK1PoX5eBp1AAvMwZufzg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-expression-evaluator-factory/-/bus-expression-evaluator-factory-5.2.3.tgz",
+      "integrity": "sha512-46jPNOXLx1bIvHSRdPk8kIW7TJAqTdZIucgcSn6z1aJyXMSsDYUZPTClX5eSZciUufKASyPicMebvP7p47++JA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/bus-merge-bindings-context": "^5.2.2",
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0"
       }
     },
     "node_modules/@comunica/bus-function-factory": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-function-factory/-/bus-function-factory-5.2.2.tgz",
-      "integrity": "sha512-HrM12dmuXTUlrcski7F2j1wq4LVPsPLpJI7PHdFB99/DIU5p89UOb7WVwVD1FUgstYfGxPvctHM9HnT6jvXoiQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-function-factory/-/bus-function-factory-5.2.3.tgz",
+      "integrity": "sha512-DlRHH5ktOTb22J0vlMumBfIkFkg3eN3mfB+mRrt+pbLabI417/arkEFSSvZKrXjLUL39zbBqhv8gbo5jM8vk4A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-expression-evaluator": "^5.2.2"
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/bus-hash-bindings": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-hash-bindings/-/bus-hash-bindings-5.2.2.tgz",
-      "integrity": "sha512-TDKbw50Zcl7550tqWmRVT4rBw5KlM23h0u7y7DY7TvHUw2dXRN8KUH6Nec6mjCcu6smJumWC5/yAzdU2TBHiKQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-hash-bindings/-/bus-hash-bindings-5.2.3.tgz",
+      "integrity": "sha512-dbGrxkKwO8e4qyDjQ8og/ZCJj9sJv3jS7hqmyaGCVU5RSMdXGNTo6mtHW0k1zTvzQ2XT5ZqrroCDzqT6xgQt6A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -4612,12 +4614,12 @@
       }
     },
     "node_modules/@comunica/bus-hash-quads": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-hash-quads/-/bus-hash-quads-5.2.2.tgz",
-      "integrity": "sha512-N9j32G/LqzkVlwuE7r3LFvfTsBkdyiu5UnG3cN3TtbSDtbsAt8Afsy4HTgz4HpucATIzk8ePJV0zIkM0fbNgew==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-hash-quads/-/bus-hash-quads-5.2.3.tgz",
+      "integrity": "sha512-qCKphc2ZqPbFtKrBO6rftq3M9wJhFhQLSCHS4RDQAYy03NT2Te01MyxJK9RjxQx/xtYsy5DPPLH/dYPrOAAFCQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2",
+        "@comunica/core": "^5.2.3",
         "rdf-data-factory": "^2.0.0"
       },
       "funding": {
@@ -4639,13 +4641,13 @@
       }
     },
     "node_modules/@comunica/bus-http": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-5.2.2.tgz",
-      "integrity": "sha512-/zpiacwXl7wXbN/fkx5HI5PJG8pJ4/WCz9cBTO60WQPpR6I9jZa8HbWLH2G2VuKM6ep55JEvw4lCBJqn9YaLBg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-5.2.3.tgz",
+      "integrity": "sha512-1xQVWj0UEScLYc2ah0LiiLdNPEG8yjcyuHl3kyDy+TLjifhNMoMjhv2vFRdB28s8B6Y05K6Zz6Jl7tnoWxNMwQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@jeswr/stream-to-string": "^2.0.0",
         "is-stream": "^2.0.1",
         "readable-from-web": "^1.0.0",
@@ -4657,12 +4659,12 @@
       }
     },
     "node_modules/@comunica/bus-http-invalidate": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-5.2.2.tgz",
-      "integrity": "sha512-Tyh7OdHtb0kOt79uuSYt2FpjVMH7kYLj+5LAJwhjXjjgCyszgrt0PTE315Ajzw3cNEMUpzcfsTXlKGsikzQ2DQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-5.2.3.tgz",
+      "integrity": "sha512-i14H83kyZ+ryDsqKizF8wE6RgqJDbo6/VK18wR3AI9WQ/RcZ7C/TQfn03DTp2z/ehHf6BfO/mlTv6WsOOYOw9A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2"
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -4670,12 +4672,12 @@
       }
     },
     "node_modules/@comunica/bus-init": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-5.2.2.tgz",
-      "integrity": "sha512-74UAn/BdoPaL8Z6you2d3TxuF+NYgkggT26+xUNpEX5eWJATZFfUMR3PYPyVlnHMvIFBwpH3Km6QJCgZBiO1XQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-5.2.3.tgz",
+      "integrity": "sha512-I2eP9JiK5WVv5vUY9QbHAbXD7NRTBP66CkW8MJ5KKswNPdsFBPJaeXW/ekcEKEm4aUsj/80zIO/eE4M0vzo2KA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2",
+        "@comunica/core": "^5.2.3",
         "readable-stream": "^4.7.0"
       },
       "funding": {
@@ -4684,13 +4686,13 @@
       }
     },
     "node_modules/@comunica/bus-merge-bindings-context": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-merge-bindings-context/-/bus-merge-bindings-context-5.2.2.tgz",
-      "integrity": "sha512-GrLE7nqUTIM48oN5tA/S05YcU3HrqTobFGp1Ky7Kzw/Soboh4/QwpHQu3anJF7+HBu9EHaqOzmEIwmFpuzTSTg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-merge-bindings-context/-/bus-merge-bindings-context-5.2.3.tgz",
+      "integrity": "sha512-X9H6amot0QX3a4X+T0B7urCvtPmNE5vkqVNKx5AJU+j0N1UhbZuaNBhn8pJ7n1bmAGKowBc+bAX1pOQNXWF3EQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0"
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -4698,13 +4700,13 @@
       }
     },
     "node_modules/@comunica/bus-optimize-query-operation": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-5.2.2.tgz",
-      "integrity": "sha512-087qDqqZPIHc1deIhUU+Xbr1PuWAVvWBx7IfDA104OWU0Bl480RnC58jGEk53HeNBB9UXFy3p2J0Ihon/7QhpQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-5.2.3.tgz",
+      "integrity": "sha512-hl8zVCgEO0yn+fyXdM9ZrQrl4PuiBzGgNH5Vda8/iIzSScOIQzTLIEUFFZv5nr4oiTSOLxyL1ZHFQ49Ij269Zw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
@@ -4713,16 +4715,16 @@
       }
     },
     "node_modules/@comunica/bus-query-operation": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-5.2.2.tgz",
-      "integrity": "sha512-mZ2kguKu+m/Xy7l/mG85T0qlyt+ZWQ90+YLMuwUE3hckxauILQUdnNsXwdGogOLMCma0ASPJjkl1bU/9/x+Gqg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-5.2.3.tgz",
+      "integrity": "sha512-B5vh4Nz699vxh04hYmlpelKDSQ0UATcsSGwFYbccVsQBIulBAdET1y8ODFPZachZyTdPXj8ehyHyYhYY+MzrNw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-metadata": "^5.2.0",
+        "@comunica/utils-metadata": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -4731,12 +4733,12 @@
       }
     },
     "node_modules/@comunica/bus-query-parse": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-parse/-/bus-query-parse-5.2.2.tgz",
-      "integrity": "sha512-szelTpU0t/hgdID6TwFIRp2zS9OAea7YDMbHh9b6mYP8p5ZAgoFZfHFbXSwnuySI34mJbeBLd8o3h/h7CJ5jOw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-parse/-/bus-query-parse-5.2.3.tgz",
+      "integrity": "sha512-zC45bBWFhuJ+PLZwx1n131MOKnZChl4o/GPQkK4xyUQL6AslGKA9xdJRxsHosxUB/NFClv1DcWGWPgB0nt5uZg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2",
+        "@comunica/core": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
         "@rdfjs/types": "*"
       },
@@ -4746,13 +4748,13 @@
       }
     },
     "node_modules/@comunica/bus-query-process": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-process/-/bus-query-process-5.2.2.tgz",
-      "integrity": "sha512-TvfYfAZK4R5vVqcWKY7WPzlw1FF1dGdQw3ZVGYbJ02KR6mSmSMeYNq1ZrzE1KAFAPC6iAKirCfd44Upy4OE1Rg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-process/-/bus-query-process-5.2.3.tgz",
+      "integrity": "sha512-qI2MplEOz3tYhRU9yY6iQUBaXTLVpLPX4OaEuUVGmPaAE7o9QIrgRSyMaCd/+jnka9pVElqVVN03mmr0AK/uiw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
@@ -4761,14 +4763,14 @@
       }
     },
     "node_modules/@comunica/bus-query-result-serialize": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-result-serialize/-/bus-query-result-serialize-5.2.2.tgz",
-      "integrity": "sha512-uql0VBVLrwvhtqmW03m6D7+6jpOZlSGeJi0pF2bX/qnYRWJOhRncvjUHdyu62yzWDEiheBzasc30lq8YLJ2UZw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-result-serialize/-/bus-query-result-serialize-5.2.3.tgz",
+      "integrity": "sha512-xNoRjHgf9rqWDJKWMKjNOfntfDwlhUCcbAiwC7CObkrF13vKga5W5NjeNVHVCQxTofk7Pqp0YzagJgNlisNkzw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0"
+        "@comunica/actor-abstract-mediatyped": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -4805,17 +4807,17 @@
       }
     },
     "node_modules/@comunica/bus-query-source-identify": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-source-identify/-/bus-query-source-identify-5.2.2.tgz",
-      "integrity": "sha512-UDzBiWS4eMeluSSdeJWaOU4Hku8HAfYDUrIqrTsQbsPTC0CRKM2QnG/Az3cES97ptYNWjz+Aiom3TUJOgf39sQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-source-identify/-/bus-query-source-identify-5.2.3.tgz",
+      "integrity": "sha512-S8sr2nFLzPbT7I4XhjJpBlW/jMDuvM4t3uuya8bUo2+bSgSJE3obDdpMNtK3mj0BD05IQZyP0DINzuG8VNFdww==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-bindings-factory": "^5.2.2",
+        "@comunica/utils-bindings-factory": "^5.2.3",
         "@comunica/utils-iterator": "^5.0.0",
-        "@comunica/utils-metadata": "^5.2.0",
+        "@comunica/utils-metadata": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "rdf-string": "^2.0.1",
@@ -4842,19 +4844,19 @@
       }
     },
     "node_modules/@comunica/bus-rdf-join": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-5.2.2.tgz",
-      "integrity": "sha512-Iyv4uTvQc3wG7LySi4rjGYWJ6pz62CJ1hpDEkb6VwuhLgUQ10b5Upp7Ia0HmnznMEU6boPt0H/1dt7CyDJHUQw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-5.2.3.tgz",
+      "integrity": "sha512-SG7A+4mGCaLJrudnaZBGiWXUxTIcA9SJSUXHm72S5RScOOW/LWd7XbXNcJEOqtjU1ySARLPacN4f8TXa7PUieg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join-entries-sort": "^5.2.2",
-        "@comunica/bus-rdf-join-selectivity": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/mediatortype-join-coefficients": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-rdf-join-entries-sort": "^5.2.3",
+        "@comunica/bus-rdf-join-selectivity": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-iterator": "^5.0.0",
-        "@comunica/utils-metadata": "^5.2.0",
+        "@comunica/utils-metadata": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -4863,13 +4865,13 @@
       }
     },
     "node_modules/@comunica/bus-rdf-join-entries-sort": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-5.2.2.tgz",
-      "integrity": "sha512-92hHOAfBcnHy8HbeJwyqzl8g8lEsRiE8nCTlb0rU7B2Av33Up3YiR2pejqg0fX3YPKJDHaQ5Nwudj5ubd56PQg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-5.2.3.tgz",
+      "integrity": "sha512-0yso5PT72CG1i6UJhF8d1bpCbrDunon7eFx/oNzniiDUDsfZSxFT7wXeXl0r8L0aHmsTRwLx+24BCrDNzTZv6A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0"
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -4877,14 +4879,14 @@
       }
     },
     "node_modules/@comunica/bus-rdf-join-selectivity": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-selectivity/-/bus-rdf-join-selectivity-5.2.2.tgz",
-      "integrity": "sha512-2dvU/uADnUF165BZIECNCi1Byu99QlsicOxl0AvxLWWPtMF9tcA1wUgpCEw/faoSkolQ27StVZB/xYTQehTEhw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-selectivity/-/bus-rdf-join-selectivity-5.2.3.tgz",
+      "integrity": "sha512-na18v7Y6YbaxtHpAte1I9my9dzqqDJ37iPJpfsLL/4QXFCJgaux3hklQf51UZQ7JosPb3dOHml+l9dqXT5AVBA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2",
-        "@comunica/mediatortype-accuracy": "^5.2.2",
-        "@comunica/types": "^5.2.0"
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-accuracy": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -4906,13 +4908,13 @@
       }
     },
     "node_modules/@comunica/bus-rdf-metadata-accumulate": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-accumulate/-/bus-rdf-metadata-accumulate-5.2.2.tgz",
-      "integrity": "sha512-LNKFuB3ze98CHNZ5gLrz/WpijzoGharHRzc4wDmgzTa2fP8g0W3q84nSLOGMFB/h9BkTiDSf6n2hQepkyEve5Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-accumulate/-/bus-rdf-metadata-accumulate-5.2.3.tgz",
+      "integrity": "sha512-oQrP8ZpPVOUMitApWibSxWV/t561q/iYr+Q4Xl71HtDasyERyUayBvVxZA/YdtTqoV6anOshCcNH1w+1xkoOGQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0"
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5021,15 +5023,15 @@
       }
     },
     "node_modules/@comunica/bus-rdf-update-quads": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-5.2.2.tgz",
-      "integrity": "sha512-MF052fQaO730+6e7YRGFGD0+avAYYWED1b5I/l0TAoJZm71W1LH9Uvt336RSemWh9JkSrrlcy0hBXJ2sXlluxw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-5.2.3.tgz",
+      "integrity": "sha512-tMc2hibV0r25KAp9Z0l6ZvTzG1uIpwF+dBfrzgd8crURXN15g6xYtFp2iDdUWeCgNAO9np/RTHeUcalLyLNqTg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-optimize-query-operation-query-source-skolemize": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/actor-optimize-query-operation-query-source-skolemize": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0"
       },
@@ -5039,15 +5041,15 @@
       }
     },
     "node_modules/@comunica/bus-term-comparator-factory": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-term-comparator-factory/-/bus-term-comparator-factory-5.2.2.tgz",
-      "integrity": "sha512-e5il+DUg8gpyJ+as9YIfWBYuQFujIM5oqeLgKV0qD+6OciVCGWFIc0+Vit4hg6JgmWzUHB9Dw/geFuF32YXO8g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-term-comparator-factory/-/bus-term-comparator-factory-5.2.3.tgz",
+      "integrity": "sha512-l6WN/oDogrCGLBpZdB3Aq+Fgpauxf0IgajT9B7dJCrknwcoZU3nbO7sEA2V93ADS4Q/ClM/Wtb7qdAecKBHPow==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.2.2",
-        "@comunica/bus-merge-bindings-context": "^5.2.2",
-        "@comunica/bus-query-operation": "^5.2.2",
-        "@comunica/core": "^5.2.2",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "@rdfjs/types": "*"
       }
     },
@@ -5062,13 +5064,13 @@
       }
     },
     "node_modules/@comunica/context-entries": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-5.2.2.tgz",
-      "integrity": "sha512-TFlyNb2IxFiBrfB/aUGcG53AVrFh3BVexLgYKejwye5s2bXlKIlfGV4B7JbWfliNb3m3j/Vw+Exn5q6F74p5sA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-5.2.3.tgz",
+      "integrity": "sha512-HGImR7IN70Dh/3k7PqyLPWsc8AddenrzH3Ns6oFuru6GdzbokdPaoe/G08818u3GAXimrMAKcM22xNPEMrEFsQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
         "@rdfjs/types": "*",
         "jsonld-context-parser": "^2.2.2"
@@ -5079,12 +5081,12 @@
       }
     },
     "node_modules/@comunica/core": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-5.2.2.tgz",
-      "integrity": "sha512-eYfPQiXlWu/WeoQJRCmgrf7SkSJ6x4AKZ+niAgz0N/cFhKQhEsXS+yulmVd2gAURZhaVhAd96/UTMzlb4mD0Ig==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-5.2.3.tgz",
+      "integrity": "sha512-+ZpuwERjRAMRCdkxBJbUHSdHpZAxU3fHGW7tA6JpJbYryneEIU7IFlEDgP/NbfmdD5O5HfO2/0GbThiMMWgOFQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/types": "^5.2.0",
+        "@comunica/types": "^5.2.3",
         "immutable": "^5.1.3"
       },
       "engines": {
@@ -5096,12 +5098,12 @@
       }
     },
     "node_modules/@comunica/logger-pretty": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-5.2.0.tgz",
-      "integrity": "sha512-t0jcru3fOYwrkATQVdalXGgRE2XEY8nc1j0G0ccdYXQfsCIed+i1/hS7QdECO1VaDGrKYRGAyGmuiS5TmD8JZQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-5.2.3.tgz",
+      "integrity": "sha512-MgNZ8MWP9GHsHbA7a9ZZ2tdSnUr/1adbisbZh9UdvvIyXdGP0mdqjhHlDq/KobBfRr9HS7AC662OD8pMl0L2pw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/types": "^5.2.0",
+        "@comunica/types": "^5.2.3",
         "object-inspect": "^1.12.2",
         "process": "^0.11.10"
       },
@@ -5111,12 +5113,12 @@
       }
     },
     "node_modules/@comunica/logger-void": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-5.2.0.tgz",
-      "integrity": "sha512-6rNY4cfCUl1w0MJIJDR5uOsP29RvzKTN+4h4Gk2H82pvgPA6IHfFGSQE/ptIGuhZcatWyXYxMew8sO2RVl8ZQA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-5.2.3.tgz",
+      "integrity": "sha512-lUgcEmvIpmJr9+D3ideshcc+18pcrd8hbajjjcrv0g/0jkSF6ijHkhKVHC3wT24WIQ8K0/BFkN3JHq7kZ8HXHw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/types": "^5.2.0"
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5124,12 +5126,12 @@
       }
     },
     "node_modules/@comunica/mediator-all": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-5.2.2.tgz",
-      "integrity": "sha512-KWMTIqQsgl8pqPGdKT7R95XrttbYFhjcpDd7PMcc6xmafRvtDrZbtKfXVQ0xcnK9q6QSY62TV1Wu9tgahwMFDA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-5.2.3.tgz",
+      "integrity": "sha512-VA+IytwflTunuPs1x9i3BRTUyrIP4iXOPlY4h2ZpsQmoLa07QAcs7tEIpLBY3owkyEbcdEAZPF9qqBYjChZ7dg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2"
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5137,13 +5139,13 @@
       }
     },
     "node_modules/@comunica/mediator-combine-pipeline": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-5.2.2.tgz",
-      "integrity": "sha512-It928JNPnuAdh6ax+lGdbcD2LYwu4QCq/YrB6CrAtsmbf248rcdmn4UiuP3TXwHhlUNZPGIFw7S0DOXesQtGzg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-5.2.3.tgz",
+      "integrity": "sha512-Tu5fkk1wO9mqYhLo8P8gqw6ZM+QlrG5YcemSNNxpyOWYBaZUzllppa3c01B4TczAcNteg1sIavf4DF3w7wo4fg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0"
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5151,12 +5153,12 @@
       }
     },
     "node_modules/@comunica/mediator-combine-union": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-5.2.2.tgz",
-      "integrity": "sha512-c9uoOoi5Krs0W9WnU9UAqZnu60vO1pg7Ucl86rOtR86LeZa8NBGFTMQPtJOLMeWgC7HMKpAjNdRuWc0um5fdug==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-5.2.3.tgz",
+      "integrity": "sha512-KeTyRBT9ZLn151eV1UQgDruYoXWKl1jr28q/Rfo9+M6xHXU93ySQCjv9Y0ckaDPKTXNQVo2Q95tI49R3XD+vww==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2"
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5164,16 +5166,16 @@
       }
     },
     "node_modules/@comunica/mediator-join-coefficients-fixed": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-join-coefficients-fixed/-/mediator-join-coefficients-fixed-5.2.2.tgz",
-      "integrity": "sha512-unw9upT5MOgdEk9a7G/EzWTTODlH7KLNsGFWu0IGfNCvH3DEHg/SXnMEq9uqgr2HQYGqa/1LKKBYflMKes6e9w==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-join-coefficients-fixed/-/mediator-join-coefficients-fixed-5.2.3.tgz",
+      "integrity": "sha512-JsUJRkLGaqqnCjDV0F4AV3VMuEC6bsbwCaI3kGIr4UnBlnFu7lzwZcl6VwGivTGizRcMQ6cBeKJcGb3VK5AE6g==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join": "^5.2.2",
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/mediatortype-join-coefficients": "^5.2.2",
-        "@comunica/types": "^5.2.0"
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5181,12 +5183,12 @@
       }
     },
     "node_modules/@comunica/mediator-number": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-5.2.2.tgz",
-      "integrity": "sha512-8WmWJCyC7zI4DKjitLwNBzG3IBXVpFuXalrJRDfCx9LV7AyhvNEW6ZVDOjj7u72CcSRlm+pgR3XR/OUhOD396g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-5.2.3.tgz",
+      "integrity": "sha512-QgMjmHdsOFPepgFOa6pX5pbGgYrxGPTRZ5cy0Az0eNxit034a4lUKdCH4+ShFID3kUXrLZ6FdjUbHxdDNTh7Ww==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2"
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5194,12 +5196,12 @@
       }
     },
     "node_modules/@comunica/mediator-race": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-5.2.2.tgz",
-      "integrity": "sha512-kw8ic1goBQr53tfTuC+yaqTGN/vHJ8DmeHBWjZOI7ovCbd66MnaKDhCwOAkZXWUPwxnNkESEZStuDLDk5IatiA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-5.2.3.tgz",
+      "integrity": "sha512-lN6OO7eG5n/pivpXriK4P6g0G25Gzg3lz2eCI9n7m52g7SqcOYFwY8r68sAxLGuT1KM1KXLJwm1ie2ymp6VWCQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2"
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5207,12 +5209,12 @@
       }
     },
     "node_modules/@comunica/mediatortype-accuracy": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-accuracy/-/mediatortype-accuracy-5.2.2.tgz",
-      "integrity": "sha512-7+qw8IGj6eE80r+H0RojssOpmS+okVGqXlsEW59zPJxUIgD9hXh4LN/hpKZrVac+y7Po4X1zsPaL3UeLFB2GRg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-accuracy/-/mediatortype-accuracy-5.2.3.tgz",
+      "integrity": "sha512-JWEAvml7xt0d/G8pp4/5iPHVBTnIggItpJ8qDtWjUf3Rdl/IWOYpMgfXo8oGNHrQ6CYevdJ7vSI4Xf3xpF7gAg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2"
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5220,12 +5222,12 @@
       }
     },
     "node_modules/@comunica/mediatortype-join-coefficients": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-join-coefficients/-/mediatortype-join-coefficients-5.2.2.tgz",
-      "integrity": "sha512-JlkZb9Yp4pxq2/Dzdlh8/3IR7sBIjUU77cQ/rIjxGcfNL92DLtpl0jxQD7/tsL/QY70QUf79H5Cx5g9omvHgPA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-join-coefficients/-/mediatortype-join-coefficients-5.2.3.tgz",
+      "integrity": "sha512-FE000HZeHgQ5/WpB39qci2HGUZ6wuoFDGkZjNGCD2hUQU6SuubWyoolxvIjXUqClqCQJVJNu7qW4eaK4MNZhzw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2",
+        "@comunica/core": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -5234,12 +5236,12 @@
       }
     },
     "node_modules/@comunica/mediatortype-time": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-5.2.2.tgz",
-      "integrity": "sha512-IhQhrWygYe66YQlqFSS351+HSw2nw0ksLeVzFTxxsQyUyWW+9obQ4v0JgOt0tPNOCut+Pgr634AMAglevleSbQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-5.2.3.tgz",
+      "integrity": "sha512-LPZjj/s/9R4jGDj8U5c8txyxfFTqqVeQ0ociQPRVtQSK0qUHJGsUHYqTUQqu2e9MCW6qFIlSInZ6a/7IOQmUEQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.2.2"
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5751,3611 +5753,220 @@
       }
     },
     "node_modules/@comunica/query-sparql-rdfjs-lite": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/query-sparql-rdfjs-lite/-/query-sparql-rdfjs-lite-4.5.0.tgz",
-      "integrity": "sha512-HBgvhn++QwBb7Q/ImzjjP6esCI126Zux7V4SGEGE+sJfxZrtSX57TIxupP0At9SWYMDg2aDqHJC/b5pDGQOHXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-bindings-aggregator-factory-average": "^4.5.0",
-        "@comunica/actor-bindings-aggregator-factory-count": "^4.5.0",
-        "@comunica/actor-bindings-aggregator-factory-group-concat": "^4.5.0",
-        "@comunica/actor-bindings-aggregator-factory-max": "^4.5.0",
-        "@comunica/actor-bindings-aggregator-factory-min": "^4.5.0",
-        "@comunica/actor-bindings-aggregator-factory-sample": "^4.5.0",
-        "@comunica/actor-bindings-aggregator-factory-sum": "^4.5.0",
-        "@comunica/actor-bindings-aggregator-factory-wildcard-count": "^4.5.0",
-        "@comunica/actor-context-preprocess-convert-shortcuts": "^4.5.0",
-        "@comunica/actor-context-preprocess-query-source-identify": "^4.5.0",
-        "@comunica/actor-context-preprocess-query-source-skolemize": "^4.5.0",
-        "@comunica/actor-context-preprocess-set-defaults": "^4.5.0",
-        "@comunica/actor-context-preprocess-source-to-destination": "^4.5.0",
-        "@comunica/actor-expression-evaluator-factory-default": "^4.5.0",
-        "@comunica/actor-function-factory-expression-bnode": "^4.5.0",
-        "@comunica/actor-function-factory-expression-bound": "^4.5.0",
-        "@comunica/actor-function-factory-expression-coalesce": "^4.5.0",
-        "@comunica/actor-function-factory-expression-concat": "^4.5.0",
-        "@comunica/actor-function-factory-expression-extensions": "^4.5.0",
-        "@comunica/actor-function-factory-expression-if": "^4.5.0",
-        "@comunica/actor-function-factory-expression-in": "^4.5.0",
-        "@comunica/actor-function-factory-expression-logical-and": "^4.5.0",
-        "@comunica/actor-function-factory-expression-logical-or": "^4.5.0",
-        "@comunica/actor-function-factory-expression-not-in": "^4.5.0",
-        "@comunica/actor-function-factory-expression-same-term": "^4.5.0",
-        "@comunica/actor-function-factory-term-abs": "^4.5.0",
-        "@comunica/actor-function-factory-term-addition": "^4.5.0",
-        "@comunica/actor-function-factory-term-ceil": "^4.5.0",
-        "@comunica/actor-function-factory-term-contains": "^4.5.0",
-        "@comunica/actor-function-factory-term-datatype": "^4.5.0",
-        "@comunica/actor-function-factory-term-day": "^4.5.0",
-        "@comunica/actor-function-factory-term-division": "^4.5.0",
-        "@comunica/actor-function-factory-term-encode-for-uri": "^4.5.0",
-        "@comunica/actor-function-factory-term-equality": "^4.5.0",
-        "@comunica/actor-function-factory-term-floor": "^4.5.0",
-        "@comunica/actor-function-factory-term-greater-than": "^4.5.0",
-        "@comunica/actor-function-factory-term-greater-than-equal": "^4.5.0",
-        "@comunica/actor-function-factory-term-hours": "^4.5.0",
-        "@comunica/actor-function-factory-term-inequality": "^4.5.0",
-        "@comunica/actor-function-factory-term-iri": "^4.5.0",
-        "@comunica/actor-function-factory-term-is-blank": "^4.5.0",
-        "@comunica/actor-function-factory-term-is-iri": "^4.5.0",
-        "@comunica/actor-function-factory-term-is-literal": "^4.5.0",
-        "@comunica/actor-function-factory-term-is-numeric": "^4.5.0",
-        "@comunica/actor-function-factory-term-is-triple": "^4.5.0",
-        "@comunica/actor-function-factory-term-lang": "^4.5.0",
-        "@comunica/actor-function-factory-term-langmatches": "^4.5.0",
-        "@comunica/actor-function-factory-term-lcase": "^4.5.0",
-        "@comunica/actor-function-factory-term-lesser-than": "^4.5.0",
-        "@comunica/actor-function-factory-term-lesser-than-equal": "^4.5.0",
-        "@comunica/actor-function-factory-term-md5": "^4.5.0",
-        "@comunica/actor-function-factory-term-minutes": "^4.5.0",
-        "@comunica/actor-function-factory-term-month": "^4.5.0",
-        "@comunica/actor-function-factory-term-multiplication": "^4.5.0",
-        "@comunica/actor-function-factory-term-not": "^4.5.0",
-        "@comunica/actor-function-factory-term-now": "^4.5.0",
-        "@comunica/actor-function-factory-term-object": "^4.5.0",
-        "@comunica/actor-function-factory-term-predicate": "^4.5.0",
-        "@comunica/actor-function-factory-term-rand": "^4.5.0",
-        "@comunica/actor-function-factory-term-regex": "^4.5.0",
-        "@comunica/actor-function-factory-term-replace": "^4.5.0",
-        "@comunica/actor-function-factory-term-round": "^4.5.0",
-        "@comunica/actor-function-factory-term-seconds": "^4.5.0",
-        "@comunica/actor-function-factory-term-sha1": "^4.5.0",
-        "@comunica/actor-function-factory-term-sha256": "^4.5.0",
-        "@comunica/actor-function-factory-term-sha384": "^4.5.0",
-        "@comunica/actor-function-factory-term-sha512": "^4.5.0",
-        "@comunica/actor-function-factory-term-str": "^4.5.0",
-        "@comunica/actor-function-factory-term-str-after": "^4.5.0",
-        "@comunica/actor-function-factory-term-str-before": "^4.5.0",
-        "@comunica/actor-function-factory-term-str-dt": "^4.5.0",
-        "@comunica/actor-function-factory-term-str-ends": "^4.5.0",
-        "@comunica/actor-function-factory-term-str-lang": "^4.5.0",
-        "@comunica/actor-function-factory-term-str-len": "^4.5.0",
-        "@comunica/actor-function-factory-term-str-starts": "^4.5.0",
-        "@comunica/actor-function-factory-term-str-uuid": "^4.5.0",
-        "@comunica/actor-function-factory-term-sub-str": "^4.5.0",
-        "@comunica/actor-function-factory-term-subject": "^4.5.0",
-        "@comunica/actor-function-factory-term-subtraction": "^4.5.0",
-        "@comunica/actor-function-factory-term-timezone": "^4.5.0",
-        "@comunica/actor-function-factory-term-triple": "^4.5.0",
-        "@comunica/actor-function-factory-term-tz": "^4.5.0",
-        "@comunica/actor-function-factory-term-ucase": "^4.5.0",
-        "@comunica/actor-function-factory-term-unary-minus": "^4.5.0",
-        "@comunica/actor-function-factory-term-unary-plus": "^4.5.0",
-        "@comunica/actor-function-factory-term-uuid": "^4.5.0",
-        "@comunica/actor-function-factory-term-xsd-to-boolean": "^4.5.0",
-        "@comunica/actor-function-factory-term-xsd-to-date": "^4.5.0",
-        "@comunica/actor-function-factory-term-xsd-to-datetime": "^4.5.0",
-        "@comunica/actor-function-factory-term-xsd-to-day-time-duration": "^4.5.0",
-        "@comunica/actor-function-factory-term-xsd-to-decimal": "^4.5.0",
-        "@comunica/actor-function-factory-term-xsd-to-double": "^4.5.0",
-        "@comunica/actor-function-factory-term-xsd-to-duration": "^4.5.0",
-        "@comunica/actor-function-factory-term-xsd-to-float": "^4.5.0",
-        "@comunica/actor-function-factory-term-xsd-to-integer": "^4.5.0",
-        "@comunica/actor-function-factory-term-xsd-to-string": "^4.5.0",
-        "@comunica/actor-function-factory-term-xsd-to-time": "^4.5.0",
-        "@comunica/actor-function-factory-term-xsd-to-year-month-duration": "^4.5.0",
-        "@comunica/actor-function-factory-term-year": "^4.5.0",
-        "@comunica/actor-hash-bindings-murmur": "^4.5.0",
-        "@comunica/actor-hash-quads-murmur": "^4.5.0",
-        "@comunica/actor-init-query": "^4.5.0",
-        "@comunica/actor-optimize-query-operation-assign-sources-exhaustive": "^4.5.0",
-        "@comunica/actor-optimize-query-operation-bgp-to-join": "^4.5.0",
-        "@comunica/actor-optimize-query-operation-construct-distinct": "^4.5.0",
-        "@comunica/actor-optimize-query-operation-describe-to-constructs-subject": "^4.5.0",
-        "@comunica/actor-optimize-query-operation-filter-pushdown": "^4.5.0",
-        "@comunica/actor-optimize-query-operation-group-sources": "^4.5.0",
-        "@comunica/actor-optimize-query-operation-join-bgp": "^4.5.0",
-        "@comunica/actor-optimize-query-operation-join-connected": "^4.5.0",
-        "@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown": "^4.5.0",
-        "@comunica/actor-optimize-query-operation-prune-empty-source-operations": "^4.5.0",
-        "@comunica/actor-optimize-query-operation-rewrite-add": "^4.5.0",
-        "@comunica/actor-optimize-query-operation-rewrite-copy": "^4.5.0",
-        "@comunica/actor-optimize-query-operation-rewrite-move": "^4.5.0",
-        "@comunica/actor-query-operation-ask": "^4.5.0",
-        "@comunica/actor-query-operation-bgp-join": "^4.5.0",
-        "@comunica/actor-query-operation-construct": "^4.5.0",
-        "@comunica/actor-query-operation-distinct-identity": "^4.5.0",
-        "@comunica/actor-query-operation-extend": "^4.5.0",
-        "@comunica/actor-query-operation-filter": "^4.5.0",
-        "@comunica/actor-query-operation-from-quad": "^4.5.0",
-        "@comunica/actor-query-operation-group": "^4.5.0",
-        "@comunica/actor-query-operation-join": "^4.5.0",
-        "@comunica/actor-query-operation-leftjoin": "^4.5.0",
-        "@comunica/actor-query-operation-minus": "^4.5.0",
-        "@comunica/actor-query-operation-nop": "^4.5.0",
-        "@comunica/actor-query-operation-orderby": "^4.5.0",
-        "@comunica/actor-query-operation-path-alt": "^4.5.0",
-        "@comunica/actor-query-operation-path-inv": "^4.5.0",
-        "@comunica/actor-query-operation-path-link": "^4.5.0",
-        "@comunica/actor-query-operation-path-nps": "^4.5.0",
-        "@comunica/actor-query-operation-path-one-or-more": "^4.5.0",
-        "@comunica/actor-query-operation-path-seq": "^4.5.0",
-        "@comunica/actor-query-operation-path-zero-or-more": "^4.5.0",
-        "@comunica/actor-query-operation-path-zero-or-one": "^4.5.0",
-        "@comunica/actor-query-operation-project": "^4.5.0",
-        "@comunica/actor-query-operation-reduced-hash": "^4.5.0",
-        "@comunica/actor-query-operation-service": "^4.5.0",
-        "@comunica/actor-query-operation-slice": "^4.5.0",
-        "@comunica/actor-query-operation-source": "^4.5.0",
-        "@comunica/actor-query-operation-union": "^4.5.0",
-        "@comunica/actor-query-operation-update-clear": "^4.5.0",
-        "@comunica/actor-query-operation-update-compositeupdate": "^4.5.0",
-        "@comunica/actor-query-operation-update-create": "^4.5.0",
-        "@comunica/actor-query-operation-update-deleteinsert": "^4.5.0",
-        "@comunica/actor-query-operation-update-drop": "^4.5.0",
-        "@comunica/actor-query-operation-update-load": "^4.5.0",
-        "@comunica/actor-query-operation-values": "^4.5.0",
-        "@comunica/actor-query-parse-sparql": "^4.5.0",
-        "@comunica/actor-query-process-sequential": "^4.5.0",
-        "@comunica/actor-query-source-identify-rdfjs": "^4.5.0",
-        "@comunica/actor-rdf-join-entries-sort-cardinality": "^4.5.0",
-        "@comunica/actor-rdf-join-inner-hash": "^4.5.0",
-        "@comunica/actor-rdf-join-inner-multi-bind": "^4.5.0",
-        "@comunica/actor-rdf-join-inner-multi-bind-source": "^4.5.0",
-        "@comunica/actor-rdf-join-inner-multi-empty": "^4.5.0",
-        "@comunica/actor-rdf-join-inner-multi-smallest": "^4.5.0",
-        "@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings": "^4.5.0",
-        "@comunica/actor-rdf-join-inner-nestedloop": "^4.5.0",
-        "@comunica/actor-rdf-join-inner-none": "^4.5.0",
-        "@comunica/actor-rdf-join-inner-single": "^4.5.0",
-        "@comunica/actor-rdf-join-inner-symmetrichash": "^4.5.0",
-        "@comunica/actor-rdf-join-minus-hash": "^4.5.0",
-        "@comunica/actor-rdf-join-optional-bind": "^4.5.0",
-        "@comunica/actor-rdf-join-optional-hash": "^4.5.0",
-        "@comunica/actor-rdf-join-optional-nestedloop": "^4.5.0",
-        "@comunica/actor-rdf-join-selectivity-variable-counting": "^4.5.0",
-        "@comunica/actor-rdf-metadata-accumulate-cardinality": "^4.5.0",
-        "@comunica/actor-rdf-metadata-accumulate-pagesize": "^4.5.0",
-        "@comunica/actor-rdf-metadata-accumulate-requesttime": "^4.5.0",
-        "@comunica/actor-rdf-update-quads-rdfjs-store": "^4.5.0",
-        "@comunica/actor-term-comparator-factory-expression-evaluator": "^4.5.0",
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/bus-http-invalidate": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/config-query-sparql": "^4.4.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/logger-void": "^4.5.0",
-        "@comunica/mediator-all": "^4.5.0",
-        "@comunica/mediator-combine-pipeline": "^4.5.0",
-        "@comunica/mediator-combine-union": "^4.5.0",
-        "@comunica/mediator-join-coefficients-fixed": "^4.5.0",
-        "@comunica/mediator-number": "^4.5.0",
-        "@comunica/mediator-race": "^4.5.0",
-        "@comunica/runner": "^4.5.0",
-        "@comunica/types": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-abstract-mediatyped": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-4.5.0.tgz",
-      "integrity": "sha512-KbLuhbTcfAQHJeLo3CDDdffCZdfA1qDu15XIdW+7P03UpUp9xMw4p1G0kYtoXwj9KzWguY704TUtpJVBO1GOnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-abstract-path": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-4.5.0.tgz",
-      "integrity": "sha512-oBm9rqCCNErmn570UjhMKa4XSM4NxQ/HtgGw7P0HTR0jx/LBg5ctkmsp0ewSJSx+OVf2fU4S7hodZgsS7jypLw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-bindings-factory": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.9.0",
-        "rdf-string": "^1.6.1",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-abstract-path/node_modules/rdf-string": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
-      "integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-bindings-aggregator-factory-average": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-average/-/actor-bindings-aggregator-factory-average-4.5.0.tgz",
-      "integrity": "sha512-QQIVsCMzi+AvaTDegSZVcc2wjBszFAVayUfNEe/OW6xvXMXKmLiEdA+5q5MSJYcfDIciwR0FR3mTFJx34GgSGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "@rdfjs/types": "*"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-bindings-aggregator-factory-count": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-count/-/actor-bindings-aggregator-factory-count-4.5.0.tgz",
-      "integrity": "sha512-BExT1O1b0oP3DVjArcFPLTjFyycShz3ineh7G4ccZ2D+h1xo3dWbCcCNvnOTBnP6XBRtvpgfHLqz2i9C/Hs8SA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "@rdfjs/types": "*",
-        "sparqlalgebrajs": "^5.0.2"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-bindings-aggregator-factory-group-concat": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-group-concat/-/actor-bindings-aggregator-factory-group-concat-4.5.0.tgz",
-      "integrity": "sha512-Gpm2uLDc7mCiE0xt1KX/bKVRXXGNyclq/jJ3zKx+QPftB4z8IFvsTUzt4WuimBYawU0OvM6CUlr6Y3pdY6k4qA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "@rdfjs/types": "*"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-bindings-aggregator-factory-max": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-max/-/actor-bindings-aggregator-factory-max-4.5.0.tgz",
-      "integrity": "sha512-iJZ/NF8s5UhokHIVOCk4fuu8glWH354Oyg2p/VvtBMAXu3x/U3M5EAofsoIGCjwkqcOrknVqG1VGywHgglIAuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@rdfjs/types": "*"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-bindings-aggregator-factory-min": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-min/-/actor-bindings-aggregator-factory-min-4.5.0.tgz",
-      "integrity": "sha512-dHkJvOrTr8fLpu0d1HLsssZQov0PdKlFgZczl5gZ/gpTvKUnpaMcI7uSi/FWkbEyZFtJH+mw2Vb9BmVuSnmzkg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@rdfjs/types": "*"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-bindings-aggregator-factory-sample": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-sample/-/actor-bindings-aggregator-factory-sample-4.5.0.tgz",
-      "integrity": "sha512-4IK9MjfLX0pzB74XxqmSJJIySjB0xr4nId96DkRYrJVvFz7PGdZL5ovr7WJEHrCaFZONUQCcJJdTIMxcazfY/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@rdfjs/types": "*"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-bindings-aggregator-factory-sum": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-sum/-/actor-bindings-aggregator-factory-sum-4.5.0.tgz",
-      "integrity": "sha512-uw3s58igOuHAFLLXr5mS9nVFfA5V5fWxeyln2o/ggipLyDOVKCtkm0GHtx5oZTBNSdyrN2s7SrATdL9ouLbJMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "@rdfjs/types": "*"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-bindings-aggregator-factory-wildcard-count": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-wildcard-count/-/actor-bindings-aggregator-factory-wildcard-count-4.5.0.tgz",
-      "integrity": "sha512-2D+uykC2LmwmgjQnDaGM5dOJf7CIAetRHUlL29P6WA5J3iWVuRZurIVajexvi7yufk+emajuTGnGuZIeB00SnA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "@rdfjs/types": "*",
-        "rdf-string": "^1.6.3"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-bindings-aggregator-factory-wildcard-count/node_modules/rdf-string": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
-      "integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-context-preprocess-convert-shortcuts": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-convert-shortcuts/-/actor-context-preprocess-convert-shortcuts-4.5.0.tgz",
-      "integrity": "sha512-Uu2buxdBxq/0u6Pr/An4FDdafH1bvDCdImeEBBIVfleeYuUNR4klbXZS0M7YxTpYanpNOw9v/i6nHIfNMgFT7w==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-context-preprocess": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-context-preprocess-set-defaults": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-set-defaults/-/actor-context-preprocess-set-defaults-4.5.0.tgz",
-      "integrity": "sha512-xEm7KPg9G6IcciLbZ2tJ0v6vrluuy/fCZN2wCOYQ1ba6bgxZm/C15kFTwjm4YSsDhtQDADteiQZa+kzkBkuudQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-context-preprocess": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-context-preprocess-source-to-destination": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-4.5.0.tgz",
-      "integrity": "sha512-ndpws/8GzO8CsOuqYS4f4IJ5DXNaCGjp7LXcabeAGobY8F5B3eQ8zWKHjC3jZEaTt89rCiMzkudY2sNWGM0ZbA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-context-preprocess": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-expression-evaluator-factory-default": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-expression-evaluator-factory-default/-/actor-expression-evaluator-factory-default-4.5.0.tgz",
-      "integrity": "sha512-1vXRPmcRBTwowYu9FAjEiHeaQv3m2rzhB2jqh/USoPFm0Zn4oR5Xdclyv3WfuhNJRaJWi2uB6P5ddRzimTuTCg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-expression-evaluator-factory": "^4.5.0",
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-bindings-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "@rdfjs/types": "*",
-        "sparqlalgebrajs": "^5.0.2"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-expression-bnode": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-bnode/-/actor-function-factory-expression-bnode-4.5.0.tgz",
-      "integrity": "sha512-wIj6ertjQBSSiV6Kbk0h6AuxjQe/IUVJGGBuZRu+VvCdGTX+I/rY00/LdUzzbdMFJgamEwK5ML/Bwu2tZUFN3w==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-data-factory": "^4.0.1",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-expression-bound": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-bound/-/actor-function-factory-expression-bound-4.5.0.tgz",
-      "integrity": "sha512-aClq0SWhyhL3G9HRlri0yyyVcb/gCdexXi3HHiWhI9udBK+oAZeOR/lM49i7/twS5ujPHE/CzbL6C0gtosZzvA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-expression-coalesce": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-coalesce/-/actor-function-factory-expression-coalesce-4.5.0.tgz",
-      "integrity": "sha512-xD8oGIsKkzaEvzb7j2HMXzJfRi1onRCaUXRmVVWhf2sWA2YIoQWoG3nHMOAucMseo2FDcY+vYN2pIiSts+C2ng==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-expression-concat": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-concat/-/actor-function-factory-expression-concat-4.5.0.tgz",
-      "integrity": "sha512-zaNB23vpQkr+49MfBr2fnjahVEb0jTzUjOKO1Hxrb8geocB0coHAhQljejghATCRwnnsnWwcCeOvVE0bjCoU6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-expression-extensions": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-extensions/-/actor-function-factory-expression-extensions-4.5.0.tgz",
-      "integrity": "sha512-wCF5jGU/MtTCL3vO0jImgwzthKDqSjJP8D+kK3Y9Sj4j6xumaF+cttj5EoflzK68uvkhhuMLsZY0PKLGkAnvXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "rdf-data-factory": "^1.1.2"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-expression-if": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-if/-/actor-function-factory-expression-if-4.5.0.tgz",
-      "integrity": "sha512-1nE7bXcMVcesnaMABAX7LKKc8PVNeIrg/TJ+LkbZ4LyV4GjUu0zQspuFRFFp/HMfpYOfO1pmhP3Y+kdVkRuFpQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-expression-in": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-in/-/actor-function-factory-expression-in-4.5.0.tgz",
-      "integrity": "sha512-ubIy7q0VmO8f/ffuXWPkhjKSI7+r1toltgGonunb9VJVmNe7IbpMKIdSiw0PtAyeZMavp/f5d7uIjYfgYbCsbw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-expression-logical-and": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-logical-and/-/actor-function-factory-expression-logical-and-4.5.0.tgz",
-      "integrity": "sha512-8Eawz0jPMmP7JFuhtEPwuSBw3hIVpscAuM/RUTOBfsgecjRZTQGMsRJ7LoDgLJVNlevbXoxtzBjL9COjUFBJ1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-expression-logical-or": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-logical-or/-/actor-function-factory-expression-logical-or-4.5.0.tgz",
-      "integrity": "sha512-SMJrSpbmOpP1DaHurnM5qm7oWk+dDNaoQZh+8dDCdxz9shSV7eOO7jhjWKhcuZsW6E94G6JSZFZZJkxtmKMrsg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-expression-not-in": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-not-in/-/actor-function-factory-expression-not-in-4.5.0.tgz",
-      "integrity": "sha512-FIJGyTDCXLkz7OmBCB8ed/cCqK2QSmGtwNn/rFh6q9UBrks7A6BzZAH5H/32q6ndcMJwx+6DYb2aQMPlScgRkg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-expression-same-term": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-same-term/-/actor-function-factory-expression-same-term-4.5.0.tgz",
-      "integrity": "sha512-uJxyZl9FXFFXN1Be90cPBLSJqXSVSYxVZ9j+rR4A1I47dc+TfAS/jWkoBsxLCtox3igm6ZkPzmMB066rHN/K5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-abs": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-abs/-/actor-function-factory-term-abs-4.5.0.tgz",
-      "integrity": "sha512-bqupPX30zWCJ0nirI3XkO9uzIuUSnw4jaWNQpI4rHXGdMLrjUNrokBXIZ4FfSXAaAnQOUb771st/XrNbEDJ+gQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-addition": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-addition/-/actor-function-factory-term-addition-4.5.0.tgz",
-      "integrity": "sha512-pqJIeZFvCas3r4PFy4tGdXFiYR9ds99G87rytAWQkVnoBstOUFKXmc6Oq8dwoKCfAnZdfi/GH++Al8buu2I2Cw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "bignumber.js": "^9.1.2"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-ceil": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-ceil/-/actor-function-factory-term-ceil-4.5.0.tgz",
-      "integrity": "sha512-Gape3scVRZgvY4DKGSFH5PSRB1TgnpcRJRWiGy9abvP1QXye3Ob4NIqEyO4iwPLd6U7zf3nyHYAec+4MgQp0nQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-contains": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-contains/-/actor-function-factory-term-contains-4.5.0.tgz",
-      "integrity": "sha512-qUv31t9RJ+n0OaMcQBLLruTj3u8BdWj69Fq/tF01E8vRkaZgNf0WkAVfkJRRaYQxr4fpMtgWxzSCZ3VSaiXFUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-datatype": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-datatype/-/actor-function-factory-term-datatype-4.5.0.tgz",
-      "integrity": "sha512-mjucrTW+MJoyCOsvxKJUBqawbNsSacVCvkazKscEBdk1Gj/b75xWUEi7cJHCd1cD1ESHn4EA5PEqhYXUyDsxzw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-day": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-day/-/actor-function-factory-term-day-4.5.0.tgz",
-      "integrity": "sha512-B2f3MniYbd7WR7vo8MJzO9jSBIeVOtXotpg9Mxo73Vyhknh7w6td95MpVxPJT8BXFVzFrkAh/OmU9nDcgcdB+Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-division": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-division/-/actor-function-factory-term-division-4.5.0.tgz",
-      "integrity": "sha512-IJ/5INqBDXkxuvESllxYNE7Ted/Y6lRQPDvzu1HDw3T+hj/KtBINEr7zPh9yLuapuTCzapygd+kIGVaoemoSJA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "bignumber.js": "^9.1.2"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-encode-for-uri": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-encode-for-uri/-/actor-function-factory-term-encode-for-uri-4.5.0.tgz",
-      "integrity": "sha512-3/8YNcg2gqG/Hc/0e24jTwepJqfU2mqhUG55kXNy5J3hKOyYza1wbNhBQUAQVFQcdpwKA/bzpb/YHwSov429Qw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-equality": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-equality/-/actor-function-factory-term-equality-4.5.0.tgz",
-      "integrity": "sha512-1q0L42931jvjv1b92nc18B/WAomYYEacg1gFJpUSsfqhGGAulA42+fTR2ngRDT0sQw/J1kT1WgY3fY1rHNADIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-floor": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-floor/-/actor-function-factory-term-floor-4.5.0.tgz",
-      "integrity": "sha512-E4jxcs8M5wLZbPdzlmOuoIAwNtTzu5oVzH3gnZnE9iBE0pfSrN6N6g0sRY7vFXKfMgJQqVMlPiFt+Cda7ZcPHA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-greater-than": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-greater-than/-/actor-function-factory-term-greater-than-4.5.0.tgz",
-      "integrity": "sha512-4WcYnNaXX6d0gXHHChW7QwmG4Ywq7CRihYC4AAkIqP9e9TX+lqz7cXaMMyGICh0uHY4JwAg33i3Pxv54TdwCog==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-greater-than-equal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-greater-than-equal/-/actor-function-factory-term-greater-than-equal-4.5.0.tgz",
-      "integrity": "sha512-vziCkcJNQedtqHC5kxvDMlvkJ+uJzO520q/4QjMMsftxyvDfpbWfX3VKQitJdRlvnAcmdZpWKb8ylltbZ/aT/A==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-hours": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-hours/-/actor-function-factory-term-hours-4.5.0.tgz",
-      "integrity": "sha512-0GkHX9KnU1N+lHzgmGLKndt8QX+8o5Mb5I+QIZWHgm7tkGHIGOQWtN0eBWhiVnzV8MBz471vyAVPHYB/OKsi5w==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-inequality": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-inequality/-/actor-function-factory-term-inequality-4.5.0.tgz",
-      "integrity": "sha512-p89dQB30AZsuFnJhFzGczz72wTIsR3nQzROP8NMwDpyic5xMrKEw1QljK+leWugrhlCprBuMQTpWWAFGe9EVfQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-iri": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-iri/-/actor-function-factory-term-iri-4.5.0.tgz",
-      "integrity": "sha512-LZ3HHdBiWOmNnulKdu+7XhcJQyysRGwtBvIkW6WFnIvQpapeHC/KZO1gD2gevUDo/VJ3l5Rg6bcPY+InVnPDug==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "relative-to-absolute-iri": "^1.0.7"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-is-blank": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-blank/-/actor-function-factory-term-is-blank-4.5.0.tgz",
-      "integrity": "sha512-hUlXgv+gJn7XyZQn9KPpi9R4ss+cFSMWxVvp02ZsmTZ8FKHYYkVP7CyGT1DqkBi17AjLlB4OcotjxY9qu43bTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-is-iri": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-iri/-/actor-function-factory-term-is-iri-4.5.0.tgz",
-      "integrity": "sha512-OzTNf4Lq+80x4M4rhHrptjJTpdu7Icl2Sk+K8B9v1adAPvinHoOEgiT1leRVqExccSstdtyOwBYCCBsJ/fhXtQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-is-literal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-literal/-/actor-function-factory-term-is-literal-4.5.0.tgz",
-      "integrity": "sha512-SagBQvOMHm8BiXLoCM2fhHerDXYlfwgnnWUiVbK3M1y9SDvynItc/Wa/BpDbimS/EMmkJxIGjnVDAEQryX7TMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-is-numeric": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-numeric/-/actor-function-factory-term-is-numeric-4.5.0.tgz",
-      "integrity": "sha512-aqt73wM21ROHUgXsMZKFiJX2johJ7j1SUvnPfdCIIeUYTuxCKSjVR6sXNLH7F+u5kcXGS5hJwaYIvl//u3DqMA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-is-triple": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-triple/-/actor-function-factory-term-is-triple-4.5.0.tgz",
-      "integrity": "sha512-0P9zR8o3/zsMYjmPvzX84dHKkQz2ZP5pjfactN57oo+SE5wCX9sb4w4WwN9DZwFifjqzxX3EMMBQR5dR1A7sBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-lang": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lang/-/actor-function-factory-term-lang-4.5.0.tgz",
-      "integrity": "sha512-sS574SUxEtR8WTfM1U9QavjC6+SCRxbgEM9uKxVe7sTu73bs4a+UGM5xSm4GBRSKMi574xcSGDBRF8lZua44sA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-langmatches": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-langmatches/-/actor-function-factory-term-langmatches-4.5.0.tgz",
-      "integrity": "sha512-VKX0DPiM70rXvtlHGBAiqWtRQbL7X8417+amOr7FV7SicC3vZhlRxQoO8VWMMRPtkJWDVbbzt6DQAMIzVt4JBg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-lcase": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lcase/-/actor-function-factory-term-lcase-4.5.0.tgz",
-      "integrity": "sha512-AY8HhhGG7zJayAvRtxq/O31Yzz23lCf5P4Z2vjesEP1c0+fOFQJ7Dc6UkoxYHLmvXLtWHTEyNAv8khtEBTfEMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-lesser-than": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lesser-than/-/actor-function-factory-term-lesser-than-4.5.0.tgz",
-      "integrity": "sha512-K423u2M02PQxhfbc8O5mUGfYVwFft4IWgIYmIMs2e0KQc8JPHt8ba665ZWoSykkzTyIoR0bffXx83mjwdMa5mw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-lesser-than-equal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lesser-than-equal/-/actor-function-factory-term-lesser-than-equal-4.5.0.tgz",
-      "integrity": "sha512-uFT9J4fVwZN6JcCnZrCkWXWkUddrp6amu9gGJrwkV++7pS/CjsDDAXuxYwQqtn+RsOZrsc6kvEX9vptJqdqRag==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-md5": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-md5/-/actor-function-factory-term-md5-4.5.0.tgz",
-      "integrity": "sha512-gzRiaYDyr1+ecJMGteO8/CSylhvRpgLpKBj4pMh4XOe1REpb9ld7rR8Lm3LzSVczr+DMabbXcPwInF77hf+drQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "@types/spark-md5": "^3.0.1",
-        "spark-md5": "^3.0.1"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-minutes": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-minutes/-/actor-function-factory-term-minutes-4.5.0.tgz",
-      "integrity": "sha512-PJPr11nOfjPu7JiFZPwsAYNDlKP2dVcjPqmyMVYg0phnPS5QMqZqclAKPjZgK/A6ipWyLly5j9+uB1NiPoAaPg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-month": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-month/-/actor-function-factory-term-month-4.5.0.tgz",
-      "integrity": "sha512-6HFV7p5rRSg8ZEKeAMeY2rpvO+MBI1aEnWkkm8Eb0n9Y9MID8RBDEoWjtim94L430xN+fzbVf2lnKEK0gG/k5g==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-multiplication": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-multiplication/-/actor-function-factory-term-multiplication-4.5.0.tgz",
-      "integrity": "sha512-cfSOAl8sKhkuJXRpIgz4Avm9ImjP074D3sjVNkptxoJsk+lMI21tbiaa7Kp6b88RV8xlHSMrzzaViX0SWD/rrA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "bignumber.js": "^9.1.2"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-not": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-not/-/actor-function-factory-term-not-4.5.0.tgz",
-      "integrity": "sha512-W9Ux+wt2UnjHJVxyLIprGNCWiPJEGSxKBvldRZq4Yaf3O3ZsAShAP5wLzp4+jyI8IX4IFcEaERg1Mek5trl52A==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-now": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-now/-/actor-function-factory-term-now-4.5.0.tgz",
-      "integrity": "sha512-bTnQUTg6tNO2orVMVCwMm+qhP61ye91Deabb5HNiDOaE9s5WVNbyyiWxVRmNx0TobPfveiNE4yRuYpHJNbMRgg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-object": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-object/-/actor-function-factory-term-object-4.5.0.tgz",
-      "integrity": "sha512-AkFP8DgitOm94NygOc63Ow10kfU8HgcV0ndUOjwkanBXDsoErwd/cZTu5FSEYUP4XedV+RC7qVKp40m51ENggw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-predicate": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-predicate/-/actor-function-factory-term-predicate-4.5.0.tgz",
-      "integrity": "sha512-ceMRBdVHXwWkwZXhE8LgnzacHy6gnzLp95JW1nnEf9Q+/ADE8tpx5OGE+W1tFrCAJbvfkVCRldz6qOXNCqhTEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-rand": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-rand/-/actor-function-factory-term-rand-4.5.0.tgz",
-      "integrity": "sha512-5ORuC18AVkWtvWYjbFpFtB9Noxcw+rg9EI8KVYmN9oE4zW2s/SV8lz4Ybu4tWU9/IvQmyRSv1gr4MZ1OS+DMxg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-regex": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-regex/-/actor-function-factory-term-regex-4.5.0.tgz",
-      "integrity": "sha512-HpUlfaDfOJ4PmaJGr4gUE2cpbFG31wcq9E0DNlDi6OlmMyTv1dYBOA0chiC/3bPUJ4JYADpgePu7kruNtEhgwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-replace": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-replace/-/actor-function-factory-term-replace-4.5.0.tgz",
-      "integrity": "sha512-eK/u8+MUB9miUlbH3ZpzQrLFdiXEZSLszOioumGyMSJSbBlASJs1CekKQ90Ed6o3X1vZ/hVlEW0gJNzW/1TkbA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-function-factory-term-regex": "^4.5.0",
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-round": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-round/-/actor-function-factory-term-round-4.5.0.tgz",
-      "integrity": "sha512-6VWjonN/WZiBpxSOKI4NVvOs0H/O4+zTuhv4JtWwHjyKLkT/nhbNi0UtU/bnMKEsuFH0tSdNMJxfbOXaFzqgMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-seconds": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-seconds/-/actor-function-factory-term-seconds-4.5.0.tgz",
-      "integrity": "sha512-kR1W9A3rZCnpgE75itDFVuZxejBKVOOxX0j1rVP96/Y1Fmsovm9sPo4pbTFTMTROuesICAWux7TP1N5avBWFaw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-sha1": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha1/-/actor-function-factory-term-sha1-4.5.0.tgz",
-      "integrity": "sha512-ydGrQVq46uCHAWYUpA2cKGtYvITxl5MsWlqRnxlfnDHgZZI2SCP+ck+im6xBEvIHpMX9PnOQBWoEe1qAJ5NW8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "hash.js": "^1.1.7"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-sha256": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha256/-/actor-function-factory-term-sha256-4.5.0.tgz",
-      "integrity": "sha512-1fOo26Gc5oBEEJypbashF2KolrQfV7Z8OS6d1/sNA8NA05u1R49OWza3p3w91PAIOToGI5QiiIIgCn1bzpUwmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "hash.js": "^1.1.7"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-sha384": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha384/-/actor-function-factory-term-sha384-4.5.0.tgz",
-      "integrity": "sha512-2n9XIEU3ZjqWOeJHqzMziJdLouz57BXyGKUV44buOM/m9zZjkuO0oP+VI44YxcltUvxzwZnkZE9HpUDz3IgdBw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "hash.js": "^1.1.7"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-sha512": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha512/-/actor-function-factory-term-sha512-4.5.0.tgz",
-      "integrity": "sha512-60pOulMI8QmW2KWNfOcfC3LdeqG9RnqMMBV/UGbdDSvQpTWQDxfeGj/qujCTNQz604+NCe9FGn2lz06YIFY2aw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "hash.js": "^1.1.7"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-str": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str/-/actor-function-factory-term-str-4.5.0.tgz",
-      "integrity": "sha512-E1vrSf+tIL2GX09+ohqY9rjLidFmN33UnarWWOxxkLJCNt6biKBHR/D2eA8r4yADVSn5Ir6DBplns+xZcPE0jw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-str-after": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-after/-/actor-function-factory-term-str-after-4.5.0.tgz",
-      "integrity": "sha512-JnrkLjqr31cF3Cw/ojAcnw0MZrZsLFZR7P6wlWo39DOIYPAvP2ztzaJZYlIeYIJn4+BIqiA5wrOBGGrDhLnwzw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-str-before": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-before/-/actor-function-factory-term-str-before-4.5.0.tgz",
-      "integrity": "sha512-Usdx/eZBwzMqVz9EFNFivQDL5s+fS6GkQ6aDL7RunGI0eRaLKYpk2lhCULuauQVgdpg3BniMVW6gnwAqgcoJZg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-str-dt": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-dt/-/actor-function-factory-term-str-dt-4.5.0.tgz",
-      "integrity": "sha512-X+hIJ3RgtEnfvYsxVqk1KDanGI6wN/1Y7HVM7TU+ErtXq1zLLA7V44F0kL4l8eH94BHnXONUL2IvBjTcNx3ocA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-str-ends": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-ends/-/actor-function-factory-term-str-ends-4.5.0.tgz",
-      "integrity": "sha512-yH54gsUdIXEEgLL1Q0TF8GXM2l27//TipImXk825yBzpSF+MvS4QlrRQ9lAfJjUFeHrUvqLYrC8mLCtnsbHhdA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-str-lang": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-lang/-/actor-function-factory-term-str-lang-4.5.0.tgz",
-      "integrity": "sha512-uupsgyA4NjzO7wYsswfuoSVEqtFJreRk02zjggcISUi7TXfDBKiqyzDELNveiSVK7gDUk4vzbbFuVnT35/fJPw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-str-len": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-len/-/actor-function-factory-term-str-len-4.5.0.tgz",
-      "integrity": "sha512-2sr025H9rj7hJIO0evfNYj2Fm6KuaC4PSi2hfIy/DGd7uaWPvf+5d+axfsL/gk48SZPjcGyOgum6tjbm+/iS1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-str-starts": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-starts/-/actor-function-factory-term-str-starts-4.5.0.tgz",
-      "integrity": "sha512-Qw4jUMM5SQDcdtTip809CLN2LU9nOlK5QsyN2mG7HTHwf4QjnxDXozq2C4fTbUzgYGMTROgQO/wbTPhzMKdgeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-str-uuid": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-uuid/-/actor-function-factory-term-str-uuid-4.5.0.tgz",
-      "integrity": "sha512-Yj5bsRkQ4omf85L8bMqjRgIa2sd+KVBvMvD04zAie5KcbnH8zMSBG62o4MCteQz5jDGZsyYmX9JeUXhmHA9UZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "@types/uuid": "^10.0.0",
-        "uuid": "^11.0.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-sub-str": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sub-str/-/actor-function-factory-term-sub-str-4.5.0.tgz",
-      "integrity": "sha512-br0Ihpcpi3D71rWOTC4BvLiIMJT2Qtt8wZEJGNEfFsLV9DfQIO3YhpFuMyPxGZoW5vkWuFVXzmqcK0JuwjLXgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-subject": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-subject/-/actor-function-factory-term-subject-4.5.0.tgz",
-      "integrity": "sha512-9C7qD7BZ9jj+S//aXGvYqNfA/HCPBAPzWz7bBe+eONLnLE/7GjlNj9wspG51gh/gZnJMlUHVLxrLAMR4AxLaWw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-subtraction": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-subtraction/-/actor-function-factory-term-subtraction-4.5.0.tgz",
-      "integrity": "sha512-INkhG5dQZekt3W6tUL4JIjO1ZVHV31OQoAWQv4GEs/a19WM1EMp3oHlHqo8yOqZgnWbBMb9oarOjRYINthaLZg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "bignumber.js": "^9.1.2"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-timezone": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-timezone/-/actor-function-factory-term-timezone-4.5.0.tgz",
-      "integrity": "sha512-N44SF5MfzjFhRNDtjJO+E6lfJBX639Ogb2Oc4x2Qh9aj/OUuHuwONEtCwaoUADIThBdDiTTGhlsfwe0tUY3e7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-triple": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-triple/-/actor-function-factory-term-triple-4.5.0.tgz",
-      "integrity": "sha512-U4yIpuR6n2w9YdRXhrONV34ju8CtVm8jA0pBopnFYK/GwnJqp6YIn00B5AC/WdKDUVZUDgNu9j+XgpwJxsN6pA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-tz": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-tz/-/actor-function-factory-term-tz-4.5.0.tgz",
-      "integrity": "sha512-wliS6iY6eDbezKYs6CsVoRqvM6ZVNxKRubEexJYyVPy/DF/KHi2Un0iWQGYu+DM6rRQ5gD/kSjmO5PUjaSvtpg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-ucase": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-ucase/-/actor-function-factory-term-ucase-4.5.0.tgz",
-      "integrity": "sha512-ygsPFyHpE1vZQvBdLiFsSMrQDw7XVl8KDlWMl0Ntj7w6UZt+DWHAfXzxn94fr2OfBrqguqRc8MLQTsX5IjK+Mw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-unary-minus": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-unary-minus/-/actor-function-factory-term-unary-minus-4.5.0.tgz",
-      "integrity": "sha512-f3FsopxQIIIiBQtAHcW4KjW3/RAxAjgNPse2BumY6igUjY8vkYPiqRDMdQkl+iV0tLprGYu0BXyj95F23X/wcA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-unary-plus": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-unary-plus/-/actor-function-factory-term-unary-plus-4.5.0.tgz",
-      "integrity": "sha512-CvJhzQE/TyyVgvbkSEyiLX0NWAeiH1cOkpWTCqazpjRoTsyvrmNQnrdO/c8yPOyylRMZ/sA7Glad8KyBVdTXqg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-uuid": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-uuid/-/actor-function-factory-term-uuid-4.5.0.tgz",
-      "integrity": "sha512-AHDwJR0DxiQexuYLH6EhOirMYcoOOuGW8KhbmCnBilVsx8juZF42l/xiTPbXXEE7QlHGiJImGxkUZF4mcidX9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "@types/uuid": "^10.0.0",
-        "uuid": "^11.0.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-xsd-to-boolean": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-boolean/-/actor-function-factory-term-xsd-to-boolean-4.5.0.tgz",
-      "integrity": "sha512-W6uIE3lRGwOpeiuxV7DclRMchm4l2Pnjb8AimAkI8DTt1Q/hEsO3MmO06Fx098OZZCpMk5kV89up92VOKaZTaw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-xsd-to-date": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-date/-/actor-function-factory-term-xsd-to-date-4.5.0.tgz",
-      "integrity": "sha512-mItiMbvoz63VgmkSYWTvqf9w9OnPXzhpe4WYSV7vKnMTmwPflCAszM6glIiN+UXKNhYFBeqXIxrRZ/fFJPu4Ag==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-xsd-to-datetime": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-datetime/-/actor-function-factory-term-xsd-to-datetime-4.5.0.tgz",
-      "integrity": "sha512-U54xs8vL9lkpHyJBwZA4Ed/zC6twOGPl05ApFomsyw4JYEoF0T9MyGQwJgwrDRz6NLaNdbrjtrC3BN/sk9XIdA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-xsd-to-day-time-duration": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-day-time-duration/-/actor-function-factory-term-xsd-to-day-time-duration-4.5.0.tgz",
-      "integrity": "sha512-9LDlkfdjpeLf2sJCCTK4JfPUqAfZ5WC3DDb3JiKeSWn0a63o1bUuvznEZniqZPJ0XPDJ3uYd7oXRlWGHP8TCKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-xsd-to-decimal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-decimal/-/actor-function-factory-term-xsd-to-decimal-4.5.0.tgz",
-      "integrity": "sha512-J4mhhGWpkm7K+vJTzxoG7Skon/PdasA2Tl1OUOYboU1SBgaEsIovoIxsDqdVV6HU7O4mHli0ZXH9HM5KVM+GXw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-xsd-to-double": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-double/-/actor-function-factory-term-xsd-to-double-4.5.0.tgz",
-      "integrity": "sha512-CsoZVOz4FqEGlyRvFDwhtFELL8hSRysiDD78b67esqEWMYWVPfS34/SaRjgN335tkIFiCM9xEq0vA0I2kLlsnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-xsd-to-duration": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-duration/-/actor-function-factory-term-xsd-to-duration-4.5.0.tgz",
-      "integrity": "sha512-djMWp2ZXz9ffY3JYivsgCH+tJQLia53P0/sqLXuCeJoPsg3QpKoSpwy9wIBkAcaLatAhn6jQJAZTeEVWPNlY+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-xsd-to-float": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-float/-/actor-function-factory-term-xsd-to-float-4.5.0.tgz",
-      "integrity": "sha512-F/BpWl3AEZeSoTe9TF3xd3sgI8g6F4q6+hekSQcp7LWLChn4ln+Bl4N+ZRocxIFJevFjGMnnjtoOi25iOhVx6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-xsd-to-integer": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-integer/-/actor-function-factory-term-xsd-to-integer-4.5.0.tgz",
-      "integrity": "sha512-diT42cLv4L8ZrlvL5UxQ50EXyZj+Id94RJUZjewmnFb13NWrfwjKKS6bdtFV+rNtiVPsvVOgzXyJEws6tHwjUA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-xsd-to-string": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-string/-/actor-function-factory-term-xsd-to-string-4.5.0.tgz",
-      "integrity": "sha512-WMKc1Y+leNhUxUUxlgur+Xbq9oHhqI/VUbkPlqcEYRGHH792d5D652a2yND8SbxpF7gdsPpoFYpBmmAwipsWQw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-xsd-to-time": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-time/-/actor-function-factory-term-xsd-to-time-4.5.0.tgz",
-      "integrity": "sha512-5C8e71T6FN0Wt1K0C2P2ooC1uBFid7UBkeGhB+GZvbiGcYe3jRJgTACgCGhONuqgIqNvrRuS0lbS7/eKp1dC+A==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-xsd-to-year-month-duration": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-year-month-duration/-/actor-function-factory-term-xsd-to-year-month-duration-4.5.0.tgz",
-      "integrity": "sha512-+wKVAq7emP25PgjyDZeBWF5hlOJ3SNOtMRM0lfU3cHgigxKs91BELss0JSdHwz7oxTwuxLMogAeA/sknMIvC7g==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-function-factory-term-year": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-year/-/actor-function-factory-term-year-4.5.0.tgz",
-      "integrity": "sha512-o5Em71Rj3w+YnDbDE5Rkjzlc/enXPFxnFFesAHx8BXwqTK1Lqr2x2izYI1mZvjsy4czwtY7t3Qa9OKNc/AdJJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-hash-bindings-murmur": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-hash-bindings-murmur/-/actor-hash-bindings-murmur-4.5.0.tgz",
-      "integrity": "sha512-bebfR1rwPT+TPgT07P7cwblDlP8/gVPIALZMIqU0w9IbH54kZcFsnc2OQLUCar1Aq7EZUkny/lY2UjcHagObcg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-hash-bindings": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@types/imurmurhash": "^0.1.4",
-        "imurmurhash": "^0.1.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-hash-quads-murmur": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-hash-quads-murmur/-/actor-hash-quads-murmur-4.5.0.tgz",
-      "integrity": "sha512-3A3aNcY23HWKoz+5BFyZXNoLYsuiRh9WGYJ+zzZkMOuNopUr/z5+JoYXbQKbbd8iQeKctdCzi9eE4XMU8emUSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-hash-quads": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@types/imurmurhash": "^0.1.4",
-        "imurmurhash": "^0.1.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-http-proxy": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-4.5.0.tgz",
-      "integrity": "sha512-M5UQ+/IqXFNXLu9qSFNeeph/vaP349HQozqZzOY+HTO4TNWSIcB/XO6HgE3SC7r4G+KV+s9WbHwQO/8PxshBPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-http": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/mediatortype-time": "^4.5.0",
-        "@comunica/types": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-init-query": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-init-query/-/actor-init-query-4.5.0.tgz",
-      "integrity": "sha512-BC+5k0qRxIyl4j00tbqiwKSoOHBkcApMVvXfzYGnK/KgJC8Xj/cPivf3+64Nn4oMgm5kJbp5VW9v7A4+6PB25w==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-http-proxy": "^4.5.0",
-        "@comunica/bus-http-invalidate": "^4.5.0",
-        "@comunica/bus-init": "^4.5.0",
-        "@comunica/bus-query-process": "^4.5.0",
-        "@comunica/bus-query-result-serialize": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/logger-pretty": "^4.5.0",
-        "@comunica/runner": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@rdfjs/types": "*",
-        "@types/yargs": "^17.0.24",
-        "asynciterator": "^3.9.0",
-        "negotiate": "^1.0.1",
-        "rdf-quad": "^1.5.0",
-        "readable-stream": "^4.5.2",
-        "sparqlalgebrajs": "^5.0.2",
-        "yargs": "^17.7.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      },
-      "optionalDependencies": {
-        "process": "^0.11.10"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-optimize-query-operation-assign-sources-exhaustive": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-assign-sources-exhaustive/-/actor-optimize-query-operation-assign-sources-exhaustive-4.5.0.tgz",
-      "integrity": "sha512-FPw1xidcpP1b6hVJ2zM3ib6wvHEoVnHEuh59jIgRV6Iz5idraCK3EVagYCxSWo9Xj0NR48/6DUVMjVWl7JMnFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^4.5.0",
-        "@comunica/bus-rdf-update-quads": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-optimize-query-operation-bgp-to-join": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-bgp-to-join/-/actor-optimize-query-operation-bgp-to-join-4.5.0.tgz",
-      "integrity": "sha512-1raQz4vjZ8MUCAhh4EYcj+6aLnb292NJoSc+jTBC+u5rtJ4gmFqNDyCJxjoI/QbxU9Ioy2Hlj4WxMq7M6F816g==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-optimize-query-operation-construct-distinct": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-construct-distinct/-/actor-optimize-query-operation-construct-distinct-4.5.0.tgz",
-      "integrity": "sha512-1phqt7HRuGMf6DzBYxlwJG8gw0KTyfFomhc4Uvr3QZrzRJ9Z41NgDTkSd+OGhbxwFm+aJ5O51VSi0FRK5K/Rvw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-optimize-query-operation-describe-to-constructs-subject": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-describe-to-constructs-subject/-/actor-optimize-query-operation-describe-to-constructs-subject-4.5.0.tgz",
-      "integrity": "sha512-bPN82pm7InpjtNvrehl4qaYAu5G8gz2pCzviPo3rHi3syYKMDDXHSW51IpkE904YAysuKbgX4hPZ17WENh4Wpg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-optimize-query-operation-filter-pushdown": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-filter-pushdown/-/actor-optimize-query-operation-filter-pushdown-4.5.0.tgz",
-      "integrity": "sha512-2U2uSbaJPCy8pngkJ/c4QKBHObzulOndFO1c2lrdfeMuyq3usUEcxBvoWufeKWhdit88Re+wHJyPY+ZYw5T7hg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "@rdfjs/types": "*",
-        "rdf-terms": "^1.11.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-optimize-query-operation-group-sources": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-group-sources/-/actor-optimize-query-operation-group-sources-4.5.0.tgz",
-      "integrity": "sha512-IsRPmnSRzKzW/YnKlRQt06qs+ytn1ML50MYwq1siUS8GpCHlBsb+uhYPDb3+1gr/+TYPZro7PzGS4Gn7pdzfAg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-optimize-query-operation-join-bgp": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-4.5.0.tgz",
-      "integrity": "sha512-/rl5ig8O2GVTrH0Ux2CjAjyTvv7XvH4nYOjuQwZx05YmsPb6rEzzE7RAGoln4qZNG9TY4X0cKwxQcXmyTJMDGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-optimize-query-operation-join-connected": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-connected/-/actor-optimize-query-operation-join-connected-4.5.0.tgz",
-      "integrity": "sha512-wJ0obFZHNaQSlyJCwWlfm/8OqNvHSLdXWlfAm3ZWeeDg7QGBDMZjdoHG5uNSYRsYzxv5GGMduTs1C2kymgfkqA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown/-/actor-optimize-query-operation-leftjoin-expression-pushdown-4.5.0.tgz",
-      "integrity": "sha512-j8aHL24PNXhpdDuLNmxUK5Y2JRZDELKZK12vCosAkh9YBcvKRM6liGm8IErfMWqLIk8W9SGac80MP04CCiaAKw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "@rdfjs/types": "*",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-optimize-query-operation-prune-empty-source-operations": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-prune-empty-source-operations/-/actor-optimize-query-operation-prune-empty-source-operations-4.5.0.tgz",
-      "integrity": "sha512-xyLHO3ZP62QAviQcAuluZuNQThyu0x0qT8uSy3EcwdLAaaAasZFf0TYric+cMMFeVk/lkbi250ksnx8HOLDuQw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-optimize-query-operation-rewrite-add": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-add/-/actor-optimize-query-operation-rewrite-add-4.5.0.tgz",
-      "integrity": "sha512-n9MgkIpjQ0OswV7tmaKGPruq/WaeOeHzjPt4uf7zoLBGna5UsUWzuL/hnQyIH69zAEDhzyHy2COCefLMKkIyvw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.2",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-optimize-query-operation-rewrite-copy": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-copy/-/actor-optimize-query-operation-rewrite-copy-4.5.0.tgz",
-      "integrity": "sha512-dlzn9XlJmgGS32xKiuP++/9qAEPWgXDZ9j1dOBscIzVfsbcwx6zdHbQ6qB0vFM7Ged88CIGS4waCSE/S3gExdg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-optimize-query-operation-rewrite-move": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-move/-/actor-optimize-query-operation-rewrite-move-4.5.0.tgz",
-      "integrity": "sha512-ITtO/5XpTewCvDuCISmtX2NGampMCGpHf6s3ew/g2YBEVSeTDhqgA73isHA847Q8cfxOESwChGFCP4CuiHv91w==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-ask": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-4.5.0.tgz",
-      "integrity": "sha512-dqO3ztOtLlxtwuG/cSsFcEb3W0hHR9mzS3MlXb+GH5u8n1Phidk8s1mfMQKoYdyTfTTnxAVSMcolHDN9VOl18g==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-bgp-join": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-join/-/actor-query-operation-bgp-join-4.5.0.tgz",
-      "integrity": "sha512-/LR/RjHoBk+YBO/FPx+nd63b6pA9OHEMzrR3U5aejIHZ4X3vCiHxcTiGWLx8LffZVKLamsL1NeWnsAa3g4t5jg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-construct": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-4.5.0.tgz",
-      "integrity": "sha512-IIVkna7LL+MDGgQbmCAlXkXDGUu2r+hiuu7nY2RVqA9uNqgos1hHwbK2+UWA3rvyCzI/ECIANXX2PInm3ieXvQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.9.0",
-        "rdf-terms": "^1.11.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-distinct-identity": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-identity/-/actor-query-operation-distinct-identity-4.5.0.tgz",
-      "integrity": "sha512-WRhvsT2UpHcgKWRuiWGeu7wX+ITjpfRw2++pPOizL/Wt4EFQQBQNxrPasrUce33jVws1QxS6zlSY+bGzUmeljw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.9.0",
-        "rdf-string": "^2.0.1",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-extend": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-4.5.0.tgz",
-      "integrity": "sha512-dbpTn3EyTch8Aw57KEKCKHCFMKaSLd+KuakGxrTxSiAjbjBJL/ZL4vhGZDpx0xI1IKA8PVFtgsLuUk7IpnP59Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-expression-evaluator-factory": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-bindings-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-filter": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter/-/actor-query-operation-filter-4.5.0.tgz",
-      "integrity": "sha512-4kWfCh+s3X/cab/2z/ZW54ah9gAfUiZAmy+DgXNqtj6ty+zBC5ZFKCFbe+O7orvZOrfDD1kwZmvdAR3GO7RrBg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-expression-evaluator-factory": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-bindings-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-from-quad": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-4.5.0.tgz",
-      "integrity": "sha512-CGRDCTWYc7hi05/d2GUVTNqF2sekcloTuU+uCrqnPMR9g6//KAq7n7QjBC/OZQj7q3454rjnhUxHf1ahTJZS/A==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@rdfjs/types": "*",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-group": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-4.5.0.tgz",
-      "integrity": "sha512-6OSCo3ssBuri0Euf6E9IFbZH7/DP0RSJre549jruLIEAed+XTreStpI9Unx1IOKAOI2X5Xv2cfLfuGubH3CRBg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
-        "@comunica/bus-merge-bindings-context": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-bindings-factory": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.9.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-join": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-4.5.0.tgz",
-      "integrity": "sha512-q2u/PxmP7LLdqpIv4teKDrxTjcqH89aRf34X63nU++8TvEzml/786/EMLmVYshgrWsNShbw9afrmwB6DWNCcpA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/bus-rdf-join": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-metadata": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.9.0",
-        "rdf-data-factory": "^1.1.2",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-leftjoin": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin/-/actor-query-operation-leftjoin-4.5.0.tgz",
-      "integrity": "sha512-F240YX+ILF1QFW30oGK7bnapo5gkwHWFPkX6UME9ogjdq6AeosM3boevtwsUVp3ykz3irsExdJDIU24QtvYhuA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/bus-rdf-join": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-minus": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-4.5.0.tgz",
-      "integrity": "sha512-8UqLHadZHp0jr2LujjtlKYFdKGZdG24PoKEJOBZpxAgdOFd6QirBFR5TA5QlIjm1o77yzLzPLSokjvlYswYW6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/bus-rdf-join": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-nop": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-nop/-/actor-query-operation-nop-4.5.0.tgz",
-      "integrity": "sha512-Qh3ZK0YkcH0FcAf8U5U22076ZWDSH37m9vbm1yYPdn/ag+G9TXf63VxcYpLcFQJFB7LM6b+6LNQezMfFXiqoYg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-merge-bindings-context": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-bindings-factory": "^4.5.0",
-        "@comunica/utils-metadata": "^4.5.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.9.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-orderby": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby/-/actor-query-operation-orderby-4.5.0.tgz",
-      "integrity": "sha512-s28lZK5M9XewM5wl+RfuqwWwcBYpIMnpEPRD6cco5bbP6m9gXZAo8KHYsDfdfBKiOfWDxIcP3QpDJZajmy5KKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-expression-evaluator-factory": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/bus-term-comparator-factory": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "asynciterator": "^3.9.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-path-alt": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-4.5.0.tgz",
-      "integrity": "sha512-bgM5/lE6C/no1g5XZZi8CL46SURZtgmernDsd10wQdzXYZzlNcxO8yu1C/HozTyKsIlRpv8FTWgh2a0jbsJlJg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^4.5.0",
-        "@comunica/actor-query-operation-union": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/bus-rdf-metadata-accumulate": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "asynciterator": "^3.9.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-path-inv": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-4.5.0.tgz",
-      "integrity": "sha512-s30h/6aEzzDxgCjy9fz/RVGakiSAD0+GAGvMmMF3zqhpM70lD6dwaMQSwxAH/7IQiEjR7VlrrYPMTI0ljK+9OA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-path-link": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-4.5.0.tgz",
-      "integrity": "sha512-Pyu1KpBOvOPTFD/tQ8JcXNzA+TnJVTggZSIsfCdzXJePx5zVglXT74cHLAMP0MS4QI709JrNYDveUWBYxJrcVA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-path-nps": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-4.5.0.tgz",
-      "integrity": "sha512-gziMhls637aQyt86J0uRfGYZlvRuOH5fPExocoqmALh34bi08/hqGUnuPBRqYX7dBnqgIz5daInqhBGaWpvyxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-path-one-or-more": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-4.5.0.tgz",
-      "integrity": "sha512-4Q/WcptuCR7asWzZShupvzfcR6KPsdISdYdguvDnDC2wkiI8DJKkPxek5fCHth78twWqP93WZnkKto3pfM2Dkw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^4.5.0",
-        "@comunica/bus-merge-bindings-context": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-bindings-factory": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "asynciterator": "^3.9.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-path-seq": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-4.5.0.tgz",
-      "integrity": "sha512-uzvJZWEQ15VpdiVvhcS4eDmQREHIDnyG4/eBsSsh64d/sBTAlnF+jTh10OF7UIBD1IpGwL3u10DoV8Xz9dhOLA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/bus-rdf-join": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-path-zero-or-more": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-4.5.0.tgz",
-      "integrity": "sha512-8HIBnqBgDEZTiiok9/Biyka24YWfDVLlJntJRX2i+qm20LLCzKqfqM8LyfmuY9xCxLzRHfZplwUMt9p1FbxcBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^4.5.0",
-        "@comunica/bus-merge-bindings-context": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-bindings-factory": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "asynciterator": "^3.9.0",
-        "rdf-string": "^1.6.1",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-path-zero-or-more/node_modules/rdf-string": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
-      "integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-path-zero-or-one": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-4.5.0.tgz",
-      "integrity": "sha512-V22P9WtJDLzLsWot/CLmJc9v566LmCoNApFGxAL9TgZeIKyZsKVESMb/TEI/GkXBuMxjAyCTh2cRm2ORztiH8g==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^4.5.0",
-        "@comunica/bus-merge-bindings-context": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-bindings-factory": "^4.5.0",
-        "@comunica/utils-metadata": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "asynciterator": "^3.9.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-project": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-4.5.0.tgz",
-      "integrity": "sha512-8tFqMnM2gaEzewE25PTm4UQMZ4kUUoOrbFS7OM65Vns3Jvw8cYwYCoYAT98L0gHMGG5z0UTYoOHMc+PdjBRuGw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-data-factory": "^4.0.1",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "@rdfjs/types": "*",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-reduced-hash": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-4.5.0.tgz",
-      "integrity": "sha512-yaA/jF4y2vxzS/mjK8UEGMWZtDx3joPPbbcidVACW02HzpXHpNGYUfb2OZOK1LnnaJayms9lJd2kfU78UThRsw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-hash-bindings": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "@rdfjs/types": "*",
-        "lru-cache": "^10.0.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-slice": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-4.5.0.tgz",
-      "integrity": "sha512-SWBFYpFwu1Ns53BypSR61YuypYcwifsyxvJ2s4mjg5EHBc+myUXf/eoeXl1TFYKWZsUp6xOvCZCLcxsMMM4OTg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-source": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-source/-/actor-query-operation-source-4.5.0.tgz",
-      "integrity": "sha512-N7Ncs92KOYQ0uKBc0P3hZ9/7yHwchnazH+wq/Gufm/WsWPt13YppB43rSJHzo0tBkVMvI8MbZvkLj3t46/wYAg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-metadata": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-union": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-4.5.0.tgz",
-      "integrity": "sha512-cKBEYMc84lXREjj9ta30idl4wYKQnSXS1P3tpyuUcc0AmGFVWA6+VzJEgKzvH6Mpbe/PGA8nhTqDZJVLi1XRXw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/bus-rdf-metadata-accumulate": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-metadata": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "asynciterator": "^3.9.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-update-clear": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-4.5.0.tgz",
-      "integrity": "sha512-R6x13rE4JU/QlDoBQXAJadtYePWB82UTGT0r3xgNaXgRaODWgaSPXadPvxRLoI9HSX0DQrJiIXaNXH0EDdGtFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/bus-rdf-update-quads": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "@rdfjs/types": "*",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-update-compositeupdate": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-4.5.0.tgz",
-      "integrity": "sha512-/7hwBvrHUl9f2arb2Z4KOOyTjFNdSAspLofGmMVeM9f8TkPH96gDMRw1+RM4qcuTLEbdJn+efc7YzVJrVmwSDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-update-create": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-4.5.0.tgz",
-      "integrity": "sha512-BphWTXX81Bpv8hq74eIkPWOi2K8/45UvM2ayQp3RblSlD1fu0GcWnxcoexLFFw1aM4Xd8sCvgRtq2k0HwhgdoA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/bus-rdf-update-quads": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-update-deleteinsert": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-4.5.0.tgz",
-      "integrity": "sha512-spJ3Rpj/FAM8tAo35ggFyFWamOfBfHZBT/eMH3CKLJ5qXEJcB9JvjxD/kmW79aMhsPSqlOqyTQ7p3g7OcQd0Jg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-query-operation-construct": "^4.5.0",
-        "@comunica/bus-merge-bindings-context": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/bus-rdf-update-quads": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-bindings-factory": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.9.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-update-drop": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-4.5.0.tgz",
-      "integrity": "sha512-jVDTwPANfoH6iUzuO2RvVoDZ0tVpyShWANwEpvvfWRocj/oy55p3tF/1CUj/I/6IVXsiBs32xivnGeP2Aurzkg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/bus-rdf-update-quads": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "@rdfjs/types": "*",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-update-load": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-4.5.0.tgz",
-      "integrity": "sha512-ZNQkrhLwUjjLdrkYE83SafnhtSt0LEiAE+cS+soRZwl9GLoIPqfRyE8+r6hPHVKtBefLkTQC01dBC53vb84cTA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/bus-query-source-identify": "^4.5.0",
-        "@comunica/bus-rdf-update-quads": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-operation-values": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-4.5.0.tgz",
-      "integrity": "sha512-3RTTA2drfC3gr4VtomTMhhXuJGjmZW5NiiX/QhKLwkxEzVp8JYDP8KTtaMG+HWvNzoXNnLgFjY+69SCVUNfk8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-merge-bindings-context": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-bindings-factory": "^4.5.0",
-        "@comunica/utils-metadata": "^4.5.0",
-        "asynciterator": "^3.9.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-parse-sparql": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-parse-sparql/-/actor-query-parse-sparql-4.5.0.tgz",
-      "integrity": "sha512-cteTjZAipUsC44z67yyCWe+4FMxBAFv1tNAe2omaqDMo8nLZJ2qnN9wj4ZqOVQuyHSGLeg5V7umc5O1m4FgFKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-query-parse": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@types/sparqljs": "^3.1.3",
-        "sparqlalgebrajs": "^5.0.2",
-        "sparqljs": "^3.7.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-process-sequential": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-process-sequential/-/actor-query-process-sequential-4.5.0.tgz",
-      "integrity": "sha512-3MlrVQfY7iz0V17jnlZzeJLav1AtawnXZTEK3Jvsnl7lQrzYJ0rEvvGCeAJ6LCrhHmE9cMI0KtghQnKO1zxuDg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-context-preprocess": "^4.5.0",
-        "@comunica/bus-merge-bindings-context": "^4.5.0",
-        "@comunica/bus-optimize-query-operation": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/bus-query-parse": "^4.5.0",
-        "@comunica/bus-query-process": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-bindings-factory": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "@rdfjs/types": "*",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-query-source-identify-rdfjs": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-rdfjs/-/actor-query-source-identify-rdfjs-4.5.0.tgz",
-      "integrity": "sha512-OODcg3Sz0TAkClTlhHout6hAgikbtm/19rycJeOo6QbsM2dUohnKrk5pXNvlTfCqIj2qsvqcnD5YTuIRjYhYiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-merge-bindings-context": "^4.5.0",
-        "@comunica/bus-query-source-identify": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-bindings-factory": "^4.5.0",
-        "@comunica/utils-metadata": "^4.5.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.9.0",
-        "rdf-terms": "^1.11.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-join-entries-sort-cardinality": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-entries-sort-cardinality/-/actor-rdf-join-entries-sort-cardinality-4.5.0.tgz",
-      "integrity": "sha512-Tk4AxcP0BdC9e5LJQqcCx1IvrVeeIbRYlin6u//s70MG4QZesFdFl3kNRPWo7PK2M40XT2yO3j5tSNrkj4TpxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-join-entries-sort": "^4.5.0",
-        "@comunica/core": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-join-inner-hash": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-hash/-/actor-rdf-join-inner-hash-4.5.0.tgz",
-      "integrity": "sha512-goMj2HrfZp2rP30F+Ea/n8E8qYbhPHv+qG335RAX1NB1/QuIzhhKf5BP5fYVfEu55lhFAy2WpNn/eDYfXEj2Lw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-hash-bindings": "^4.5.0",
-        "@comunica/bus-rdf-join": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/mediatortype-join-coefficients": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-bindings-index": "^4.5.0",
-        "@comunica/utils-iterator": "^4.5.0",
-        "asynciterator": "^3.9.0",
-        "asyncjoin": "^1.2.4",
-        "rdf-string": "^1.6.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-join-inner-hash/node_modules/rdf-string": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
-      "integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-join-inner-multi-bind": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind/-/actor-rdf-join-inner-multi-bind-4.5.0.tgz",
-      "integrity": "sha512-jCJyQ0E8G589V5Is3fK6W4LpPwKdOv3jC7MtAPdbRzq57l9aY7kYc0n0U4lC7mGSjyPMAcvCQJCE8MMqYyFmeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-merge-bindings-context": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/bus-rdf-join": "^4.5.0",
-        "@comunica/bus-rdf-join-entries-sort": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/mediatortype-join-coefficients": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-bindings-factory": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "asynciterator": "^3.9.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-join-inner-multi-bind-source": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind-source/-/actor-rdf-join-inner-multi-bind-source-4.5.0.tgz",
-      "integrity": "sha512-pnd/r9YW21yxxmJIq8GEz3AB6Qrmvxj9zh04xOw8407Kicxf9iZ2jFm1z5rtrE3fVX4gh206wwKNo5dopOp9Qw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-join": "^4.5.0",
-        "@comunica/bus-rdf-join-entries-sort": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/mediatortype-join-coefficients": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-iterator": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "asynciterator": "^3.9.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-join-inner-multi-empty": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-empty/-/actor-rdf-join-inner-multi-empty-4.5.0.tgz",
-      "integrity": "sha512-f9FDa00yqmxIn9n0YSc+JxyJGHR/TKQTlkc4A/lkBbHauD+o0LoryGIm/88mK4ZEDG0ebz2s1znmspCEyhol6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-join": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/mediatortype-join-coefficients": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-metadata": "^4.5.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-join-inner-multi-smallest": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest/-/actor-rdf-join-inner-multi-smallest-4.5.0.tgz",
-      "integrity": "sha512-X9cVWpImkX7ovYxaRMS5w/Y6z7izvAvglcl6Rn4qnL/u3tsgFEcvVb+nMkGjH3+Dk5yef+oThCvVhc5nb7t9mw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-join": "^4.5.0",
-        "@comunica/bus-rdf-join-entries-sort": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/mediatortype-join-coefficients": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings/-/actor-rdf-join-inner-multi-smallest-filter-bindings-4.5.0.tgz",
-      "integrity": "sha512-i04prUsnBsdgPvL847NeZihXiE5Pn5mdcYO4i/LDsPoOoD2vcodm2WvfVl8bFI69FJIIyuf/VlfQOFKNp+9JbA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-join": "^4.5.0",
-        "@comunica/bus-rdf-join-entries-sort": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/mediatortype-join-coefficients": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-bindings-factory": "^4.5.0",
-        "@comunica/utils-iterator": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "asynciterator": "^3.9.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-join-inner-nestedloop": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-nestedloop/-/actor-rdf-join-inner-nestedloop-4.5.0.tgz",
-      "integrity": "sha512-+u8peRhrLHmTSyMHkKN4Ky0OmUAVteu9WDHagtflNChhGL1OGMZuO1tw+hu8YCrK0/fWCd3ujgr9i5u4Y49iog==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-join": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/mediatortype-join-coefficients": "^4.5.0",
-        "asyncjoin": "^1.2.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-join-inner-none": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-none/-/actor-rdf-join-inner-none-4.5.0.tgz",
-      "integrity": "sha512-PSOkwq2NMvDL6ikcDuPEa1Rp2aqFlmgvAzUk8OhiCDI0kEqlUzWxskrqQIjVneK8PmJiV3CaA+QkfDp/V48h0w==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-merge-bindings-context": "^4.5.0",
-        "@comunica/bus-rdf-join": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/mediatortype-join-coefficients": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-bindings-factory": "^4.5.0",
-        "@comunica/utils-metadata": "^4.5.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-join-inner-single": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-single/-/actor-rdf-join-inner-single-4.5.0.tgz",
-      "integrity": "sha512-XCSO3ULvMMfpmPduzj06oInkvUyTk/n0/p7ovhC/A/0zUJc6Ml9dPrwJZdCiHWF7zjqd74mDrRmu23ouDmuwow==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-join": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/mediatortype-join-coefficients": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-join-inner-symmetrichash": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-symmetrichash/-/actor-rdf-join-inner-symmetrichash-4.5.0.tgz",
-      "integrity": "sha512-TgOoAG/Z7+tgR/vLvym7v3udcIqcD90+w5ttQ+hTa7dfHw/NNhAUALmK6ZMa6uJ6RWeNUu2JZSDDaLFkPDeqDg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-hash-bindings": "^4.5.0",
-        "@comunica/bus-rdf-join": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/mediatortype-join-coefficients": "^4.5.0",
-        "asyncjoin": "^1.2.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-join-minus-hash": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-minus-hash/-/actor-rdf-join-minus-hash-4.5.0.tgz",
-      "integrity": "sha512-3smcJln7Tr+wNEiRuL4KPO+FodMhqQeIaEdnEcs+gzU6JAE9zlPtJDqlTn2pwmUfUYg4xXcScIQJHJoBuf516A==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-join": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/mediatortype-join-coefficients": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-bindings-factory": "^4.5.0",
-        "@comunica/utils-bindings-index": "^4.5.0",
-        "@comunica/utils-iterator": "^4.5.0",
-        "@rdfjs/types": "*",
-        "rdf-string": "^1.6.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-join-minus-hash/node_modules/rdf-string": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
-      "integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-join-optional-bind": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-bind/-/actor-rdf-join-optional-bind-4.5.0.tgz",
-      "integrity": "sha512-R0XBCZXv3bL0712FIwqZ+2U+P+k9YGgQFLHI2/PtW9sJWi/s79JSYnwnACfEEfMwIdkPHwK0NIuNmnw3BTT+1w==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-rdf-join-inner-multi-bind": "^4.5.0",
-        "@comunica/bus-merge-bindings-context": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/bus-rdf-join": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/mediatortype-join-coefficients": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-bindings-factory": "^4.5.0",
-        "@comunica/utils-query-operation": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-join-optional-hash": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-hash/-/actor-rdf-join-optional-hash-4.5.0.tgz",
-      "integrity": "sha512-ogSoBp2OJGZFlUyu5XnggNKBhhQoYBivf4Avvphnm4xZ+4IQmLfwBuzEXhPTZN5Yyfu7L0hQK6Kykk1YuAZo0w==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-join": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/mediatortype-join-coefficients": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-bindings-factory": "^4.5.0",
-        "@comunica/utils-bindings-index": "^4.5.0",
-        "@comunica/utils-iterator": "^4.5.0",
-        "asynciterator": "^3.9.0",
-        "rdf-string": "^1.6.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-join-optional-hash/node_modules/rdf-string": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
-      "integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-join-optional-nestedloop": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-nestedloop/-/actor-rdf-join-optional-nestedloop-4.5.0.tgz",
-      "integrity": "sha512-szhKIYdV7r6Sv1+q7WW7831O33dO7yYlgbsTDwPir5hgLYHRprrjDFKhPbyA361waWiR7JLrUfdJaXt6FbSIYg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-join": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/mediatortype-join-coefficients": "^4.5.0",
-        "asyncjoin": "^1.2.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-join-selectivity-variable-counting": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-selectivity-variable-counting/-/actor-rdf-join-selectivity-variable-counting-4.5.0.tgz",
-      "integrity": "sha512-98plhmPvrnYPXQa5PES6sAeNFB+qrGiZg1bUvAM5Jtg5jQ9BfwH+Bf02yIVAfyACjaLaTNGoOP/qHzb6HrUQdg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-join-selectivity": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/mediatortype-accuracy": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-metadata-accumulate-cardinality": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-cardinality/-/actor-rdf-metadata-accumulate-cardinality-4.5.0.tgz",
-      "integrity": "sha512-fHQAs1dqOGwWrSAyCLMGMU3M1GKbjjvcyKS9cYwN47OiT2rEsbBZ1sGWOcpNgxJa4T59lvO4RlfDuuMpmcYLSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-metadata-accumulate": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-metadata-accumulate-pagesize": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-pagesize/-/actor-rdf-metadata-accumulate-pagesize-4.5.0.tgz",
-      "integrity": "sha512-V3Gci3XEN4gO6w+dSHt9QnzaO1+lhytmYxoHIkkwVcjh4X5WYxM82D2fjFf4dW9xF0Yej009ps8RpuX54YRseQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-metadata-accumulate": "^4.5.0",
-        "@comunica/core": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-metadata-accumulate-requesttime": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-requesttime/-/actor-rdf-metadata-accumulate-requesttime-4.5.0.tgz",
-      "integrity": "sha512-Br5hlNujsRFCHJ0g48oW8xBBQvDDT5lNaCuY0ky/sIv/ULk5aT5J/jBIvc5aeIXpA37D3KrvfenXz3ScqvTHSA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-metadata-accumulate": "^4.5.0",
-        "@comunica/core": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-update-quads-rdfjs-store": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-4.5.0.tgz",
-      "integrity": "sha512-PsV7Fdm/y0jLfSsByUpU0GkbRIV4d73q7d6Ytl5iWQLwvfYiJ8KE6qQyN0tOvcYO9cCwhMCYusEoy6kep6Ml4A==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-update-quads": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.9.0",
-        "event-emitter-promisify": "^1.1.0",
-        "rdf-string": "^1.6.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-rdf-update-quads-rdfjs-store/node_modules/rdf-string": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
-      "integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/actor-term-comparator-factory-expression-evaluator": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-term-comparator-factory-expression-evaluator/-/actor-term-comparator-factory-expression-evaluator-4.5.0.tgz",
-      "integrity": "sha512-sI46VJ80mfgwTDBhSuzPfIzNABOc10du4rE3NPVl9ysXU+mlfy71B1tkOq25wkGc/bKqo3etNURJz790qCD+4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-expression-evaluator-factory-default": "^4.5.0",
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/bus-term-comparator-factory": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/utils-bindings-factory": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "@rdfjs/types": "*"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-bindings-aggregator-factory": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-bindings-aggregator-factory/-/bus-bindings-aggregator-factory-4.5.0.tgz",
-      "integrity": "sha512-gI8UIgEJwYriQmalmMcA1q5g9cu7EzXLuJELiJZMm03msAoVB+RcZmbRBlYnVfRw/uTShl7IV8k27Hl05AjpCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-expression-evaluator-factory": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "@rdfjs/types": "*",
-        "rdf-string": "^1.6.3",
-        "sparqlalgebrajs": "^5.0.2"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-bindings-aggregator-factory/node_modules/rdf-string": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
-      "integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-context-preprocess": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-4.5.0.tgz",
-      "integrity": "sha512-PE2aSmzcQsDuIUJGt0Ko6yD8YithHy6XwXKeS8OHaQeI93S+V6DZKaaCE+gCNcDBi8jZ4P4cislay/+8V1ZIPg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-expression-evaluator-factory": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-expression-evaluator-factory/-/bus-expression-evaluator-factory-4.5.0.tgz",
-      "integrity": "sha512-QaeEiiXq75fV6+P3DnTKJkrV5p9yv1PqmsSPJ3h66DUManXrQEh9ATnJAwEBoUJlHE4Sy2aqho6Whate1W/orA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/bus-merge-bindings-context": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-function-factory": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-function-factory/-/bus-function-factory-4.5.0.tgz",
-      "integrity": "sha512-C/D9hzDWAv0GNDYV547rZrVAvkR7pc5CBeE3f3VOHW1aEBc3cvRFSf6FkrweqtxvywK3gI2V+3OPr4kwmRAGXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-expression-evaluator": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-hash-bindings": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-hash-bindings/-/bus-hash-bindings-4.5.0.tgz",
-      "integrity": "sha512-SV1B83AD1ULprq9Xj/DAConubdOkH7ZYWF5MePolYTE1Wx7BMZv1giGVvR56/tA3/37NZzvffZPfqUc6C8Ip0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@rdfjs/types": "*"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-hash-quads": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-hash-quads/-/bus-hash-quads-4.5.0.tgz",
-      "integrity": "sha512-733+aHqi+hnlOY6bKAvy27Py54/IvOeGtehr6De8g6ZswP5UatiL4GURQk+acBK4aYSw9RzeyQhCu/LxO0q//g==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0",
-        "rdf-data-factory": "^1.1.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-http": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-4.5.0.tgz",
-      "integrity": "sha512-wWyPNNOl6shDbtibdBl/pa9OIcoEMemNIo/J4tUViXxYXZ8i1h4FZ6PqaLtAls6O+pV71mR4SKJzKEUuiZiXPg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0",
-        "@jeswr/stream-to-string": "^2.0.0",
-        "is-stream": "^2.0.1",
-        "readable-from-web": "^1.0.0",
-        "readable-stream-node-to-web": "^1.0.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-http-invalidate": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-4.5.0.tgz",
-      "integrity": "sha512-s6BJuWjN4enAqWMk07jVVxCaib9KlMTo/XW+ySM+RAa6KUmiy01ucNcvxaqjrFMdLTAoxl6R+4/XZdTOyH4bJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-init": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-4.5.0.tgz",
-      "integrity": "sha512-9TYFLjirHDt7HPXj3eQW9KX3x5T3mZ1G/EKadL1gQxo0FAqs3y8TdicepCLhk3HY/egidlyv9WQYAPvJ+WAmAg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0",
-        "readable-stream": "^4.5.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-merge-bindings-context": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-merge-bindings-context/-/bus-merge-bindings-context-4.5.0.tgz",
-      "integrity": "sha512-btvNISwnA+e7ZEvgD80yWnUc90obUgCVDPTA0mx2s2gpi3rx8JV3RusC1fjw4R6d5s9xc4kGq0BmEP60w1v82Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-optimize-query-operation": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-4.5.0.tgz",
-      "integrity": "sha512-JMSpmIehaIQKDktrI5JKqxjU7M/4PYIGbuNHMYgcauZ2XxhFCbUhthshT+tY7pknmJg38whr9bK0Ziyw233Nvw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-query-operation": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-4.5.0.tgz",
-      "integrity": "sha512-5sLmlmF+oBmNep0lEQuz9V291ddYSRzFJXT3nF+kswB6SjHj2FzwQZpjDEBkIhNXy3h5JY6J/3BqO20hR/IK2g==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-metadata": "^4.5.0",
-        "@rdfjs/types": "*",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-query-parse": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-parse/-/bus-query-parse-4.5.0.tgz",
-      "integrity": "sha512-Zd5uKEAVmVuAC9RQWg4QfVD8qidg7SqUdLA4lDMp6UfRUv+GyGQzTuGIr9DD3xjnxPfeiaO4t7M1CSaMA0kqhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0",
-        "@rdfjs/types": "*",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-query-process": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-process/-/bus-query-process-4.5.0.tgz",
-      "integrity": "sha512-GYNGP9bjB8UtHCqQ77RPYaR0Kd58brGjSuA1xFxVCm255r6AmM5o0SwG6hydl4I3scdz+E12h938a1YV+LFL1A==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-query-result-serialize": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-result-serialize/-/bus-query-result-serialize-4.5.0.tgz",
-      "integrity": "sha512-KONwhEtNcoiKsVATz9RikdpWSLlKcxII+Bwh8jT9XogWwFXx0oj0WoqTPl97IwtNN2DNvfnzHqZ06v/nsMXBSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-query-source-identify": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-source-identify/-/bus-query-source-identify-4.5.0.tgz",
-      "integrity": "sha512-snauZ+CF/S8NWm/isIk940qy/5RVhPWAvt2D0cmKpCFZOSnOrHe1zh0mX7mQrH/IA2IQmJloXE2rGugbNm22YQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-bindings-factory": "^4.5.0",
-        "@comunica/utils-iterator": "^4.5.0",
-        "@comunica/utils-metadata": "^4.5.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.9.0",
-        "rdf-string": "^1.6.3",
-        "rdf-terms": "^1.11.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-query-source-identify/node_modules/rdf-string": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
-      "integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-rdf-join": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-4.5.0.tgz",
-      "integrity": "sha512-qvasYM2hfF+nEvAi5N/0KZfqFRrPDxu7xU9Tq9XK+14cQRaxGQ/8Xh+cGRTQvNgdXM6zo5MBmtauDsJ0L85msg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-join-entries-sort": "^4.5.0",
-        "@comunica/bus-rdf-join-selectivity": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/mediatortype-join-coefficients": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-iterator": "^4.5.0",
-        "@comunica/utils-metadata": "^4.5.0",
-        "@rdfjs/types": "*"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-rdf-join-entries-sort": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-4.5.0.tgz",
-      "integrity": "sha512-WdAHVpFvDyF3Ale56bxSaAwLhxyE8344B5uOxCGsqrlbh+luVZL4ccyUFPyCyvP24M1YUEyxVzV6hHQu860x8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-rdf-join-selectivity": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-selectivity/-/bus-rdf-join-selectivity-4.5.0.tgz",
-      "integrity": "sha512-QocxGFR0XPoq7CnvGs3cyh3xYnTVwTHTZHkMksO/GJ6WBeAFo9PYaSdusrfShyNHL3SxrfhGO4vqBfNzvtzHLw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0",
-        "@comunica/mediatortype-accuracy": "^4.5.0",
-        "@comunica/types": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-rdf-metadata-accumulate": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-accumulate/-/bus-rdf-metadata-accumulate-4.5.0.tgz",
-      "integrity": "sha512-rnyo4XNGwRiK4tue0i928LgPt0rTuOCILYL4Qvon5Zj4tHQtV9yKinvnR58NnUqjLmjQLEmPrcpgYTZN4KLzjw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-rdf-update-quads": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-4.5.0.tgz",
-      "integrity": "sha512-ZxUzqT+/DSyAMYWP/hSh3VIMErgjrWD73EciNqLg/QL6gjuG3twSbnO9ywSlYe2eKDEu8f4aX8ghGW400gZLPA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/actor-context-preprocess-query-source-skolemize": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/bus-term-comparator-factory": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-term-comparator-factory/-/bus-term-comparator-factory-4.5.0.tgz",
-      "integrity": "sha512-UXqoBtF9uPT6V/uUo8byWOssOtHtc5Azrg2sb9cT8AWH2Salt0c/Hd4vWCM602Z1Hs/LxTSDaGEMdpZJin/7Ng==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-function-factory": "^4.5.0",
-        "@comunica/bus-merge-bindings-context": "^4.5.0",
-        "@comunica/bus-query-operation": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@rdfjs/types": "*"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/config-query-sparql": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/config-query-sparql/-/config-query-sparql-4.4.0.tgz",
-      "integrity": "sha512-ZVK6eqpYLNa3MRLOWjRaudgfSdraJH/oZIkc5S2doJI2ZmnHROqQUtjPs13kwkI3hGZ6MVBtLm55oz+tKj2lKA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/context-entries": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-4.5.0.tgz",
-      "integrity": "sha512-mgeSYFBcpMKLq34COpy129LVHigGUgA1uEI66WXmk3mdmlAKRQNe9D/W2Q924w0FZZmIOpeLMo+s358tFsodow==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@rdfjs/types": "*",
-        "jsonld-context-parser": "^2.2.2",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-4.5.0.tgz",
-      "integrity": "sha512-UFHBboFaY0eESH0H8qJRIRuRfda2QduS886l2sRum/V4qhzJkMpf3zdOoZoBbRDU24PBmliWysi9TEsaPsyRwg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^4.5.0",
-        "immutable": "^5.1.3"
-      },
-      "engines": {
-        "node": ">=14.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/logger-pretty": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-4.5.0.tgz",
-      "integrity": "sha512-4Fs0FCnHWFO1EHmFTNhd92o9WTVIigesu6kuk2DP+Zwvm6HKTqgMqllovyllE0nIVyL+YcWSAPvkUTWmQybFIg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^4.5.0",
-        "object-inspect": "^1.12.2",
-        "process": "^0.11.10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/logger-void": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-4.5.0.tgz",
-      "integrity": "sha512-qvRxSlD65KLLqIkU7zwnJ/uPMmYTlsI9J4gsYgEi8OOss5YuNSChAbbzZwRCNrAZOnRGjyrPfgN/Cd3NuglGew==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/mediator-all": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-4.5.0.tgz",
-      "integrity": "sha512-9qX58JgDaC56at0m3FdyYZhXw7kBUPuXihpwYowBwuopdlh0XioJyT/b3g+DC0/kiuSCcx6NhSAWzfNLAqTL7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/mediator-combine-pipeline": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-4.5.0.tgz",
-      "integrity": "sha512-Z4uLxugl+Ls8oAwD0dAIQg+i1rkiXbpiFLhgv5h6nksnz9q6Nv14xItm6baivxAJ9p8XVHCOwPxW46YJBtWIoQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/mediator-combine-union": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-4.5.0.tgz",
-      "integrity": "sha512-aCoO3CiANssR8PEjad2aNuCcfhKdUFZWplTWq77cVUMVc4nsUWNleeEvN6kfOx51qdT8lFpH3b8X+S7bT8CABg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/mediator-join-coefficients-fixed": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-join-coefficients-fixed/-/mediator-join-coefficients-fixed-4.5.0.tgz",
-      "integrity": "sha512-kSK0i5FPOmeUmg6nJcoqOvRE6aCXFYMzCFPiId/k5cCjvpT4Uaod33xHEQ0TnX52uLdjNENIRjH8z3OsnhSd/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-rdf-join": "^4.5.0",
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/mediatortype-join-coefficients": "^4.5.0",
-        "@comunica/types": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/mediator-number": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-4.5.0.tgz",
-      "integrity": "sha512-fChc4gh+gtwPOS0F5eNeDuU4Kyb2fAuppN28d1/5s+OUr5v+1Wya7yZ1zbPHYxDMWZEpJBR06eX6djcI0gKlkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/mediator-race": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-4.5.0.tgz",
-      "integrity": "sha512-eAWjQolFMOxKoKuUMmcQzxwf/ZL9ooT0/OUWv1vbVfHIQb/eqDs/h8wDqwXMgEiK5dIF9ZQYaRL2vEaLq+U3Ew==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/mediatortype-accuracy": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-accuracy/-/mediatortype-accuracy-4.5.0.tgz",
-      "integrity": "sha512-f6OVVGwzf3udDT6x0oP/k76XqBV8ZJFdo5SYGVBR/ebsG81V6LciAHvo8BrihZXgmpo1KTCbIFbRmN++M8b6Rg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/mediatortype-join-coefficients": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-join-coefficients/-/mediatortype-join-coefficients-4.5.0.tgz",
-      "integrity": "sha512-wLhEdEd7TBF1r5xoShOk42Hh4kH4r7YyoPs4W7k41Q5m5tPdv8iyZojqv/MItDKv7XCiTpZLcIQpfV3RcAewhg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0",
-        "@rdfjs/types": "*"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/mediatortype-time": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-4.5.0.tgz",
-      "integrity": "sha512-HND+om4L0VW3VcQrLHHE4+7Nsg7soC98i7g7UqqzDkJ4fix2FnJs0i9WH4RP+oLcx+bPhBSl5mG1m44A6sV19g==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/core": "^4.5.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/runner": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-4.5.0.tgz",
-      "integrity": "sha512-Xq5HUsuNQ2cKHBqQjJ3Xx1jpcdD9Oi+ef7t6wPeUCR6VzZKCmRNxEcwQ0Cz629KMicrZCyWnIkXoB322GRWMVA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-init": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "componentsjs": "^6.2.0",
-        "process": "^0.11.10"
-      },
-      "bin": {
-        "comunica-compile-config": "bin/compile-config"
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/query-sparql-rdfjs-lite/-/query-sparql-rdfjs-lite-5.2.3.tgz",
+      "integrity": "sha512-uUCu9xzQjzwwHoBB1/G5eIXkuhp4n4XMWiNyFu/QholiJ2gfiz31ozvWevqY1/2pmIboaAVikp3EE5YjPMlAkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-bindings-aggregator-factory-average": "^5.2.3",
+        "@comunica/actor-bindings-aggregator-factory-count": "^5.2.3",
+        "@comunica/actor-bindings-aggregator-factory-group-concat": "^5.2.3",
+        "@comunica/actor-bindings-aggregator-factory-max": "^5.2.3",
+        "@comunica/actor-bindings-aggregator-factory-min": "^5.2.3",
+        "@comunica/actor-bindings-aggregator-factory-sample": "^5.2.3",
+        "@comunica/actor-bindings-aggregator-factory-sum": "^5.2.3",
+        "@comunica/actor-bindings-aggregator-factory-wildcard-count": "^5.2.3",
+        "@comunica/actor-context-preprocess-convert-shortcuts": "^5.2.3",
+        "@comunica/actor-context-preprocess-set-defaults": "^5.2.3",
+        "@comunica/actor-context-preprocess-source-to-destination": "^5.2.3",
+        "@comunica/actor-expression-evaluator-factory-default": "^5.2.3",
+        "@comunica/actor-function-factory-expression-bnode": "^5.2.3",
+        "@comunica/actor-function-factory-expression-bound": "^5.2.3",
+        "@comunica/actor-function-factory-expression-coalesce": "^5.2.3",
+        "@comunica/actor-function-factory-expression-concat": "^5.2.3",
+        "@comunica/actor-function-factory-expression-extensions": "^5.2.3",
+        "@comunica/actor-function-factory-expression-if": "^5.2.3",
+        "@comunica/actor-function-factory-expression-in": "^5.2.3",
+        "@comunica/actor-function-factory-expression-logical-and": "^5.2.3",
+        "@comunica/actor-function-factory-expression-logical-or": "^5.2.3",
+        "@comunica/actor-function-factory-expression-not-in": "^5.2.3",
+        "@comunica/actor-function-factory-expression-same-term": "^5.2.3",
+        "@comunica/actor-function-factory-term-abs": "^5.2.3",
+        "@comunica/actor-function-factory-term-addition": "^5.2.3",
+        "@comunica/actor-function-factory-term-ceil": "^5.2.3",
+        "@comunica/actor-function-factory-term-contains": "^5.2.3",
+        "@comunica/actor-function-factory-term-datatype": "^5.2.3",
+        "@comunica/actor-function-factory-term-day": "^5.2.3",
+        "@comunica/actor-function-factory-term-division": "^5.2.3",
+        "@comunica/actor-function-factory-term-encode-for-uri": "^5.2.3",
+        "@comunica/actor-function-factory-term-equality": "^5.2.3",
+        "@comunica/actor-function-factory-term-floor": "^5.2.3",
+        "@comunica/actor-function-factory-term-greater-than": "^5.2.3",
+        "@comunica/actor-function-factory-term-greater-than-equal": "^5.2.3",
+        "@comunica/actor-function-factory-term-has-lang": "^5.2.3",
+        "@comunica/actor-function-factory-term-has-langdir": "^5.2.3",
+        "@comunica/actor-function-factory-term-hours": "^5.2.3",
+        "@comunica/actor-function-factory-term-inequality": "^5.2.3",
+        "@comunica/actor-function-factory-term-iri": "^5.2.3",
+        "@comunica/actor-function-factory-term-is-blank": "^5.2.3",
+        "@comunica/actor-function-factory-term-is-iri": "^5.2.3",
+        "@comunica/actor-function-factory-term-is-literal": "^5.2.3",
+        "@comunica/actor-function-factory-term-is-numeric": "^5.2.3",
+        "@comunica/actor-function-factory-term-is-triple": "^5.2.3",
+        "@comunica/actor-function-factory-term-lang": "^5.2.3",
+        "@comunica/actor-function-factory-term-langdir": "^5.2.3",
+        "@comunica/actor-function-factory-term-langmatches": "^5.2.3",
+        "@comunica/actor-function-factory-term-lcase": "^5.2.3",
+        "@comunica/actor-function-factory-term-lesser-than": "^5.2.3",
+        "@comunica/actor-function-factory-term-lesser-than-equal": "^5.2.3",
+        "@comunica/actor-function-factory-term-md5": "^5.2.3",
+        "@comunica/actor-function-factory-term-minutes": "^5.2.3",
+        "@comunica/actor-function-factory-term-month": "^5.2.3",
+        "@comunica/actor-function-factory-term-multiplication": "^5.2.3",
+        "@comunica/actor-function-factory-term-not": "^5.2.3",
+        "@comunica/actor-function-factory-term-now": "^5.2.3",
+        "@comunica/actor-function-factory-term-object": "^5.2.3",
+        "@comunica/actor-function-factory-term-predicate": "^5.2.3",
+        "@comunica/actor-function-factory-term-rand": "^5.2.3",
+        "@comunica/actor-function-factory-term-regex": "^5.2.3",
+        "@comunica/actor-function-factory-term-replace": "^5.2.3",
+        "@comunica/actor-function-factory-term-round": "^5.2.3",
+        "@comunica/actor-function-factory-term-seconds": "^5.2.3",
+        "@comunica/actor-function-factory-term-sha1": "^5.2.3",
+        "@comunica/actor-function-factory-term-sha256": "^5.2.3",
+        "@comunica/actor-function-factory-term-sha384": "^5.2.3",
+        "@comunica/actor-function-factory-term-sha512": "^5.2.3",
+        "@comunica/actor-function-factory-term-str": "^5.2.3",
+        "@comunica/actor-function-factory-term-str-after": "^5.2.3",
+        "@comunica/actor-function-factory-term-str-before": "^5.2.3",
+        "@comunica/actor-function-factory-term-str-dt": "^5.2.3",
+        "@comunica/actor-function-factory-term-str-ends": "^5.2.3",
+        "@comunica/actor-function-factory-term-str-lang": "^5.2.3",
+        "@comunica/actor-function-factory-term-str-langdir": "^5.2.3",
+        "@comunica/actor-function-factory-term-str-len": "^5.2.3",
+        "@comunica/actor-function-factory-term-str-starts": "^5.2.3",
+        "@comunica/actor-function-factory-term-str-uuid": "^5.2.3",
+        "@comunica/actor-function-factory-term-sub-str": "^5.2.3",
+        "@comunica/actor-function-factory-term-subject": "^5.2.3",
+        "@comunica/actor-function-factory-term-subtraction": "^5.2.3",
+        "@comunica/actor-function-factory-term-timezone": "^5.2.3",
+        "@comunica/actor-function-factory-term-triple": "^5.2.3",
+        "@comunica/actor-function-factory-term-tz": "^5.2.3",
+        "@comunica/actor-function-factory-term-ucase": "^5.2.3",
+        "@comunica/actor-function-factory-term-unary-minus": "^5.2.3",
+        "@comunica/actor-function-factory-term-unary-plus": "^5.2.3",
+        "@comunica/actor-function-factory-term-uuid": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-boolean": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-date": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-datetime": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-day-time-duration": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-decimal": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-double": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-duration": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-float": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-integer": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-string": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-time": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-year-month-duration": "^5.2.3",
+        "@comunica/actor-function-factory-term-year": "^5.2.3",
+        "@comunica/actor-hash-bindings-murmur": "^5.2.3",
+        "@comunica/actor-hash-quads-murmur": "^5.2.3",
+        "@comunica/actor-init-query": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-assign-sources-exhaustive": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-bgp-to-join": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-construct-distinct": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-describe-to-constructs-subject": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-distinct-terms-pushdown": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-filter-pushdown": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-group-file-sources": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-group-sources": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-join-bgp": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-join-connected": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-prune-empty-source-operations": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-query-source-identify": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-query-source-skolemize": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-rewrite-add": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-rewrite-copy": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-rewrite-move": "^5.2.3",
+        "@comunica/actor-query-operation-ask": "^5.2.3",
+        "@comunica/actor-query-operation-bgp-join": "^5.2.3",
+        "@comunica/actor-query-operation-construct": "^5.2.3",
+        "@comunica/actor-query-operation-distinct-identity": "^5.2.3",
+        "@comunica/actor-query-operation-extend": "^5.2.3",
+        "@comunica/actor-query-operation-filter": "^5.2.3",
+        "@comunica/actor-query-operation-from-quad": "^5.2.3",
+        "@comunica/actor-query-operation-group": "^5.2.3",
+        "@comunica/actor-query-operation-join": "^5.2.3",
+        "@comunica/actor-query-operation-leftjoin": "^5.2.3",
+        "@comunica/actor-query-operation-minus": "^5.2.3",
+        "@comunica/actor-query-operation-nodes": "^5.2.3",
+        "@comunica/actor-query-operation-nop": "^5.2.3",
+        "@comunica/actor-query-operation-orderby": "^5.2.3",
+        "@comunica/actor-query-operation-path-alt": "^5.2.3",
+        "@comunica/actor-query-operation-path-inv": "^5.2.3",
+        "@comunica/actor-query-operation-path-link": "^5.2.3",
+        "@comunica/actor-query-operation-path-nps": "^5.2.3",
+        "@comunica/actor-query-operation-path-one-or-more": "^5.2.3",
+        "@comunica/actor-query-operation-path-seq": "^5.2.3",
+        "@comunica/actor-query-operation-path-zero-or-more": "^5.2.3",
+        "@comunica/actor-query-operation-path-zero-or-one": "^5.2.3",
+        "@comunica/actor-query-operation-project": "^5.2.3",
+        "@comunica/actor-query-operation-reduced-hash": "^5.2.3",
+        "@comunica/actor-query-operation-slice": "^5.2.3",
+        "@comunica/actor-query-operation-source": "^5.2.3",
+        "@comunica/actor-query-operation-union": "^5.2.3",
+        "@comunica/actor-query-operation-update-clear": "^5.2.3",
+        "@comunica/actor-query-operation-update-compositeupdate": "^5.2.3",
+        "@comunica/actor-query-operation-update-create": "^5.2.3",
+        "@comunica/actor-query-operation-update-deleteinsert": "^5.2.3",
+        "@comunica/actor-query-operation-update-drop": "^5.2.3",
+        "@comunica/actor-query-operation-update-load": "^5.2.3",
+        "@comunica/actor-query-operation-values": "^5.2.3",
+        "@comunica/actor-query-parse-sparql": "^5.2.3",
+        "@comunica/actor-query-process-sequential": "^5.2.3",
+        "@comunica/actor-query-source-identify-rdfjs": "^5.2.3",
+        "@comunica/actor-rdf-join-entries-sort-cardinality": "^5.2.3",
+        "@comunica/actor-rdf-join-entries-sort-selectivity": "^5.2.3",
+        "@comunica/actor-rdf-join-inner-hash": "^5.2.3",
+        "@comunica/actor-rdf-join-inner-multi-bind": "^5.2.3",
+        "@comunica/actor-rdf-join-inner-multi-bind-source": "^5.2.3",
+        "@comunica/actor-rdf-join-inner-multi-empty": "^5.2.3",
+        "@comunica/actor-rdf-join-inner-multi-smallest": "^5.2.3",
+        "@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings": "^5.2.3",
+        "@comunica/actor-rdf-join-inner-nestedloop": "^5.2.3",
+        "@comunica/actor-rdf-join-inner-none": "^5.2.3",
+        "@comunica/actor-rdf-join-inner-single": "^5.2.3",
+        "@comunica/actor-rdf-join-inner-symmetrichash": "^5.2.3",
+        "@comunica/actor-rdf-join-minus-hash": "^5.2.3",
+        "@comunica/actor-rdf-join-optional-bind": "^5.2.3",
+        "@comunica/actor-rdf-join-optional-hash": "^5.2.3",
+        "@comunica/actor-rdf-join-optional-nestedloop": "^5.2.3",
+        "@comunica/actor-rdf-join-selectivity-variable-counting": "^5.2.3",
+        "@comunica/actor-rdf-metadata-accumulate-cardinality": "^5.2.3",
+        "@comunica/actor-rdf-metadata-accumulate-pagesize": "^5.2.3",
+        "@comunica/actor-rdf-metadata-accumulate-requesttime": "^5.2.3",
+        "@comunica/actor-rdf-update-quads-rdfjs-store": "^5.2.3",
+        "@comunica/actor-term-comparator-factory-expression-evaluator": "^5.2.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/bus-http-invalidate": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/config-query-sparql": "^5.2.1",
+        "@comunica/core": "^5.2.3",
+        "@comunica/logger-void": "^5.2.3",
+        "@comunica/mediator-all": "^5.2.3",
+        "@comunica/mediator-combine-pipeline": "^5.2.3",
+        "@comunica/mediator-combine-union": "^5.2.3",
+        "@comunica/mediator-join-coefficients-fixed": "^5.2.3",
+        "@comunica/mediator-number": "^5.2.3",
+        "@comunica/mediator-race": "^5.2.3",
+        "@comunica/runner": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/types": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-4.5.0.tgz",
-      "integrity": "sha512-XhnkspVgYilchErpSAELHRA7B4wRszDdvCkhbd52vjLrThzGUDfDoGx+56y4AeziWkxQLNug8AZbo/Q6J2vCzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "@types/yargs": "^17.0.24",
-        "asynciterator": "^3.9.0",
-        "lru-cache": "^10.0.1",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/utils-bindings-factory": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-bindings-factory/-/utils-bindings-factory-4.5.0.tgz",
-      "integrity": "sha512-LxwHMoBn8JqeVoGEZVaOne9iaShHmaDwJaCBJH3cQi224bv81ylmEBJgrxfNJt+FAzwBfsRdO4aR8dRX5l7Pdg==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/bus-merge-bindings-context": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@rdfjs/types": "*",
-        "immutable": "^5.1.3",
-        "rdf-string": "^1.6.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/utils-bindings-factory/node_modules/rdf-string": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
-      "integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/utils-bindings-index": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-bindings-index/-/utils-bindings-index-4.5.0.tgz",
-      "integrity": "sha512-vV+POCwgVxR3DqtlAt/+q1EzTTghCTYMkx2yV0PJYWdrjsu/JEfoS4S7B1zgb0DjUS7zq0aoeB7FShBUWz/fuw==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^4.5.0",
-        "@rdfjs/types": "*"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/utils-data-factory": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-data-factory/-/utils-data-factory-4.0.1.tgz",
-      "integrity": "sha512-6FTyTC0dNgXwnZN4/5QSDsfNT7AhWPJUcE3a9aa78kQodaq3LfQNW4fiG4tC2O4tcbSy4Ds7ZG/cflThCHwa2w==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/utils-expression-evaluator": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-expression-evaluator/-/utils-expression-evaluator-4.5.0.tgz",
-      "integrity": "sha512-i4kek6vg5yx/EqwoEEop7UyNy0aHp7MIMdId98opXa/hU64Z8icIaFD+3+1tv98M1LviuJAIPX6lCJwuB22jqA==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@rdfjs/types": "*",
-        "lru-cache": "^10.0.0",
-        "rdf-data-factory": "^1.1.2",
-        "rdf-string": "^1.6.3",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/utils-expression-evaluator/node_modules/rdf-string": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
-      "integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/utils-iterator": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-iterator/-/utils-iterator-4.5.0.tgz",
-      "integrity": "sha512-Gnn6asz0xILR1f5lQrTjg1BgW5IiSibOETul4iJ+sjYnVncZH1eK5qJNG81f6fX40D3FEHyu+jWQSPNMFqdaoQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynciterator": "^3.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/utils-metadata": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-metadata/-/utils-metadata-4.5.0.tgz",
-      "integrity": "sha512-NmWWz9F558NQXR5UOyAIdhLmi4tBMtI0N3kHee/DsPCFaxn0wjQ/ckZGrTVTGeP+sdYzobaYvGcIPpf8MmPALQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/types": "^4.5.0",
-        "@rdfjs/types": "*",
-        "asynciterator": "^3.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/utils-query-operation": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-query-operation/-/utils-query-operation-4.5.0.tgz",
-      "integrity": "sha512-R5j61Awzyz+p0FbvACSxh8GuZ4IiBt824UfNZpgDipwzX0JnSaKP5yFKL2dcmb9LlElN8wmDjzy4o512HLK67w==",
-      "license": "MIT",
-      "dependencies": {
-        "@comunica/context-entries": "^4.5.0",
-        "@comunica/core": "^4.5.0",
-        "@comunica/types": "^4.5.0",
-        "@comunica/utils-bindings-factory": "^4.5.0",
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.2",
-        "rdf-string": "^1.6.1",
-        "rdf-terms": "^1.11.0",
-        "sparqlalgebrajs": "^5.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/comunica-association"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/@comunica/utils-query-operation/node_modules/rdf-string": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
-      "integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/bignumber.js": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/rdf-literal": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/rdf-literal/-/rdf-literal-1.3.2.tgz",
-      "integrity": "sha512-79Stlu3sXy0kq9/decHFLf3xNPuY6sfhFPhd/diWErgaFr0Ekyg38Vh9bnVcqDYu48CFRi0t+hrFii49n92Hbw==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/rdf-quad": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/rdf-quad/-/rdf-quad-1.5.0.tgz",
-      "integrity": "sha512-LnCYx8XbRVW1wr6UiZPSy2Tv7bXAtEwuyck/68dANhFu8VMnGS+QfUNP3b9YI6p4Bfd/fyDx5E3x81IxGV6BzA==",
-      "license": "MIT",
-      "dependencies": {
-        "rdf-data-factory": "^1.0.1",
-        "rdf-literal": "^1.2.0",
-        "rdf-string": "^1.5.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/rdf-quad/node_modules/rdf-string": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
-      "integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/rdf-terms": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.11.0.tgz",
-      "integrity": "sha512-iKlVgnMopRKl9pHVNrQrax7PtZKRCT/uJIgYqvuw1VVQb88zDvurtDr1xp0rt7N9JtKtFwUXoIQoEsjyRo20qQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-string": "^1.6.0"
-      }
-    },
-    "node_modules/@comunica/query-sparql-rdfjs-lite/node_modules/rdf-terms/node_modules/rdf-string": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
-      "integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@rdfjs/types": "*",
-        "rdf-data-factory": "^1.1.0"
       }
     },
     "node_modules/@comunica/runner": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-5.2.2.tgz",
-      "integrity": "sha512-tlJqvg8dHpS11GyAhD0tO/z8bLfrLEooKSZLo1iq1E2jmNxEFEknlyFT4fs92Z7Nc7+zxhBgMJynZp9Mtv8CPw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-5.2.3.tgz",
+      "integrity": "sha512-EVkGef4gP4cue+irSFHHv6jfa9mSKOykf18iwtSiKKs35a0Kft9/v2xvty+TFlKEqMjA9Ha2wU3r4nNAaWWusQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-init": "^5.2.2",
-        "@comunica/core": "^5.2.2",
+        "@comunica/bus-init": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "componentsjs": "^6.2.0",
         "process": "^0.11.10"
       },
@@ -9387,9 +5998,9 @@
       }
     },
     "node_modules/@comunica/types": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-5.2.0.tgz",
-      "integrity": "sha512-KVDvDkAZfvXk6ymtEbS+49k39Yc1S5xIVBL+XLkn482ngvlMAyX/wMSKOa7OIAn1cSTaAoh6OiFhb1oSEnEUXQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-5.2.3.tgz",
+      "integrity": "sha512-/28Wr3OZEgNlLcdJ5IRnrambic7iYmrrm9eO2NqF2Vo8rDokSdrAwzEVr29peWwW/0gbLmGerclSxFj7lPI4mA==",
       "license": "MIT",
       "dependencies": {
         "@comunica/utils-algebra": "^5.2.0",
@@ -9420,14 +6031,14 @@
       }
     },
     "node_modules/@comunica/utils-bindings-factory": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-bindings-factory/-/utils-bindings-factory-5.2.2.tgz",
-      "integrity": "sha512-KMmCCe5IND5czW+XKw5o2S69ayfGsOwyJHYyXDPzWaw6A5TT57mRxublhyww6PAk346JQrh8+1hiZFDV2eHtcg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-bindings-factory/-/utils-bindings-factory-5.2.3.tgz",
+      "integrity": "sha512-kf7LPEokpKfMQzkggWsCyvuo8qDDig04ybqVtFl6KBKnoC8qYBKLsoNB7sfQaSdKeAxaIktRvKoNrEAJ+WRc7w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-merge-bindings-context": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*",
         "immutable": "^5.1.3",
         "rdf-string": "^2.0.1"
@@ -9438,12 +6049,12 @@
       }
     },
     "node_modules/@comunica/utils-bindings-index": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-bindings-index/-/utils-bindings-index-5.2.0.tgz",
-      "integrity": "sha512-ncTac3PuDDXk8X+4bKExLva25ce+/CkapwcbMzJyAUO3/MpYaOq0UGHBm2cdIwjNHl2TFhUL5GOaATIKlfUpiw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-bindings-index/-/utils-bindings-index-5.2.3.tgz",
+      "integrity": "sha512-sZmHPX20E4nuf5JqWsnOre0n8CJE3iFotZnvfq9Zj34LKaStUUB5M1vtiUM9JgN+gPk2sc0pFGVXNsNjveliiA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/types": "^5.2.0",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -9465,13 +6076,13 @@
       }
     },
     "node_modules/@comunica/utils-expression-evaluator": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-expression-evaluator/-/utils-expression-evaluator-5.2.2.tgz",
-      "integrity": "sha512-gbASzAlG0DLpDJ45AevU1lzehsaWh+yayzjYrbsohKZDG/in1cqd2jZXsNqt7TvLL62g8u61BdojCYJx7lNTEA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-expression-evaluator/-/utils-expression-evaluator-5.2.3.tgz",
+      "integrity": "sha512-u9SjaBIuhUSLthfjRSL+Utsf0EtfUWRZbCI3gOC6RJ8lXUVRSjKKSJZsgvnWSbkoROHczKI9dJPFe4iusO6sYg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
         "@rdfjs/types": "*",
         "lru-cache": "^11.2.2",
@@ -9510,12 +6121,12 @@
       }
     },
     "node_modules/@comunica/utils-metadata": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-metadata/-/utils-metadata-5.2.0.tgz",
-      "integrity": "sha512-O9++P9VI3Z2NFK1u6JFOC0yPLvKEyrgOlsR9UTBhjpcgvf27UWLQGmGIoT5mbtU/L20RfL8mYdtpDM3qlrIWnQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-metadata/-/utils-metadata-5.2.3.tgz",
+      "integrity": "sha512-2CvKcXI/V/jvRrWnjXa/JF9gsToPtl0l7ISVQeGYYqWfj+9mJwF8qDxo8f0XBb6ihSeu/MF+AHrfZLNNnZnZag==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/types": "^5.2.0",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0"
       },
@@ -9525,16 +6136,16 @@
       }
     },
     "node_modules/@comunica/utils-query-operation": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-query-operation/-/utils-query-operation-5.2.2.tgz",
-      "integrity": "sha512-Nl5QoPWN6B2V5Vnh/lFkY8hz/HGevBWdTiTotSnlGTYQIL4CJ9E1XbfGBhR0M1t1Izty8KIZvAq7N61gCbBZtQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-query-operation/-/utils-query-operation-5.2.3.tgz",
+      "integrity": "sha512-uzZvBeUEvfOWVqzleHzQ8Ruo+Byrmo6pF52UeI7DHFGNSDxCIfyD3flXNbKki2jg4a+s2E3JoY07fSxgi2N11w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/context-entries": "^5.2.2",
-        "@comunica/core": "^5.2.2",
-        "@comunica/types": "^5.2.0",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-algebra": "^5.2.0",
-        "@comunica/utils-bindings-factory": "^5.2.2",
+        "@comunica/utils-bindings-factory": "^5.2.3",
         "@rdfjs/types": "*",
         "rdf-data-factory": "^2.0.0",
         "rdf-string": "^2.0.1",
@@ -9589,6 +6200,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -9849,6 +6494,13 @@
       "dependencies": {
         "event-emitter-promisify": "^1.1.0"
       }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@js-sdsl/ordered-map": {
       "version": "4.4.2",
@@ -10184,6 +6836,25 @@
         "node": ">=18"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@netwerk-digitaal-erfgoed/network-of-terms-catalog": {
       "version": "10.19.22",
       "resolved": "https://registry.npmjs.org/@netwerk-digitaal-erfgoed/network-of-terms-catalog/-/network-of-terms-catalog-10.19.22.tgz",
@@ -10471,6 +7142,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@pinojs/redact": {
@@ -10798,6 +7479,288 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rubensworks/saxes": {
       "version": "6.0.1",
       "license": "ISC",
@@ -10875,7 +7838,9 @@
       }
     },
     "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@traqula/algebra-sparql-1-1": {
@@ -11071,12 +8036,41 @@
         "@ts-jison/lexer": "^0.4.1-alpha.1"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/concat-stream": {
       "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -11442,6 +8436,119 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@zazuko/prefixes": {
       "version": "2.6.1",
       "license": "MIT"
@@ -11544,6 +8651,16 @@
       "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async": {
@@ -11783,6 +8900,16 @@
     "node_modules/caseless": {
       "version": "0.12.0",
       "license": "Apache-2.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "5.6.2",
@@ -12726,6 +9853,13 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "license": "MIT"
@@ -12809,6 +9943,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/docker-modem": {
@@ -13022,6 +10166,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -13397,6 +10548,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "dev": true,
@@ -13445,6 +10606,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -14713,6 +11884,279 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "dev": true,
@@ -14792,6 +12236,16 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/map-stream": {
@@ -14975,6 +12429,25 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "dev": true,
@@ -15089,6 +12562,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
@@ -15301,6 +12785,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pause-stream": {
       "version": "0.0.11",
       "dev": true,
@@ -15317,6 +12808,13 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
@@ -15360,6 +12858,35 @@
     "node_modules/pino-std-serializers": {
       "version": "7.1.0",
       "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -16199,6 +13726,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.132.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.2",
+        "@rolldown/binding-darwin-arm64": "1.0.2",
+        "@rolldown/binding-darwin-x64": "1.0.2",
+        "@rolldown/binding-freebsd-x64": "1.0.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+        "@rolldown/binding-linux-arm64-musl": "1.0.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-musl": "1.0.2",
+        "@rolldown/binding-openharmony-arm64": "1.0.2",
+        "@rolldown/binding-wasm32-wasi": "1.0.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+        "@rolldown/binding-win32-x64-msvc": "1.0.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -16274,6 +13835,2691 @@
         "readable-stream": "^4.5.1"
       }
     },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-abstract-mediatyped": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-4.5.0.tgz",
+      "integrity": "sha512-KbLuhbTcfAQHJeLo3CDDdffCZdfA1qDu15XIdW+7P03UpUp9xMw4p1G0kYtoXwj9KzWguY704TUtpJVBO1GOnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-abstract-path": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-4.5.0.tgz",
+      "integrity": "sha512-oBm9rqCCNErmn570UjhMKa4XSM4NxQ/HtgGw7P0HTR0jx/LBg5ctkmsp0ewSJSx+OVf2fU4S7hodZgsS7jypLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "rdf-string": "^1.6.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-bindings-aggregator-factory-average": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-average/-/actor-bindings-aggregator-factory-average-4.5.0.tgz",
+      "integrity": "sha512-QQIVsCMzi+AvaTDegSZVcc2wjBszFAVayUfNEe/OW6xvXMXKmLiEdA+5q5MSJYcfDIciwR0FR3mTFJx34GgSGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-bindings-aggregator-factory-count": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-count/-/actor-bindings-aggregator-factory-count-4.5.0.tgz",
+      "integrity": "sha512-BExT1O1b0oP3DVjArcFPLTjFyycShz3ineh7G4ccZ2D+h1xo3dWbCcCNvnOTBnP6XBRtvpgfHLqz2i9C/Hs8SA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^5.0.2"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-bindings-aggregator-factory-group-concat": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-group-concat/-/actor-bindings-aggregator-factory-group-concat-4.5.0.tgz",
+      "integrity": "sha512-Gpm2uLDc7mCiE0xt1KX/bKVRXXGNyclq/jJ3zKx+QPftB4z8IFvsTUzt4WuimBYawU0OvM6CUlr6Y3pdY6k4qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-bindings-aggregator-factory-max": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-max/-/actor-bindings-aggregator-factory-max-4.5.0.tgz",
+      "integrity": "sha512-iJZ/NF8s5UhokHIVOCk4fuu8glWH354Oyg2p/VvtBMAXu3x/U3M5EAofsoIGCjwkqcOrknVqG1VGywHgglIAuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-bindings-aggregator-factory-min": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-min/-/actor-bindings-aggregator-factory-min-4.5.0.tgz",
+      "integrity": "sha512-dHkJvOrTr8fLpu0d1HLsssZQov0PdKlFgZczl5gZ/gpTvKUnpaMcI7uSi/FWkbEyZFtJH+mw2Vb9BmVuSnmzkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-bindings-aggregator-factory-sample": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-sample/-/actor-bindings-aggregator-factory-sample-4.5.0.tgz",
+      "integrity": "sha512-4IK9MjfLX0pzB74XxqmSJJIySjB0xr4nId96DkRYrJVvFz7PGdZL5ovr7WJEHrCaFZONUQCcJJdTIMxcazfY/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-bindings-aggregator-factory-sum": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-sum/-/actor-bindings-aggregator-factory-sum-4.5.0.tgz",
+      "integrity": "sha512-uw3s58igOuHAFLLXr5mS9nVFfA5V5fWxeyln2o/ggipLyDOVKCtkm0GHtx5oZTBNSdyrN2s7SrATdL9ouLbJMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-bindings-aggregator-factory-wildcard-count": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-wildcard-count/-/actor-bindings-aggregator-factory-wildcard-count-4.5.0.tgz",
+      "integrity": "sha512-2D+uykC2LmwmgjQnDaGM5dOJf7CIAetRHUlL29P6WA5J3iWVuRZurIVajexvi7yufk+emajuTGnGuZIeB00SnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@rdfjs/types": "*",
+        "rdf-string": "^1.6.3"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-context-preprocess-convert-shortcuts": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-convert-shortcuts/-/actor-context-preprocess-convert-shortcuts-4.5.0.tgz",
+      "integrity": "sha512-Uu2buxdBxq/0u6Pr/An4FDdafH1bvDCdImeEBBIVfleeYuUNR4klbXZS0M7YxTpYanpNOw9v/i6nHIfNMgFT7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-context-preprocess": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-context-preprocess-set-defaults": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-set-defaults/-/actor-context-preprocess-set-defaults-4.5.0.tgz",
+      "integrity": "sha512-xEm7KPg9G6IcciLbZ2tJ0v6vrluuy/fCZN2wCOYQ1ba6bgxZm/C15kFTwjm4YSsDhtQDADteiQZa+kzkBkuudQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-context-preprocess": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-context-preprocess-source-to-destination": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-4.5.0.tgz",
+      "integrity": "sha512-ndpws/8GzO8CsOuqYS4f4IJ5DXNaCGjp7LXcabeAGobY8F5B3eQ8zWKHjC3jZEaTt89rCiMzkudY2sNWGM0ZbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-context-preprocess": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-expression-evaluator-factory-default": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-expression-evaluator-factory-default/-/actor-expression-evaluator-factory-default-4.5.0.tgz",
+      "integrity": "sha512-1vXRPmcRBTwowYu9FAjEiHeaQv3m2rzhB2jqh/USoPFm0Zn4oR5Xdclyv3WfuhNJRaJWi2uB6P5ddRzimTuTCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-expression-evaluator-factory": "^4.5.0",
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^5.0.2"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-expression-bnode": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-bnode/-/actor-function-factory-expression-bnode-4.5.0.tgz",
+      "integrity": "sha512-wIj6ertjQBSSiV6Kbk0h6AuxjQe/IUVJGGBuZRu+VvCdGTX+I/rY00/LdUzzbdMFJgamEwK5ML/Bwu2tZUFN3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-data-factory": "^4.0.1",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-expression-bound": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-bound/-/actor-function-factory-expression-bound-4.5.0.tgz",
+      "integrity": "sha512-aClq0SWhyhL3G9HRlri0yyyVcb/gCdexXi3HHiWhI9udBK+oAZeOR/lM49i7/twS5ujPHE/CzbL6C0gtosZzvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-expression-coalesce": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-coalesce/-/actor-function-factory-expression-coalesce-4.5.0.tgz",
+      "integrity": "sha512-xD8oGIsKkzaEvzb7j2HMXzJfRi1onRCaUXRmVVWhf2sWA2YIoQWoG3nHMOAucMseo2FDcY+vYN2pIiSts+C2ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-expression-concat": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-concat/-/actor-function-factory-expression-concat-4.5.0.tgz",
+      "integrity": "sha512-zaNB23vpQkr+49MfBr2fnjahVEb0jTzUjOKO1Hxrb8geocB0coHAhQljejghATCRwnnsnWwcCeOvVE0bjCoU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-expression-extensions": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-extensions/-/actor-function-factory-expression-extensions-4.5.0.tgz",
+      "integrity": "sha512-wCF5jGU/MtTCL3vO0jImgwzthKDqSjJP8D+kK3Y9Sj4j6xumaF+cttj5EoflzK68uvkhhuMLsZY0PKLGkAnvXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "rdf-data-factory": "^1.1.2"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-expression-if": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-if/-/actor-function-factory-expression-if-4.5.0.tgz",
+      "integrity": "sha512-1nE7bXcMVcesnaMABAX7LKKc8PVNeIrg/TJ+LkbZ4LyV4GjUu0zQspuFRFFp/HMfpYOfO1pmhP3Y+kdVkRuFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-expression-in": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-in/-/actor-function-factory-expression-in-4.5.0.tgz",
+      "integrity": "sha512-ubIy7q0VmO8f/ffuXWPkhjKSI7+r1toltgGonunb9VJVmNe7IbpMKIdSiw0PtAyeZMavp/f5d7uIjYfgYbCsbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-expression-logical-and": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-logical-and/-/actor-function-factory-expression-logical-and-4.5.0.tgz",
+      "integrity": "sha512-8Eawz0jPMmP7JFuhtEPwuSBw3hIVpscAuM/RUTOBfsgecjRZTQGMsRJ7LoDgLJVNlevbXoxtzBjL9COjUFBJ1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-expression-logical-or": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-logical-or/-/actor-function-factory-expression-logical-or-4.5.0.tgz",
+      "integrity": "sha512-SMJrSpbmOpP1DaHurnM5qm7oWk+dDNaoQZh+8dDCdxz9shSV7eOO7jhjWKhcuZsW6E94G6JSZFZZJkxtmKMrsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-expression-not-in": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-not-in/-/actor-function-factory-expression-not-in-4.5.0.tgz",
+      "integrity": "sha512-FIJGyTDCXLkz7OmBCB8ed/cCqK2QSmGtwNn/rFh6q9UBrks7A6BzZAH5H/32q6ndcMJwx+6DYb2aQMPlScgRkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-expression-same-term": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-same-term/-/actor-function-factory-expression-same-term-4.5.0.tgz",
+      "integrity": "sha512-uJxyZl9FXFFXN1Be90cPBLSJqXSVSYxVZ9j+rR4A1I47dc+TfAS/jWkoBsxLCtox3igm6ZkPzmMB066rHN/K5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-abs": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-abs/-/actor-function-factory-term-abs-4.5.0.tgz",
+      "integrity": "sha512-bqupPX30zWCJ0nirI3XkO9uzIuUSnw4jaWNQpI4rHXGdMLrjUNrokBXIZ4FfSXAaAnQOUb771st/XrNbEDJ+gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-addition": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-addition/-/actor-function-factory-term-addition-4.5.0.tgz",
+      "integrity": "sha512-pqJIeZFvCas3r4PFy4tGdXFiYR9ds99G87rytAWQkVnoBstOUFKXmc6Oq8dwoKCfAnZdfi/GH++Al8buu2I2Cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "bignumber.js": "^9.1.2"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-ceil": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-ceil/-/actor-function-factory-term-ceil-4.5.0.tgz",
+      "integrity": "sha512-Gape3scVRZgvY4DKGSFH5PSRB1TgnpcRJRWiGy9abvP1QXye3Ob4NIqEyO4iwPLd6U7zf3nyHYAec+4MgQp0nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-contains": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-contains/-/actor-function-factory-term-contains-4.5.0.tgz",
+      "integrity": "sha512-qUv31t9RJ+n0OaMcQBLLruTj3u8BdWj69Fq/tF01E8vRkaZgNf0WkAVfkJRRaYQxr4fpMtgWxzSCZ3VSaiXFUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-datatype": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-datatype/-/actor-function-factory-term-datatype-4.5.0.tgz",
+      "integrity": "sha512-mjucrTW+MJoyCOsvxKJUBqawbNsSacVCvkazKscEBdk1Gj/b75xWUEi7cJHCd1cD1ESHn4EA5PEqhYXUyDsxzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-day": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-day/-/actor-function-factory-term-day-4.5.0.tgz",
+      "integrity": "sha512-B2f3MniYbd7WR7vo8MJzO9jSBIeVOtXotpg9Mxo73Vyhknh7w6td95MpVxPJT8BXFVzFrkAh/OmU9nDcgcdB+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-division": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-division/-/actor-function-factory-term-division-4.5.0.tgz",
+      "integrity": "sha512-IJ/5INqBDXkxuvESllxYNE7Ted/Y6lRQPDvzu1HDw3T+hj/KtBINEr7zPh9yLuapuTCzapygd+kIGVaoemoSJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "bignumber.js": "^9.1.2"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-encode-for-uri": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-encode-for-uri/-/actor-function-factory-term-encode-for-uri-4.5.0.tgz",
+      "integrity": "sha512-3/8YNcg2gqG/Hc/0e24jTwepJqfU2mqhUG55kXNy5J3hKOyYza1wbNhBQUAQVFQcdpwKA/bzpb/YHwSov429Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-equality": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-equality/-/actor-function-factory-term-equality-4.5.0.tgz",
+      "integrity": "sha512-1q0L42931jvjv1b92nc18B/WAomYYEacg1gFJpUSsfqhGGAulA42+fTR2ngRDT0sQw/J1kT1WgY3fY1rHNADIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-floor": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-floor/-/actor-function-factory-term-floor-4.5.0.tgz",
+      "integrity": "sha512-E4jxcs8M5wLZbPdzlmOuoIAwNtTzu5oVzH3gnZnE9iBE0pfSrN6N6g0sRY7vFXKfMgJQqVMlPiFt+Cda7ZcPHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-greater-than": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-greater-than/-/actor-function-factory-term-greater-than-4.5.0.tgz",
+      "integrity": "sha512-4WcYnNaXX6d0gXHHChW7QwmG4Ywq7CRihYC4AAkIqP9e9TX+lqz7cXaMMyGICh0uHY4JwAg33i3Pxv54TdwCog==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-greater-than-equal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-greater-than-equal/-/actor-function-factory-term-greater-than-equal-4.5.0.tgz",
+      "integrity": "sha512-vziCkcJNQedtqHC5kxvDMlvkJ+uJzO520q/4QjMMsftxyvDfpbWfX3VKQitJdRlvnAcmdZpWKb8ylltbZ/aT/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-hours": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-hours/-/actor-function-factory-term-hours-4.5.0.tgz",
+      "integrity": "sha512-0GkHX9KnU1N+lHzgmGLKndt8QX+8o5Mb5I+QIZWHgm7tkGHIGOQWtN0eBWhiVnzV8MBz471vyAVPHYB/OKsi5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-inequality": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-inequality/-/actor-function-factory-term-inequality-4.5.0.tgz",
+      "integrity": "sha512-p89dQB30AZsuFnJhFzGczz72wTIsR3nQzROP8NMwDpyic5xMrKEw1QljK+leWugrhlCprBuMQTpWWAFGe9EVfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-iri": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-iri/-/actor-function-factory-term-iri-4.5.0.tgz",
+      "integrity": "sha512-LZ3HHdBiWOmNnulKdu+7XhcJQyysRGwtBvIkW6WFnIvQpapeHC/KZO1gD2gevUDo/VJ3l5Rg6bcPY+InVnPDug==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "relative-to-absolute-iri": "^1.0.7"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-is-blank": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-blank/-/actor-function-factory-term-is-blank-4.5.0.tgz",
+      "integrity": "sha512-hUlXgv+gJn7XyZQn9KPpi9R4ss+cFSMWxVvp02ZsmTZ8FKHYYkVP7CyGT1DqkBi17AjLlB4OcotjxY9qu43bTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-is-iri": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-iri/-/actor-function-factory-term-is-iri-4.5.0.tgz",
+      "integrity": "sha512-OzTNf4Lq+80x4M4rhHrptjJTpdu7Icl2Sk+K8B9v1adAPvinHoOEgiT1leRVqExccSstdtyOwBYCCBsJ/fhXtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-is-literal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-literal/-/actor-function-factory-term-is-literal-4.5.0.tgz",
+      "integrity": "sha512-SagBQvOMHm8BiXLoCM2fhHerDXYlfwgnnWUiVbK3M1y9SDvynItc/Wa/BpDbimS/EMmkJxIGjnVDAEQryX7TMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-is-numeric": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-numeric/-/actor-function-factory-term-is-numeric-4.5.0.tgz",
+      "integrity": "sha512-aqt73wM21ROHUgXsMZKFiJX2johJ7j1SUvnPfdCIIeUYTuxCKSjVR6sXNLH7F+u5kcXGS5hJwaYIvl//u3DqMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-is-triple": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-triple/-/actor-function-factory-term-is-triple-4.5.0.tgz",
+      "integrity": "sha512-0P9zR8o3/zsMYjmPvzX84dHKkQz2ZP5pjfactN57oo+SE5wCX9sb4w4WwN9DZwFifjqzxX3EMMBQR5dR1A7sBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-lang": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lang/-/actor-function-factory-term-lang-4.5.0.tgz",
+      "integrity": "sha512-sS574SUxEtR8WTfM1U9QavjC6+SCRxbgEM9uKxVe7sTu73bs4a+UGM5xSm4GBRSKMi574xcSGDBRF8lZua44sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-langmatches": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-langmatches/-/actor-function-factory-term-langmatches-4.5.0.tgz",
+      "integrity": "sha512-VKX0DPiM70rXvtlHGBAiqWtRQbL7X8417+amOr7FV7SicC3vZhlRxQoO8VWMMRPtkJWDVbbzt6DQAMIzVt4JBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-lcase": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lcase/-/actor-function-factory-term-lcase-4.5.0.tgz",
+      "integrity": "sha512-AY8HhhGG7zJayAvRtxq/O31Yzz23lCf5P4Z2vjesEP1c0+fOFQJ7Dc6UkoxYHLmvXLtWHTEyNAv8khtEBTfEMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-lesser-than": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lesser-than/-/actor-function-factory-term-lesser-than-4.5.0.tgz",
+      "integrity": "sha512-K423u2M02PQxhfbc8O5mUGfYVwFft4IWgIYmIMs2e0KQc8JPHt8ba665ZWoSykkzTyIoR0bffXx83mjwdMa5mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-lesser-than-equal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lesser-than-equal/-/actor-function-factory-term-lesser-than-equal-4.5.0.tgz",
+      "integrity": "sha512-uFT9J4fVwZN6JcCnZrCkWXWkUddrp6amu9gGJrwkV++7pS/CjsDDAXuxYwQqtn+RsOZrsc6kvEX9vptJqdqRag==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-md5": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-md5/-/actor-function-factory-term-md5-4.5.0.tgz",
+      "integrity": "sha512-gzRiaYDyr1+ecJMGteO8/CSylhvRpgLpKBj4pMh4XOe1REpb9ld7rR8Lm3LzSVczr+DMabbXcPwInF77hf+drQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@types/spark-md5": "^3.0.1",
+        "spark-md5": "^3.0.1"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-minutes": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-minutes/-/actor-function-factory-term-minutes-4.5.0.tgz",
+      "integrity": "sha512-PJPr11nOfjPu7JiFZPwsAYNDlKP2dVcjPqmyMVYg0phnPS5QMqZqclAKPjZgK/A6ipWyLly5j9+uB1NiPoAaPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-month": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-month/-/actor-function-factory-term-month-4.5.0.tgz",
+      "integrity": "sha512-6HFV7p5rRSg8ZEKeAMeY2rpvO+MBI1aEnWkkm8Eb0n9Y9MID8RBDEoWjtim94L430xN+fzbVf2lnKEK0gG/k5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-multiplication": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-multiplication/-/actor-function-factory-term-multiplication-4.5.0.tgz",
+      "integrity": "sha512-cfSOAl8sKhkuJXRpIgz4Avm9ImjP074D3sjVNkptxoJsk+lMI21tbiaa7Kp6b88RV8xlHSMrzzaViX0SWD/rrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "bignumber.js": "^9.1.2"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-not": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-not/-/actor-function-factory-term-not-4.5.0.tgz",
+      "integrity": "sha512-W9Ux+wt2UnjHJVxyLIprGNCWiPJEGSxKBvldRZq4Yaf3O3ZsAShAP5wLzp4+jyI8IX4IFcEaERg1Mek5trl52A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-now": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-now/-/actor-function-factory-term-now-4.5.0.tgz",
+      "integrity": "sha512-bTnQUTg6tNO2orVMVCwMm+qhP61ye91Deabb5HNiDOaE9s5WVNbyyiWxVRmNx0TobPfveiNE4yRuYpHJNbMRgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-object": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-object/-/actor-function-factory-term-object-4.5.0.tgz",
+      "integrity": "sha512-AkFP8DgitOm94NygOc63Ow10kfU8HgcV0ndUOjwkanBXDsoErwd/cZTu5FSEYUP4XedV+RC7qVKp40m51ENggw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-predicate": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-predicate/-/actor-function-factory-term-predicate-4.5.0.tgz",
+      "integrity": "sha512-ceMRBdVHXwWkwZXhE8LgnzacHy6gnzLp95JW1nnEf9Q+/ADE8tpx5OGE+W1tFrCAJbvfkVCRldz6qOXNCqhTEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-rand": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-rand/-/actor-function-factory-term-rand-4.5.0.tgz",
+      "integrity": "sha512-5ORuC18AVkWtvWYjbFpFtB9Noxcw+rg9EI8KVYmN9oE4zW2s/SV8lz4Ybu4tWU9/IvQmyRSv1gr4MZ1OS+DMxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-regex": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-regex/-/actor-function-factory-term-regex-4.5.0.tgz",
+      "integrity": "sha512-HpUlfaDfOJ4PmaJGr4gUE2cpbFG31wcq9E0DNlDi6OlmMyTv1dYBOA0chiC/3bPUJ4JYADpgePu7kruNtEhgwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-replace": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-replace/-/actor-function-factory-term-replace-4.5.0.tgz",
+      "integrity": "sha512-eK/u8+MUB9miUlbH3ZpzQrLFdiXEZSLszOioumGyMSJSbBlASJs1CekKQ90Ed6o3X1vZ/hVlEW0gJNzW/1TkbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-function-factory-term-regex": "^4.5.0",
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-round": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-round/-/actor-function-factory-term-round-4.5.0.tgz",
+      "integrity": "sha512-6VWjonN/WZiBpxSOKI4NVvOs0H/O4+zTuhv4JtWwHjyKLkT/nhbNi0UtU/bnMKEsuFH0tSdNMJxfbOXaFzqgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-seconds": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-seconds/-/actor-function-factory-term-seconds-4.5.0.tgz",
+      "integrity": "sha512-kR1W9A3rZCnpgE75itDFVuZxejBKVOOxX0j1rVP96/Y1Fmsovm9sPo4pbTFTMTROuesICAWux7TP1N5avBWFaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-sha1": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha1/-/actor-function-factory-term-sha1-4.5.0.tgz",
+      "integrity": "sha512-ydGrQVq46uCHAWYUpA2cKGtYvITxl5MsWlqRnxlfnDHgZZI2SCP+ck+im6xBEvIHpMX9PnOQBWoEe1qAJ5NW8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "hash.js": "^1.1.7"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-sha256": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha256/-/actor-function-factory-term-sha256-4.5.0.tgz",
+      "integrity": "sha512-1fOo26Gc5oBEEJypbashF2KolrQfV7Z8OS6d1/sNA8NA05u1R49OWza3p3w91PAIOToGI5QiiIIgCn1bzpUwmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "hash.js": "^1.1.7"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-sha384": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha384/-/actor-function-factory-term-sha384-4.5.0.tgz",
+      "integrity": "sha512-2n9XIEU3ZjqWOeJHqzMziJdLouz57BXyGKUV44buOM/m9zZjkuO0oP+VI44YxcltUvxzwZnkZE9HpUDz3IgdBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "hash.js": "^1.1.7"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-sha512": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha512/-/actor-function-factory-term-sha512-4.5.0.tgz",
+      "integrity": "sha512-60pOulMI8QmW2KWNfOcfC3LdeqG9RnqMMBV/UGbdDSvQpTWQDxfeGj/qujCTNQz604+NCe9FGn2lz06YIFY2aw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "hash.js": "^1.1.7"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-str": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str/-/actor-function-factory-term-str-4.5.0.tgz",
+      "integrity": "sha512-E1vrSf+tIL2GX09+ohqY9rjLidFmN33UnarWWOxxkLJCNt6biKBHR/D2eA8r4yADVSn5Ir6DBplns+xZcPE0jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-str-after": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-after/-/actor-function-factory-term-str-after-4.5.0.tgz",
+      "integrity": "sha512-JnrkLjqr31cF3Cw/ojAcnw0MZrZsLFZR7P6wlWo39DOIYPAvP2ztzaJZYlIeYIJn4+BIqiA5wrOBGGrDhLnwzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-str-before": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-before/-/actor-function-factory-term-str-before-4.5.0.tgz",
+      "integrity": "sha512-Usdx/eZBwzMqVz9EFNFivQDL5s+fS6GkQ6aDL7RunGI0eRaLKYpk2lhCULuauQVgdpg3BniMVW6gnwAqgcoJZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-str-dt": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-dt/-/actor-function-factory-term-str-dt-4.5.0.tgz",
+      "integrity": "sha512-X+hIJ3RgtEnfvYsxVqk1KDanGI6wN/1Y7HVM7TU+ErtXq1zLLA7V44F0kL4l8eH94BHnXONUL2IvBjTcNx3ocA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-str-ends": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-ends/-/actor-function-factory-term-str-ends-4.5.0.tgz",
+      "integrity": "sha512-yH54gsUdIXEEgLL1Q0TF8GXM2l27//TipImXk825yBzpSF+MvS4QlrRQ9lAfJjUFeHrUvqLYrC8mLCtnsbHhdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-str-lang": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-lang/-/actor-function-factory-term-str-lang-4.5.0.tgz",
+      "integrity": "sha512-uupsgyA4NjzO7wYsswfuoSVEqtFJreRk02zjggcISUi7TXfDBKiqyzDELNveiSVK7gDUk4vzbbFuVnT35/fJPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-str-len": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-len/-/actor-function-factory-term-str-len-4.5.0.tgz",
+      "integrity": "sha512-2sr025H9rj7hJIO0evfNYj2Fm6KuaC4PSi2hfIy/DGd7uaWPvf+5d+axfsL/gk48SZPjcGyOgum6tjbm+/iS1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-str-starts": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-starts/-/actor-function-factory-term-str-starts-4.5.0.tgz",
+      "integrity": "sha512-Qw4jUMM5SQDcdtTip809CLN2LU9nOlK5QsyN2mG7HTHwf4QjnxDXozq2C4fTbUzgYGMTROgQO/wbTPhzMKdgeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-str-uuid": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-uuid/-/actor-function-factory-term-str-uuid-4.5.0.tgz",
+      "integrity": "sha512-Yj5bsRkQ4omf85L8bMqjRgIa2sd+KVBvMvD04zAie5KcbnH8zMSBG62o4MCteQz5jDGZsyYmX9JeUXhmHA9UZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@types/uuid": "^10.0.0",
+        "uuid": "^11.0.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-sub-str": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sub-str/-/actor-function-factory-term-sub-str-4.5.0.tgz",
+      "integrity": "sha512-br0Ihpcpi3D71rWOTC4BvLiIMJT2Qtt8wZEJGNEfFsLV9DfQIO3YhpFuMyPxGZoW5vkWuFVXzmqcK0JuwjLXgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-subject": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-subject/-/actor-function-factory-term-subject-4.5.0.tgz",
+      "integrity": "sha512-9C7qD7BZ9jj+S//aXGvYqNfA/HCPBAPzWz7bBe+eONLnLE/7GjlNj9wspG51gh/gZnJMlUHVLxrLAMR4AxLaWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-subtraction": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-subtraction/-/actor-function-factory-term-subtraction-4.5.0.tgz",
+      "integrity": "sha512-INkhG5dQZekt3W6tUL4JIjO1ZVHV31OQoAWQv4GEs/a19WM1EMp3oHlHqo8yOqZgnWbBMb9oarOjRYINthaLZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "bignumber.js": "^9.1.2"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-timezone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-timezone/-/actor-function-factory-term-timezone-4.5.0.tgz",
+      "integrity": "sha512-N44SF5MfzjFhRNDtjJO+E6lfJBX639Ogb2Oc4x2Qh9aj/OUuHuwONEtCwaoUADIThBdDiTTGhlsfwe0tUY3e7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-triple": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-triple/-/actor-function-factory-term-triple-4.5.0.tgz",
+      "integrity": "sha512-U4yIpuR6n2w9YdRXhrONV34ju8CtVm8jA0pBopnFYK/GwnJqp6YIn00B5AC/WdKDUVZUDgNu9j+XgpwJxsN6pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-tz": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-tz/-/actor-function-factory-term-tz-4.5.0.tgz",
+      "integrity": "sha512-wliS6iY6eDbezKYs6CsVoRqvM6ZVNxKRubEexJYyVPy/DF/KHi2Un0iWQGYu+DM6rRQ5gD/kSjmO5PUjaSvtpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-ucase": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-ucase/-/actor-function-factory-term-ucase-4.5.0.tgz",
+      "integrity": "sha512-ygsPFyHpE1vZQvBdLiFsSMrQDw7XVl8KDlWMl0Ntj7w6UZt+DWHAfXzxn94fr2OfBrqguqRc8MLQTsX5IjK+Mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-unary-minus": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-unary-minus/-/actor-function-factory-term-unary-minus-4.5.0.tgz",
+      "integrity": "sha512-f3FsopxQIIIiBQtAHcW4KjW3/RAxAjgNPse2BumY6igUjY8vkYPiqRDMdQkl+iV0tLprGYu0BXyj95F23X/wcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-unary-plus": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-unary-plus/-/actor-function-factory-term-unary-plus-4.5.0.tgz",
+      "integrity": "sha512-CvJhzQE/TyyVgvbkSEyiLX0NWAeiH1cOkpWTCqazpjRoTsyvrmNQnrdO/c8yPOyylRMZ/sA7Glad8KyBVdTXqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-uuid": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-uuid/-/actor-function-factory-term-uuid-4.5.0.tgz",
+      "integrity": "sha512-AHDwJR0DxiQexuYLH6EhOirMYcoOOuGW8KhbmCnBilVsx8juZF42l/xiTPbXXEE7QlHGiJImGxkUZF4mcidX9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@types/uuid": "^10.0.0",
+        "uuid": "^11.0.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-xsd-to-boolean": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-boolean/-/actor-function-factory-term-xsd-to-boolean-4.5.0.tgz",
+      "integrity": "sha512-W6uIE3lRGwOpeiuxV7DclRMchm4l2Pnjb8AimAkI8DTt1Q/hEsO3MmO06Fx098OZZCpMk5kV89up92VOKaZTaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-xsd-to-date": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-date/-/actor-function-factory-term-xsd-to-date-4.5.0.tgz",
+      "integrity": "sha512-mItiMbvoz63VgmkSYWTvqf9w9OnPXzhpe4WYSV7vKnMTmwPflCAszM6glIiN+UXKNhYFBeqXIxrRZ/fFJPu4Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-xsd-to-datetime": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-datetime/-/actor-function-factory-term-xsd-to-datetime-4.5.0.tgz",
+      "integrity": "sha512-U54xs8vL9lkpHyJBwZA4Ed/zC6twOGPl05ApFomsyw4JYEoF0T9MyGQwJgwrDRz6NLaNdbrjtrC3BN/sk9XIdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-xsd-to-day-time-duration": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-day-time-duration/-/actor-function-factory-term-xsd-to-day-time-duration-4.5.0.tgz",
+      "integrity": "sha512-9LDlkfdjpeLf2sJCCTK4JfPUqAfZ5WC3DDb3JiKeSWn0a63o1bUuvznEZniqZPJ0XPDJ3uYd7oXRlWGHP8TCKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-xsd-to-decimal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-decimal/-/actor-function-factory-term-xsd-to-decimal-4.5.0.tgz",
+      "integrity": "sha512-J4mhhGWpkm7K+vJTzxoG7Skon/PdasA2Tl1OUOYboU1SBgaEsIovoIxsDqdVV6HU7O4mHli0ZXH9HM5KVM+GXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-xsd-to-double": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-double/-/actor-function-factory-term-xsd-to-double-4.5.0.tgz",
+      "integrity": "sha512-CsoZVOz4FqEGlyRvFDwhtFELL8hSRysiDD78b67esqEWMYWVPfS34/SaRjgN335tkIFiCM9xEq0vA0I2kLlsnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-xsd-to-duration": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-duration/-/actor-function-factory-term-xsd-to-duration-4.5.0.tgz",
+      "integrity": "sha512-djMWp2ZXz9ffY3JYivsgCH+tJQLia53P0/sqLXuCeJoPsg3QpKoSpwy9wIBkAcaLatAhn6jQJAZTeEVWPNlY+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-xsd-to-float": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-float/-/actor-function-factory-term-xsd-to-float-4.5.0.tgz",
+      "integrity": "sha512-F/BpWl3AEZeSoTe9TF3xd3sgI8g6F4q6+hekSQcp7LWLChn4ln+Bl4N+ZRocxIFJevFjGMnnjtoOi25iOhVx6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-xsd-to-integer": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-integer/-/actor-function-factory-term-xsd-to-integer-4.5.0.tgz",
+      "integrity": "sha512-diT42cLv4L8ZrlvL5UxQ50EXyZj+Id94RJUZjewmnFb13NWrfwjKKS6bdtFV+rNtiVPsvVOgzXyJEws6tHwjUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-xsd-to-string": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-string/-/actor-function-factory-term-xsd-to-string-4.5.0.tgz",
+      "integrity": "sha512-WMKc1Y+leNhUxUUxlgur+Xbq9oHhqI/VUbkPlqcEYRGHH792d5D652a2yND8SbxpF7gdsPpoFYpBmmAwipsWQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-xsd-to-time": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-time/-/actor-function-factory-term-xsd-to-time-4.5.0.tgz",
+      "integrity": "sha512-5C8e71T6FN0Wt1K0C2P2ooC1uBFid7UBkeGhB+GZvbiGcYe3jRJgTACgCGhONuqgIqNvrRuS0lbS7/eKp1dC+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-xsd-to-year-month-duration": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-year-month-duration/-/actor-function-factory-term-xsd-to-year-month-duration-4.5.0.tgz",
+      "integrity": "sha512-+wKVAq7emP25PgjyDZeBWF5hlOJ3SNOtMRM0lfU3cHgigxKs91BELss0JSdHwz7oxTwuxLMogAeA/sknMIvC7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-function-factory-term-year": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-year/-/actor-function-factory-term-year-4.5.0.tgz",
+      "integrity": "sha512-o5Em71Rj3w+YnDbDE5Rkjzlc/enXPFxnFFesAHx8BXwqTK1Lqr2x2izYI1mZvjsy4czwtY7t3Qa9OKNc/AdJJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-hash-bindings-murmur": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-hash-bindings-murmur/-/actor-hash-bindings-murmur-4.5.0.tgz",
+      "integrity": "sha512-bebfR1rwPT+TPgT07P7cwblDlP8/gVPIALZMIqU0w9IbH54kZcFsnc2OQLUCar1Aq7EZUkny/lY2UjcHagObcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-hash-bindings": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@types/imurmurhash": "^0.1.4",
+        "imurmurhash": "^0.1.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-hash-quads-murmur": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-hash-quads-murmur/-/actor-hash-quads-murmur-4.5.0.tgz",
+      "integrity": "sha512-3A3aNcY23HWKoz+5BFyZXNoLYsuiRh9WGYJ+zzZkMOuNopUr/z5+JoYXbQKbbd8iQeKctdCzi9eE4XMU8emUSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-hash-quads": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@types/imurmurhash": "^0.1.4",
+        "imurmurhash": "^0.1.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-http-proxy": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-4.5.0.tgz",
+      "integrity": "sha512-M5UQ+/IqXFNXLu9qSFNeeph/vaP349HQozqZzOY+HTO4TNWSIcB/XO6HgE3SC7r4G+KV+s9WbHwQO/8PxshBPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-http": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-time": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-init-query": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-query/-/actor-init-query-4.5.0.tgz",
+      "integrity": "sha512-BC+5k0qRxIyl4j00tbqiwKSoOHBkcApMVvXfzYGnK/KgJC8Xj/cPivf3+64Nn4oMgm5kJbp5VW9v7A4+6PB25w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-http-proxy": "^4.5.0",
+        "@comunica/bus-http-invalidate": "^4.5.0",
+        "@comunica/bus-init": "^4.5.0",
+        "@comunica/bus-query-process": "^4.5.0",
+        "@comunica/bus-query-result-serialize": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/logger-pretty": "^4.5.0",
+        "@comunica/runner": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.9.0",
+        "negotiate": "^1.0.1",
+        "rdf-quad": "^1.5.0",
+        "readable-stream": "^4.5.2",
+        "sparqlalgebrajs": "^5.0.2",
+        "yargs": "^17.7.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      },
+      "optionalDependencies": {
+        "process": "^0.11.10"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-optimize-query-operation-assign-sources-exhaustive": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-assign-sources-exhaustive/-/actor-optimize-query-operation-assign-sources-exhaustive-4.5.0.tgz",
+      "integrity": "sha512-FPw1xidcpP1b6hVJ2zM3ib6wvHEoVnHEuh59jIgRV6Iz5idraCK3EVagYCxSWo9Xj0NR48/6DUVMjVWl7JMnFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-update-quads": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-optimize-query-operation-bgp-to-join": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-bgp-to-join/-/actor-optimize-query-operation-bgp-to-join-4.5.0.tgz",
+      "integrity": "sha512-1raQz4vjZ8MUCAhh4EYcj+6aLnb292NJoSc+jTBC+u5rtJ4gmFqNDyCJxjoI/QbxU9Ioy2Hlj4WxMq7M6F816g==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-optimize-query-operation-construct-distinct": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-construct-distinct/-/actor-optimize-query-operation-construct-distinct-4.5.0.tgz",
+      "integrity": "sha512-1phqt7HRuGMf6DzBYxlwJG8gw0KTyfFomhc4Uvr3QZrzRJ9Z41NgDTkSd+OGhbxwFm+aJ5O51VSi0FRK5K/Rvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-optimize-query-operation-describe-to-constructs-subject": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-describe-to-constructs-subject/-/actor-optimize-query-operation-describe-to-constructs-subject-4.5.0.tgz",
+      "integrity": "sha512-bPN82pm7InpjtNvrehl4qaYAu5G8gz2pCzviPo3rHi3syYKMDDXHSW51IpkE904YAysuKbgX4hPZ17WENh4Wpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-optimize-query-operation-filter-pushdown": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-filter-pushdown/-/actor-optimize-query-operation-filter-pushdown-4.5.0.tgz",
+      "integrity": "sha512-2U2uSbaJPCy8pngkJ/c4QKBHObzulOndFO1c2lrdfeMuyq3usUEcxBvoWufeKWhdit88Re+wHJyPY+ZYw5T7hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-optimize-query-operation-group-sources": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-group-sources/-/actor-optimize-query-operation-group-sources-4.5.0.tgz",
+      "integrity": "sha512-IsRPmnSRzKzW/YnKlRQt06qs+ytn1ML50MYwq1siUS8GpCHlBsb+uhYPDb3+1gr/+TYPZro7PzGS4Gn7pdzfAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-optimize-query-operation-join-bgp": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-4.5.0.tgz",
+      "integrity": "sha512-/rl5ig8O2GVTrH0Ux2CjAjyTvv7XvH4nYOjuQwZx05YmsPb6rEzzE7RAGoln4qZNG9TY4X0cKwxQcXmyTJMDGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-optimize-query-operation-join-connected": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-connected/-/actor-optimize-query-operation-join-connected-4.5.0.tgz",
+      "integrity": "sha512-wJ0obFZHNaQSlyJCwWlfm/8OqNvHSLdXWlfAm3ZWeeDg7QGBDMZjdoHG5uNSYRsYzxv5GGMduTs1C2kymgfkqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown/-/actor-optimize-query-operation-leftjoin-expression-pushdown-4.5.0.tgz",
+      "integrity": "sha512-j8aHL24PNXhpdDuLNmxUK5Y2JRZDELKZK12vCosAkh9YBcvKRM6liGm8IErfMWqLIk8W9SGac80MP04CCiaAKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-optimize-query-operation-prune-empty-source-operations": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-prune-empty-source-operations/-/actor-optimize-query-operation-prune-empty-source-operations-4.5.0.tgz",
+      "integrity": "sha512-xyLHO3ZP62QAviQcAuluZuNQThyu0x0qT8uSy3EcwdLAaaAasZFf0TYric+cMMFeVk/lkbi250ksnx8HOLDuQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-optimize-query-operation-rewrite-add": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-add/-/actor-optimize-query-operation-rewrite-add-4.5.0.tgz",
+      "integrity": "sha512-n9MgkIpjQ0OswV7tmaKGPruq/WaeOeHzjPt4uf7zoLBGna5UsUWzuL/hnQyIH69zAEDhzyHy2COCefLMKkIyvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.2",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-optimize-query-operation-rewrite-copy": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-copy/-/actor-optimize-query-operation-rewrite-copy-4.5.0.tgz",
+      "integrity": "sha512-dlzn9XlJmgGS32xKiuP++/9qAEPWgXDZ9j1dOBscIzVfsbcwx6zdHbQ6qB0vFM7Ged88CIGS4waCSE/S3gExdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-optimize-query-operation-rewrite-move": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-move/-/actor-optimize-query-operation-rewrite-move-4.5.0.tgz",
+      "integrity": "sha512-ITtO/5XpTewCvDuCISmtX2NGampMCGpHf6s3ew/g2YBEVSeTDhqgA73isHA847Q8cfxOESwChGFCP4CuiHv91w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-ask": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-4.5.0.tgz",
+      "integrity": "sha512-dqO3ztOtLlxtwuG/cSsFcEb3W0hHR9mzS3MlXb+GH5u8n1Phidk8s1mfMQKoYdyTfTTnxAVSMcolHDN9VOl18g==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-bgp-join": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-join/-/actor-query-operation-bgp-join-4.5.0.tgz",
+      "integrity": "sha512-/LR/RjHoBk+YBO/FPx+nd63b6pA9OHEMzrR3U5aejIHZ4X3vCiHxcTiGWLx8LffZVKLamsL1NeWnsAa3g4t5jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-construct": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-4.5.0.tgz",
+      "integrity": "sha512-IIVkna7LL+MDGgQbmCAlXkXDGUu2r+hiuu7nY2RVqA9uNqgos1hHwbK2+UWA3rvyCzI/ECIANXX2PInm3ieXvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-distinct-identity": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-identity/-/actor-query-operation-distinct-identity-4.5.0.tgz",
+      "integrity": "sha512-WRhvsT2UpHcgKWRuiWGeu7wX+ITjpfRw2++pPOizL/Wt4EFQQBQNxrPasrUce33jVws1QxS6zlSY+bGzUmeljw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "rdf-string": "^2.0.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-distinct-identity/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-distinct-identity/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-extend": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-4.5.0.tgz",
+      "integrity": "sha512-dbpTn3EyTch8Aw57KEKCKHCFMKaSLd+KuakGxrTxSiAjbjBJL/ZL4vhGZDpx0xI1IKA8PVFtgsLuUk7IpnP59Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-expression-evaluator-factory": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-filter": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter/-/actor-query-operation-filter-4.5.0.tgz",
+      "integrity": "sha512-4kWfCh+s3X/cab/2z/ZW54ah9gAfUiZAmy+DgXNqtj6ty+zBC5ZFKCFbe+O7orvZOrfDD1kwZmvdAR3GO7RrBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-expression-evaluator-factory": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-from-quad": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-4.5.0.tgz",
+      "integrity": "sha512-CGRDCTWYc7hi05/d2GUVTNqF2sekcloTuU+uCrqnPMR9g6//KAq7n7QjBC/OZQj7q3454rjnhUxHf1ahTJZS/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-group": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-4.5.0.tgz",
+      "integrity": "sha512-6OSCo3ssBuri0Euf6E9IFbZH7/DP0RSJre549jruLIEAed+XTreStpI9Unx1IOKAOI2X5Xv2cfLfuGubH3CRBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-bindings-aggregator-factory": "^4.5.0",
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-join": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-4.5.0.tgz",
+      "integrity": "sha512-q2u/PxmP7LLdqpIv4teKDrxTjcqH89aRf34X63nU++8TvEzml/786/EMLmVYshgrWsNShbw9afrmwB6DWNCcpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "rdf-data-factory": "^1.1.2",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-leftjoin": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin/-/actor-query-operation-leftjoin-4.5.0.tgz",
+      "integrity": "sha512-F240YX+ILF1QFW30oGK7bnapo5gkwHWFPkX6UME9ogjdq6AeosM3boevtwsUVp3ykz3irsExdJDIU24QtvYhuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-minus": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-4.5.0.tgz",
+      "integrity": "sha512-8UqLHadZHp0jr2LujjtlKYFdKGZdG24PoKEJOBZpxAgdOFd6QirBFR5TA5QlIjm1o77yzLzPLSokjvlYswYW6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-nop": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-nop/-/actor-query-operation-nop-4.5.0.tgz",
+      "integrity": "sha512-Qh3ZK0YkcH0FcAf8U5U22076ZWDSH37m9vbm1yYPdn/ag+G9TXf63VxcYpLcFQJFB7LM6b+6LNQezMfFXiqoYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-orderby": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby/-/actor-query-operation-orderby-4.5.0.tgz",
+      "integrity": "sha512-s28lZK5M9XewM5wl+RfuqwWwcBYpIMnpEPRD6cco5bbP6m9gXZAo8KHYsDfdfBKiOfWDxIcP3QpDJZajmy5KKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-expression-evaluator-factory": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-term-comparator-factory": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-path-alt": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-4.5.0.tgz",
+      "integrity": "sha512-bgM5/lE6C/no1g5XZZi8CL46SURZtgmernDsd10wQdzXYZzlNcxO8yu1C/HozTyKsIlRpv8FTWgh2a0jbsJlJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^4.5.0",
+        "@comunica/actor-query-operation-union": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-metadata-accumulate": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-path-inv": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-4.5.0.tgz",
+      "integrity": "sha512-s30h/6aEzzDxgCjy9fz/RVGakiSAD0+GAGvMmMF3zqhpM70lD6dwaMQSwxAH/7IQiEjR7VlrrYPMTI0ljK+9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-path-link": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-4.5.0.tgz",
+      "integrity": "sha512-Pyu1KpBOvOPTFD/tQ8JcXNzA+TnJVTggZSIsfCdzXJePx5zVglXT74cHLAMP0MS4QI709JrNYDveUWBYxJrcVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-path-nps": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-4.5.0.tgz",
+      "integrity": "sha512-gziMhls637aQyt86J0uRfGYZlvRuOH5fPExocoqmALh34bi08/hqGUnuPBRqYX7dBnqgIz5daInqhBGaWpvyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-path-one-or-more": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-4.5.0.tgz",
+      "integrity": "sha512-4Q/WcptuCR7asWzZShupvzfcR6KPsdISdYdguvDnDC2wkiI8DJKkPxek5fCHth78twWqP93WZnkKto3pfM2Dkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^4.5.0",
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-path-seq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-4.5.0.tgz",
+      "integrity": "sha512-uzvJZWEQ15VpdiVvhcS4eDmQREHIDnyG4/eBsSsh64d/sBTAlnF+jTh10OF7UIBD1IpGwL3u10DoV8Xz9dhOLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-path-zero-or-more": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-4.5.0.tgz",
+      "integrity": "sha512-8HIBnqBgDEZTiiok9/Biyka24YWfDVLlJntJRX2i+qm20LLCzKqfqM8LyfmuY9xCxLzRHfZplwUMt9p1FbxcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^4.5.0",
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "rdf-string": "^1.6.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-path-zero-or-one": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-4.5.0.tgz",
+      "integrity": "sha512-V22P9WtJDLzLsWot/CLmJc9v566LmCoNApFGxAL9TgZeIKyZsKVESMb/TEI/GkXBuMxjAyCTh2cRm2ORztiH8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^4.5.0",
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-project": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-4.5.0.tgz",
+      "integrity": "sha512-8tFqMnM2gaEzewE25PTm4UQMZ4kUUoOrbFS7OM65Vns3Jvw8cYwYCoYAT98L0gHMGG5z0UTYoOHMc+PdjBRuGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-data-factory": "^4.0.1",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-reduced-hash": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-4.5.0.tgz",
+      "integrity": "sha512-yaA/jF4y2vxzS/mjK8UEGMWZtDx3joPPbbcidVACW02HzpXHpNGYUfb2OZOK1LnnaJayms9lJd2kfU78UThRsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-hash-bindings": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "lru-cache": "^10.0.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-slice": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-4.5.0.tgz",
+      "integrity": "sha512-SWBFYpFwu1Ns53BypSR61YuypYcwifsyxvJ2s4mjg5EHBc+myUXf/eoeXl1TFYKWZsUp6xOvCZCLcxsMMM4OTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-source": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-source/-/actor-query-operation-source-4.5.0.tgz",
+      "integrity": "sha512-N7Ncs92KOYQ0uKBc0P3hZ9/7yHwchnazH+wq/Gufm/WsWPt13YppB43rSJHzo0tBkVMvI8MbZvkLj3t46/wYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-union": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-4.5.0.tgz",
+      "integrity": "sha512-cKBEYMc84lXREjj9ta30idl4wYKQnSXS1P3tpyuUcc0AmGFVWA6+VzJEgKzvH6Mpbe/PGA8nhTqDZJVLi1XRXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-metadata-accumulate": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-update-clear": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-4.5.0.tgz",
+      "integrity": "sha512-R6x13rE4JU/QlDoBQXAJadtYePWB82UTGT0r3xgNaXgRaODWgaSPXadPvxRLoI9HSX0DQrJiIXaNXH0EDdGtFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-update-quads": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-update-compositeupdate": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-4.5.0.tgz",
+      "integrity": "sha512-/7hwBvrHUl9f2arb2Z4KOOyTjFNdSAspLofGmMVeM9f8TkPH96gDMRw1+RM4qcuTLEbdJn+efc7YzVJrVmwSDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-update-create": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-4.5.0.tgz",
+      "integrity": "sha512-BphWTXX81Bpv8hq74eIkPWOi2K8/45UvM2ayQp3RblSlD1fu0GcWnxcoexLFFw1aM4Xd8sCvgRtq2k0HwhgdoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-update-quads": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-update-deleteinsert": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-4.5.0.tgz",
+      "integrity": "sha512-spJ3Rpj/FAM8tAo35ggFyFWamOfBfHZBT/eMH3CKLJ5qXEJcB9JvjxD/kmW79aMhsPSqlOqyTQ7p3g7OcQd0Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-query-operation-construct": "^4.5.0",
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-update-quads": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-update-drop": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-4.5.0.tgz",
+      "integrity": "sha512-jVDTwPANfoH6iUzuO2RvVoDZ0tVpyShWANwEpvvfWRocj/oy55p3tF/1CUj/I/6IVXsiBs32xivnGeP2Aurzkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-update-quads": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-update-load": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-4.5.0.tgz",
+      "integrity": "sha512-ZNQkrhLwUjjLdrkYE83SafnhtSt0LEiAE+cS+soRZwl9GLoIPqfRyE8+r6hPHVKtBefLkTQC01dBC53vb84cTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-query-source-identify": "^4.5.0",
+        "@comunica/bus-rdf-update-quads": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-operation-values": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-4.5.0.tgz",
+      "integrity": "sha512-3RTTA2drfC3gr4VtomTMhhXuJGjmZW5NiiX/QhKLwkxEzVp8JYDP8KTtaMG+HWvNzoXNnLgFjY+69SCVUNfk8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-parse-sparql": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-parse-sparql/-/actor-query-parse-sparql-4.5.0.tgz",
+      "integrity": "sha512-cteTjZAipUsC44z67yyCWe+4FMxBAFv1tNAe2omaqDMo8nLZJ2qnN9wj4ZqOVQuyHSGLeg5V7umc5O1m4FgFKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-parse": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@types/sparqljs": "^3.1.3",
+        "sparqlalgebrajs": "^5.0.2",
+        "sparqljs": "^3.7.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-process-sequential": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-process-sequential/-/actor-query-process-sequential-4.5.0.tgz",
+      "integrity": "sha512-3MlrVQfY7iz0V17jnlZzeJLav1AtawnXZTEK3Jvsnl7lQrzYJ0rEvvGCeAJ6LCrhHmE9cMI0KtghQnKO1zxuDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-context-preprocess": "^4.5.0",
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-optimize-query-operation": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-query-parse": "^4.5.0",
+        "@comunica/bus-query-process": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-query-source-identify-rdfjs": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-rdfjs/-/actor-query-source-identify-rdfjs-4.5.0.tgz",
+      "integrity": "sha512-OODcg3Sz0TAkClTlhHout6hAgikbtm/19rycJeOo6QbsM2dUohnKrk5pXNvlTfCqIj2qsvqcnD5YTuIRjYhYiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-source-identify": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-rdf-join-entries-sort-cardinality": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-entries-sort-cardinality/-/actor-rdf-join-entries-sort-cardinality-4.5.0.tgz",
+      "integrity": "sha512-Tk4AxcP0BdC9e5LJQqcCx1IvrVeeIbRYlin6u//s70MG4QZesFdFl3kNRPWo7PK2M40XT2yO3j5tSNrkj4TpxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join-entries-sort": "^4.5.0",
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-rdf-join-inner-hash": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-hash/-/actor-rdf-join-inner-hash-4.5.0.tgz",
+      "integrity": "sha512-goMj2HrfZp2rP30F+Ea/n8E8qYbhPHv+qG335RAX1NB1/QuIzhhKf5BP5fYVfEu55lhFAy2WpNn/eDYfXEj2Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-hash-bindings": "^4.5.0",
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-index": "^4.5.0",
+        "@comunica/utils-iterator": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "asyncjoin": "^1.2.4",
+        "rdf-string": "^1.6.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-rdf-join-inner-multi-bind": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind/-/actor-rdf-join-inner-multi-bind-4.5.0.tgz",
+      "integrity": "sha512-jCJyQ0E8G589V5Is3fK6W4LpPwKdOv3jC7MtAPdbRzq57l9aY7kYc0n0U4lC7mGSjyPMAcvCQJCE8MMqYyFmeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/bus-rdf-join-entries-sort": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-rdf-join-inner-multi-bind-source": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind-source/-/actor-rdf-join-inner-multi-bind-source-4.5.0.tgz",
+      "integrity": "sha512-pnd/r9YW21yxxmJIq8GEz3AB6Qrmvxj9zh04xOw8407Kicxf9iZ2jFm1z5rtrE3fVX4gh206wwKNo5dopOp9Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/bus-rdf-join-entries-sort": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-iterator": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-rdf-join-inner-multi-empty": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-empty/-/actor-rdf-join-inner-multi-empty-4.5.0.tgz",
+      "integrity": "sha512-f9FDa00yqmxIn9n0YSc+JxyJGHR/TKQTlkc4A/lkBbHauD+o0LoryGIm/88mK4ZEDG0ebz2s1znmspCEyhol6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-rdf-join-inner-multi-smallest": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest/-/actor-rdf-join-inner-multi-smallest-4.5.0.tgz",
+      "integrity": "sha512-X9cVWpImkX7ovYxaRMS5w/Y6z7izvAvglcl6Rn4qnL/u3tsgFEcvVb+nMkGjH3+Dk5yef+oThCvVhc5nb7t9mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/bus-rdf-join-entries-sort": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings/-/actor-rdf-join-inner-multi-smallest-filter-bindings-4.5.0.tgz",
+      "integrity": "sha512-i04prUsnBsdgPvL847NeZihXiE5Pn5mdcYO4i/LDsPoOoD2vcodm2WvfVl8bFI69FJIIyuf/VlfQOFKNp+9JbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/bus-rdf-join-entries-sort": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-iterator": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-rdf-join-inner-nestedloop": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-nestedloop/-/actor-rdf-join-inner-nestedloop-4.5.0.tgz",
+      "integrity": "sha512-+u8peRhrLHmTSyMHkKN4Ky0OmUAVteu9WDHagtflNChhGL1OGMZuO1tw+hu8YCrK0/fWCd3ujgr9i5u4Y49iog==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "asyncjoin": "^1.2.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-rdf-join-inner-none": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-none/-/actor-rdf-join-inner-none-4.5.0.tgz",
+      "integrity": "sha512-PSOkwq2NMvDL6ikcDuPEa1Rp2aqFlmgvAzUk8OhiCDI0kEqlUzWxskrqQIjVneK8PmJiV3CaA+QkfDp/V48h0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-rdf-join-inner-single": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-single/-/actor-rdf-join-inner-single-4.5.0.tgz",
+      "integrity": "sha512-XCSO3ULvMMfpmPduzj06oInkvUyTk/n0/p7ovhC/A/0zUJc6Ml9dPrwJZdCiHWF7zjqd74mDrRmu23ouDmuwow==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-rdf-join-inner-symmetrichash": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-symmetrichash/-/actor-rdf-join-inner-symmetrichash-4.5.0.tgz",
+      "integrity": "sha512-TgOoAG/Z7+tgR/vLvym7v3udcIqcD90+w5ttQ+hTa7dfHw/NNhAUALmK6ZMa6uJ6RWeNUu2JZSDDaLFkPDeqDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-hash-bindings": "^4.5.0",
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "asyncjoin": "^1.2.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-rdf-join-minus-hash": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-minus-hash/-/actor-rdf-join-minus-hash-4.5.0.tgz",
+      "integrity": "sha512-3smcJln7Tr+wNEiRuL4KPO+FodMhqQeIaEdnEcs+gzU6JAE9zlPtJDqlTn2pwmUfUYg4xXcScIQJHJoBuf516A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-bindings-index": "^4.5.0",
+        "@comunica/utils-iterator": "^4.5.0",
+        "@rdfjs/types": "*",
+        "rdf-string": "^1.6.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-rdf-join-optional-bind": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-bind/-/actor-rdf-join-optional-bind-4.5.0.tgz",
+      "integrity": "sha512-R0XBCZXv3bL0712FIwqZ+2U+P+k9YGgQFLHI2/PtW9sJWi/s79JSYnwnACfEEfMwIdkPHwK0NIuNmnw3BTT+1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-rdf-join-inner-multi-bind": "^4.5.0",
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-query-operation": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-rdf-join-optional-hash": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-hash/-/actor-rdf-join-optional-hash-4.5.0.tgz",
+      "integrity": "sha512-ogSoBp2OJGZFlUyu5XnggNKBhhQoYBivf4Avvphnm4xZ+4IQmLfwBuzEXhPTZN5Yyfu7L0hQK6Kykk1YuAZo0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-bindings-index": "^4.5.0",
+        "@comunica/utils-iterator": "^4.5.0",
+        "asynciterator": "^3.9.0",
+        "rdf-string": "^1.6.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-rdf-join-optional-nestedloop": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-nestedloop/-/actor-rdf-join-optional-nestedloop-4.5.0.tgz",
+      "integrity": "sha512-szhKIYdV7r6Sv1+q7WW7831O33dO7yYlgbsTDwPir5hgLYHRprrjDFKhPbyA361waWiR7JLrUfdJaXt6FbSIYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "asyncjoin": "^1.2.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-rdf-join-selectivity-variable-counting": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-selectivity-variable-counting/-/actor-rdf-join-selectivity-variable-counting-4.5.0.tgz",
+      "integrity": "sha512-98plhmPvrnYPXQa5PES6sAeNFB+qrGiZg1bUvAM5Jtg5jQ9BfwH+Bf02yIVAfyACjaLaTNGoOP/qHzb6HrUQdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join-selectivity": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-accuracy": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-rdf-metadata-accumulate-cardinality": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-cardinality/-/actor-rdf-metadata-accumulate-cardinality-4.5.0.tgz",
+      "integrity": "sha512-fHQAs1dqOGwWrSAyCLMGMU3M1GKbjjvcyKS9cYwN47OiT2rEsbBZ1sGWOcpNgxJa4T59lvO4RlfDuuMpmcYLSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-accumulate": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-rdf-metadata-accumulate-pagesize": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-pagesize/-/actor-rdf-metadata-accumulate-pagesize-4.5.0.tgz",
+      "integrity": "sha512-V3Gci3XEN4gO6w+dSHt9QnzaO1+lhytmYxoHIkkwVcjh4X5WYxM82D2fjFf4dW9xF0Yej009ps8RpuX54YRseQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-accumulate": "^4.5.0",
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-rdf-metadata-accumulate-requesttime": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-requesttime/-/actor-rdf-metadata-accumulate-requesttime-4.5.0.tgz",
+      "integrity": "sha512-Br5hlNujsRFCHJ0g48oW8xBBQvDDT5lNaCuY0ky/sIv/ULk5aT5J/jBIvc5aeIXpA37D3KrvfenXz3ScqvTHSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-accumulate": "^4.5.0",
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-rdf-update-quads-rdfjs-store": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-4.5.0.tgz",
+      "integrity": "sha512-PsV7Fdm/y0jLfSsByUpU0GkbRIV4d73q7d6Ytl5iWQLwvfYiJ8KE6qQyN0tOvcYO9cCwhMCYusEoy6kep6Ml4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-update-quads": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "event-emitter-promisify": "^1.1.0",
+        "rdf-string": "^1.6.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/actor-term-comparator-factory-expression-evaluator": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-term-comparator-factory-expression-evaluator/-/actor-term-comparator-factory-expression-evaluator-4.5.0.tgz",
+      "integrity": "sha512-sI46VJ80mfgwTDBhSuzPfIzNABOc10du4rE3NPVl9ysXU+mlfy71B1tkOq25wkGc/bKqo3etNURJz790qCD+4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-expression-evaluator-factory-default": "^4.5.0",
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/bus-term-comparator-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/bus-bindings-aggregator-factory": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-bindings-aggregator-factory/-/bus-bindings-aggregator-factory-4.5.0.tgz",
+      "integrity": "sha512-gI8UIgEJwYriQmalmMcA1q5g9cu7EzXLuJELiJZMm03msAoVB+RcZmbRBlYnVfRw/uTShl7IV8k27Hl05AjpCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-expression-evaluator-factory": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "@rdfjs/types": "*",
+        "rdf-string": "^1.6.3",
+        "sparqlalgebrajs": "^5.0.2"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/bus-context-preprocess": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-4.5.0.tgz",
+      "integrity": "sha512-PE2aSmzcQsDuIUJGt0Ko6yD8YithHy6XwXKeS8OHaQeI93S+V6DZKaaCE+gCNcDBi8jZ4P4cislay/+8V1ZIPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/bus-expression-evaluator-factory": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-expression-evaluator-factory/-/bus-expression-evaluator-factory-4.5.0.tgz",
+      "integrity": "sha512-QaeEiiXq75fV6+P3DnTKJkrV5p9yv1PqmsSPJ3h66DUManXrQEh9ATnJAwEBoUJlHE4Sy2aqho6Whate1W/orA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/bus-function-factory": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-function-factory/-/bus-function-factory-4.5.0.tgz",
+      "integrity": "sha512-C/D9hzDWAv0GNDYV547rZrVAvkR7pc5CBeE3f3VOHW1aEBc3cvRFSf6FkrweqtxvywK3gI2V+3OPr4kwmRAGXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-expression-evaluator": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/bus-hash-bindings": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-hash-bindings/-/bus-hash-bindings-4.5.0.tgz",
+      "integrity": "sha512-SV1B83AD1ULprq9Xj/DAConubdOkH7ZYWF5MePolYTE1Wx7BMZv1giGVvR56/tA3/37NZzvffZPfqUc6C8Ip0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/bus-hash-quads": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-hash-quads/-/bus-hash-quads-4.5.0.tgz",
+      "integrity": "sha512-733+aHqi+hnlOY6bKAvy27Py54/IvOeGtehr6De8g6ZswP5UatiL4GURQk+acBK4aYSw9RzeyQhCu/LxO0q//g==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "rdf-data-factory": "^1.1.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/bus-http": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-4.5.0.tgz",
+      "integrity": "sha512-wWyPNNOl6shDbtibdBl/pa9OIcoEMemNIo/J4tUViXxYXZ8i1h4FZ6PqaLtAls6O+pV71mR4SKJzKEUuiZiXPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@jeswr/stream-to-string": "^2.0.0",
+        "is-stream": "^2.0.1",
+        "readable-from-web": "^1.0.0",
+        "readable-stream-node-to-web": "^1.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/bus-http-invalidate": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-4.5.0.tgz",
+      "integrity": "sha512-s6BJuWjN4enAqWMk07jVVxCaib9KlMTo/XW+ySM+RAa6KUmiy01ucNcvxaqjrFMdLTAoxl6R+4/XZdTOyH4bJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/bus-init": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-4.5.0.tgz",
+      "integrity": "sha512-9TYFLjirHDt7HPXj3eQW9KX3x5T3mZ1G/EKadL1gQxo0FAqs3y8TdicepCLhk3HY/egidlyv9WQYAPvJ+WAmAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "readable-stream": "^4.5.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
     "node_modules/shacl-engine/node_modules/@comunica/bus-merge-bindings-context": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/@comunica/bus-merge-bindings-context/-/bus-merge-bindings-context-4.5.0.tgz",
@@ -16282,6 +16528,228 @@
       "dependencies": {
         "@comunica/core": "^4.5.0",
         "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/bus-optimize-query-operation": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-4.5.0.tgz",
+      "integrity": "sha512-JMSpmIehaIQKDktrI5JKqxjU7M/4PYIGbuNHMYgcauZ2XxhFCbUhthshT+tY7pknmJg38whr9bK0Ziyw233Nvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/bus-query-operation": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-4.5.0.tgz",
+      "integrity": "sha512-5sLmlmF+oBmNep0lEQuz9V291ddYSRzFJXT3nF+kswB6SjHj2FzwQZpjDEBkIhNXy3h5JY6J/3BqO20hR/IK2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/bus-query-parse": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-parse/-/bus-query-parse-4.5.0.tgz",
+      "integrity": "sha512-Zd5uKEAVmVuAC9RQWg4QfVD8qidg7SqUdLA4lDMp6UfRUv+GyGQzTuGIr9DD3xjnxPfeiaO4t7M1CSaMA0kqhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/bus-query-process": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-process/-/bus-query-process-4.5.0.tgz",
+      "integrity": "sha512-GYNGP9bjB8UtHCqQ77RPYaR0Kd58brGjSuA1xFxVCm255r6AmM5o0SwG6hydl4I3scdz+E12h938a1YV+LFL1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/bus-query-result-serialize": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-result-serialize/-/bus-query-result-serialize-4.5.0.tgz",
+      "integrity": "sha512-KONwhEtNcoiKsVATz9RikdpWSLlKcxII+Bwh8jT9XogWwFXx0oj0WoqTPl97IwtNN2DNvfnzHqZ06v/nsMXBSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/bus-query-source-identify": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-source-identify/-/bus-query-source-identify-4.5.0.tgz",
+      "integrity": "sha512-snauZ+CF/S8NWm/isIk940qy/5RVhPWAvt2D0cmKpCFZOSnOrHe1zh0mX7mQrH/IA2IQmJloXE2rGugbNm22YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@comunica/utils-iterator": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0",
+        "rdf-string": "^1.6.3",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/bus-rdf-join": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-4.5.0.tgz",
+      "integrity": "sha512-qvasYM2hfF+nEvAi5N/0KZfqFRrPDxu7xU9Tq9XK+14cQRaxGQ/8Xh+cGRTQvNgdXM6zo5MBmtauDsJ0L85msg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join-entries-sort": "^4.5.0",
+        "@comunica/bus-rdf-join-selectivity": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-iterator": "^4.5.0",
+        "@comunica/utils-metadata": "^4.5.0",
+        "@rdfjs/types": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/bus-rdf-join-entries-sort": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-4.5.0.tgz",
+      "integrity": "sha512-WdAHVpFvDyF3Ale56bxSaAwLhxyE8344B5uOxCGsqrlbh+luVZL4ccyUFPyCyvP24M1YUEyxVzV6hHQu860x8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/bus-rdf-join-selectivity": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-selectivity/-/bus-rdf-join-selectivity-4.5.0.tgz",
+      "integrity": "sha512-QocxGFR0XPoq7CnvGs3cyh3xYnTVwTHTZHkMksO/GJ6WBeAFo9PYaSdusrfShyNHL3SxrfhGO4vqBfNzvtzHLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-accuracy": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/bus-rdf-metadata-accumulate": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-accumulate/-/bus-rdf-metadata-accumulate-4.5.0.tgz",
+      "integrity": "sha512-rnyo4XNGwRiK4tue0i928LgPt0rTuOCILYL4Qvon5Zj4tHQtV9yKinvnR58NnUqjLmjQLEmPrcpgYTZN4KLzjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/bus-rdf-update-quads": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-4.5.0.tgz",
+      "integrity": "sha512-ZxUzqT+/DSyAMYWP/hSh3VIMErgjrWD73EciNqLg/QL6gjuG3twSbnO9ywSlYe2eKDEu8f4aX8ghGW400gZLPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-context-preprocess-query-source-skolemize": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/bus-term-comparator-factory": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-term-comparator-factory/-/bus-term-comparator-factory-4.5.0.tgz",
+      "integrity": "sha512-UXqoBtF9uPT6V/uUo8byWOssOtHtc5Azrg2sb9cT8AWH2Salt0c/Hd4vWCM602Z1Hs/LxTSDaGEMdpZJin/7Ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/bus-merge-bindings-context": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/config-query-sparql": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/config-query-sparql/-/config-query-sparql-4.4.0.tgz",
+      "integrity": "sha512-ZVK6eqpYLNa3MRLOWjRaudgfSdraJH/oZIkc5S2doJI2ZmnHROqQUtjPs13kwkI3hGZ6MVBtLm55oz+tKj2lKA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/context-entries": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-4.5.0.tgz",
+      "integrity": "sha512-mgeSYFBcpMKLq34COpy129LVHigGUgA1uEI66WXmk3mdmlAKRQNe9D/W2Q924w0FZZmIOpeLMo+s358tFsodow==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "jsonld-context-parser": "^2.2.2",
+        "sparqlalgebrajs": "^5.0.2"
       },
       "funding": {
         "type": "opencollective",
@@ -16299,6 +16767,375 @@
       },
       "engines": {
         "node": ">=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/logger-pretty": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-4.5.0.tgz",
+      "integrity": "sha512-4Fs0FCnHWFO1EHmFTNhd92o9WTVIigesu6kuk2DP+Zwvm6HKTqgMqllovyllE0nIVyL+YcWSAPvkUTWmQybFIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "object-inspect": "^1.12.2",
+        "process": "^0.11.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/logger-void": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-4.5.0.tgz",
+      "integrity": "sha512-qvRxSlD65KLLqIkU7zwnJ/uPMmYTlsI9J4gsYgEi8OOss5YuNSChAbbzZwRCNrAZOnRGjyrPfgN/Cd3NuglGew==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/mediator-all": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-4.5.0.tgz",
+      "integrity": "sha512-9qX58JgDaC56at0m3FdyYZhXw7kBUPuXihpwYowBwuopdlh0XioJyT/b3g+DC0/kiuSCcx6NhSAWzfNLAqTL7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/mediator-combine-pipeline": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-4.5.0.tgz",
+      "integrity": "sha512-Z4uLxugl+Ls8oAwD0dAIQg+i1rkiXbpiFLhgv5h6nksnz9q6Nv14xItm6baivxAJ9p8XVHCOwPxW46YJBtWIoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/mediator-combine-union": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-4.5.0.tgz",
+      "integrity": "sha512-aCoO3CiANssR8PEjad2aNuCcfhKdUFZWplTWq77cVUMVc4nsUWNleeEvN6kfOx51qdT8lFpH3b8X+S7bT8CABg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/mediator-join-coefficients-fixed": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-join-coefficients-fixed/-/mediator-join-coefficients-fixed-4.5.0.tgz",
+      "integrity": "sha512-kSK0i5FPOmeUmg6nJcoqOvRE6aCXFYMzCFPiId/k5cCjvpT4Uaod33xHEQ0TnX52uLdjNENIRjH8z3OsnhSd/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-join-coefficients": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/mediator-number": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-4.5.0.tgz",
+      "integrity": "sha512-fChc4gh+gtwPOS0F5eNeDuU4Kyb2fAuppN28d1/5s+OUr5v+1Wya7yZ1zbPHYxDMWZEpJBR06eX6djcI0gKlkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/mediator-race": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-4.5.0.tgz",
+      "integrity": "sha512-eAWjQolFMOxKoKuUMmcQzxwf/ZL9ooT0/OUWv1vbVfHIQb/eqDs/h8wDqwXMgEiK5dIF9ZQYaRL2vEaLq+U3Ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/mediatortype-accuracy": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-accuracy/-/mediatortype-accuracy-4.5.0.tgz",
+      "integrity": "sha512-f6OVVGwzf3udDT6x0oP/k76XqBV8ZJFdo5SYGVBR/ebsG81V6LciAHvo8BrihZXgmpo1KTCbIFbRmN++M8b6Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/mediatortype-join-coefficients": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-join-coefficients/-/mediatortype-join-coefficients-4.5.0.tgz",
+      "integrity": "sha512-wLhEdEd7TBF1r5xoShOk42Hh4kH4r7YyoPs4W7k41Q5m5tPdv8iyZojqv/MItDKv7XCiTpZLcIQpfV3RcAewhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@rdfjs/types": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/mediatortype-time": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-4.5.0.tgz",
+      "integrity": "sha512-HND+om4L0VW3VcQrLHHE4+7Nsg7soC98i7g7UqqzDkJ4fix2FnJs0i9WH4RP+oLcx+bPhBSl5mG1m44A6sV19g==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/query-sparql-rdfjs-lite": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/query-sparql-rdfjs-lite/-/query-sparql-rdfjs-lite-4.5.0.tgz",
+      "integrity": "sha512-HBgvhn++QwBb7Q/ImzjjP6esCI126Zux7V4SGEGE+sJfxZrtSX57TIxupP0At9SWYMDg2aDqHJC/b5pDGQOHXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-bindings-aggregator-factory-average": "^4.5.0",
+        "@comunica/actor-bindings-aggregator-factory-count": "^4.5.0",
+        "@comunica/actor-bindings-aggregator-factory-group-concat": "^4.5.0",
+        "@comunica/actor-bindings-aggregator-factory-max": "^4.5.0",
+        "@comunica/actor-bindings-aggregator-factory-min": "^4.5.0",
+        "@comunica/actor-bindings-aggregator-factory-sample": "^4.5.0",
+        "@comunica/actor-bindings-aggregator-factory-sum": "^4.5.0",
+        "@comunica/actor-bindings-aggregator-factory-wildcard-count": "^4.5.0",
+        "@comunica/actor-context-preprocess-convert-shortcuts": "^4.5.0",
+        "@comunica/actor-context-preprocess-query-source-identify": "^4.5.0",
+        "@comunica/actor-context-preprocess-query-source-skolemize": "^4.5.0",
+        "@comunica/actor-context-preprocess-set-defaults": "^4.5.0",
+        "@comunica/actor-context-preprocess-source-to-destination": "^4.5.0",
+        "@comunica/actor-expression-evaluator-factory-default": "^4.5.0",
+        "@comunica/actor-function-factory-expression-bnode": "^4.5.0",
+        "@comunica/actor-function-factory-expression-bound": "^4.5.0",
+        "@comunica/actor-function-factory-expression-coalesce": "^4.5.0",
+        "@comunica/actor-function-factory-expression-concat": "^4.5.0",
+        "@comunica/actor-function-factory-expression-extensions": "^4.5.0",
+        "@comunica/actor-function-factory-expression-if": "^4.5.0",
+        "@comunica/actor-function-factory-expression-in": "^4.5.0",
+        "@comunica/actor-function-factory-expression-logical-and": "^4.5.0",
+        "@comunica/actor-function-factory-expression-logical-or": "^4.5.0",
+        "@comunica/actor-function-factory-expression-not-in": "^4.5.0",
+        "@comunica/actor-function-factory-expression-same-term": "^4.5.0",
+        "@comunica/actor-function-factory-term-abs": "^4.5.0",
+        "@comunica/actor-function-factory-term-addition": "^4.5.0",
+        "@comunica/actor-function-factory-term-ceil": "^4.5.0",
+        "@comunica/actor-function-factory-term-contains": "^4.5.0",
+        "@comunica/actor-function-factory-term-datatype": "^4.5.0",
+        "@comunica/actor-function-factory-term-day": "^4.5.0",
+        "@comunica/actor-function-factory-term-division": "^4.5.0",
+        "@comunica/actor-function-factory-term-encode-for-uri": "^4.5.0",
+        "@comunica/actor-function-factory-term-equality": "^4.5.0",
+        "@comunica/actor-function-factory-term-floor": "^4.5.0",
+        "@comunica/actor-function-factory-term-greater-than": "^4.5.0",
+        "@comunica/actor-function-factory-term-greater-than-equal": "^4.5.0",
+        "@comunica/actor-function-factory-term-hours": "^4.5.0",
+        "@comunica/actor-function-factory-term-inequality": "^4.5.0",
+        "@comunica/actor-function-factory-term-iri": "^4.5.0",
+        "@comunica/actor-function-factory-term-is-blank": "^4.5.0",
+        "@comunica/actor-function-factory-term-is-iri": "^4.5.0",
+        "@comunica/actor-function-factory-term-is-literal": "^4.5.0",
+        "@comunica/actor-function-factory-term-is-numeric": "^4.5.0",
+        "@comunica/actor-function-factory-term-is-triple": "^4.5.0",
+        "@comunica/actor-function-factory-term-lang": "^4.5.0",
+        "@comunica/actor-function-factory-term-langmatches": "^4.5.0",
+        "@comunica/actor-function-factory-term-lcase": "^4.5.0",
+        "@comunica/actor-function-factory-term-lesser-than": "^4.5.0",
+        "@comunica/actor-function-factory-term-lesser-than-equal": "^4.5.0",
+        "@comunica/actor-function-factory-term-md5": "^4.5.0",
+        "@comunica/actor-function-factory-term-minutes": "^4.5.0",
+        "@comunica/actor-function-factory-term-month": "^4.5.0",
+        "@comunica/actor-function-factory-term-multiplication": "^4.5.0",
+        "@comunica/actor-function-factory-term-not": "^4.5.0",
+        "@comunica/actor-function-factory-term-now": "^4.5.0",
+        "@comunica/actor-function-factory-term-object": "^4.5.0",
+        "@comunica/actor-function-factory-term-predicate": "^4.5.0",
+        "@comunica/actor-function-factory-term-rand": "^4.5.0",
+        "@comunica/actor-function-factory-term-regex": "^4.5.0",
+        "@comunica/actor-function-factory-term-replace": "^4.5.0",
+        "@comunica/actor-function-factory-term-round": "^4.5.0",
+        "@comunica/actor-function-factory-term-seconds": "^4.5.0",
+        "@comunica/actor-function-factory-term-sha1": "^4.5.0",
+        "@comunica/actor-function-factory-term-sha256": "^4.5.0",
+        "@comunica/actor-function-factory-term-sha384": "^4.5.0",
+        "@comunica/actor-function-factory-term-sha512": "^4.5.0",
+        "@comunica/actor-function-factory-term-str": "^4.5.0",
+        "@comunica/actor-function-factory-term-str-after": "^4.5.0",
+        "@comunica/actor-function-factory-term-str-before": "^4.5.0",
+        "@comunica/actor-function-factory-term-str-dt": "^4.5.0",
+        "@comunica/actor-function-factory-term-str-ends": "^4.5.0",
+        "@comunica/actor-function-factory-term-str-lang": "^4.5.0",
+        "@comunica/actor-function-factory-term-str-len": "^4.5.0",
+        "@comunica/actor-function-factory-term-str-starts": "^4.5.0",
+        "@comunica/actor-function-factory-term-str-uuid": "^4.5.0",
+        "@comunica/actor-function-factory-term-sub-str": "^4.5.0",
+        "@comunica/actor-function-factory-term-subject": "^4.5.0",
+        "@comunica/actor-function-factory-term-subtraction": "^4.5.0",
+        "@comunica/actor-function-factory-term-timezone": "^4.5.0",
+        "@comunica/actor-function-factory-term-triple": "^4.5.0",
+        "@comunica/actor-function-factory-term-tz": "^4.5.0",
+        "@comunica/actor-function-factory-term-ucase": "^4.5.0",
+        "@comunica/actor-function-factory-term-unary-minus": "^4.5.0",
+        "@comunica/actor-function-factory-term-unary-plus": "^4.5.0",
+        "@comunica/actor-function-factory-term-uuid": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-boolean": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-date": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-datetime": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-day-time-duration": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-decimal": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-double": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-duration": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-float": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-integer": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-string": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-time": "^4.5.0",
+        "@comunica/actor-function-factory-term-xsd-to-year-month-duration": "^4.5.0",
+        "@comunica/actor-function-factory-term-year": "^4.5.0",
+        "@comunica/actor-hash-bindings-murmur": "^4.5.0",
+        "@comunica/actor-hash-quads-murmur": "^4.5.0",
+        "@comunica/actor-init-query": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-assign-sources-exhaustive": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-bgp-to-join": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-construct-distinct": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-describe-to-constructs-subject": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-filter-pushdown": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-group-sources": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-join-bgp": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-join-connected": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-prune-empty-source-operations": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-rewrite-add": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-rewrite-copy": "^4.5.0",
+        "@comunica/actor-optimize-query-operation-rewrite-move": "^4.5.0",
+        "@comunica/actor-query-operation-ask": "^4.5.0",
+        "@comunica/actor-query-operation-bgp-join": "^4.5.0",
+        "@comunica/actor-query-operation-construct": "^4.5.0",
+        "@comunica/actor-query-operation-distinct-identity": "^4.5.0",
+        "@comunica/actor-query-operation-extend": "^4.5.0",
+        "@comunica/actor-query-operation-filter": "^4.5.0",
+        "@comunica/actor-query-operation-from-quad": "^4.5.0",
+        "@comunica/actor-query-operation-group": "^4.5.0",
+        "@comunica/actor-query-operation-join": "^4.5.0",
+        "@comunica/actor-query-operation-leftjoin": "^4.5.0",
+        "@comunica/actor-query-operation-minus": "^4.5.0",
+        "@comunica/actor-query-operation-nop": "^4.5.0",
+        "@comunica/actor-query-operation-orderby": "^4.5.0",
+        "@comunica/actor-query-operation-path-alt": "^4.5.0",
+        "@comunica/actor-query-operation-path-inv": "^4.5.0",
+        "@comunica/actor-query-operation-path-link": "^4.5.0",
+        "@comunica/actor-query-operation-path-nps": "^4.5.0",
+        "@comunica/actor-query-operation-path-one-or-more": "^4.5.0",
+        "@comunica/actor-query-operation-path-seq": "^4.5.0",
+        "@comunica/actor-query-operation-path-zero-or-more": "^4.5.0",
+        "@comunica/actor-query-operation-path-zero-or-one": "^4.5.0",
+        "@comunica/actor-query-operation-project": "^4.5.0",
+        "@comunica/actor-query-operation-reduced-hash": "^4.5.0",
+        "@comunica/actor-query-operation-service": "^4.5.0",
+        "@comunica/actor-query-operation-slice": "^4.5.0",
+        "@comunica/actor-query-operation-source": "^4.5.0",
+        "@comunica/actor-query-operation-union": "^4.5.0",
+        "@comunica/actor-query-operation-update-clear": "^4.5.0",
+        "@comunica/actor-query-operation-update-compositeupdate": "^4.5.0",
+        "@comunica/actor-query-operation-update-create": "^4.5.0",
+        "@comunica/actor-query-operation-update-deleteinsert": "^4.5.0",
+        "@comunica/actor-query-operation-update-drop": "^4.5.0",
+        "@comunica/actor-query-operation-update-load": "^4.5.0",
+        "@comunica/actor-query-operation-values": "^4.5.0",
+        "@comunica/actor-query-parse-sparql": "^4.5.0",
+        "@comunica/actor-query-process-sequential": "^4.5.0",
+        "@comunica/actor-query-source-identify-rdfjs": "^4.5.0",
+        "@comunica/actor-rdf-join-entries-sort-cardinality": "^4.5.0",
+        "@comunica/actor-rdf-join-inner-hash": "^4.5.0",
+        "@comunica/actor-rdf-join-inner-multi-bind": "^4.5.0",
+        "@comunica/actor-rdf-join-inner-multi-bind-source": "^4.5.0",
+        "@comunica/actor-rdf-join-inner-multi-empty": "^4.5.0",
+        "@comunica/actor-rdf-join-inner-multi-smallest": "^4.5.0",
+        "@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings": "^4.5.0",
+        "@comunica/actor-rdf-join-inner-nestedloop": "^4.5.0",
+        "@comunica/actor-rdf-join-inner-none": "^4.5.0",
+        "@comunica/actor-rdf-join-inner-single": "^4.5.0",
+        "@comunica/actor-rdf-join-inner-symmetrichash": "^4.5.0",
+        "@comunica/actor-rdf-join-minus-hash": "^4.5.0",
+        "@comunica/actor-rdf-join-optional-bind": "^4.5.0",
+        "@comunica/actor-rdf-join-optional-hash": "^4.5.0",
+        "@comunica/actor-rdf-join-optional-nestedloop": "^4.5.0",
+        "@comunica/actor-rdf-join-selectivity-variable-counting": "^4.5.0",
+        "@comunica/actor-rdf-metadata-accumulate-cardinality": "^4.5.0",
+        "@comunica/actor-rdf-metadata-accumulate-pagesize": "^4.5.0",
+        "@comunica/actor-rdf-metadata-accumulate-requesttime": "^4.5.0",
+        "@comunica/actor-rdf-update-quads-rdfjs-store": "^4.5.0",
+        "@comunica/actor-term-comparator-factory-expression-evaluator": "^4.5.0",
+        "@comunica/bus-function-factory": "^4.5.0",
+        "@comunica/bus-http-invalidate": "^4.5.0",
+        "@comunica/bus-query-operation": "^4.5.0",
+        "@comunica/config-query-sparql": "^4.4.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/logger-void": "^4.5.0",
+        "@comunica/mediator-all": "^4.5.0",
+        "@comunica/mediator-combine-pipeline": "^4.5.0",
+        "@comunica/mediator-combine-union": "^4.5.0",
+        "@comunica/mediator-join-coefficients-fixed": "^4.5.0",
+        "@comunica/mediator-number": "^4.5.0",
+        "@comunica/mediator-race": "^4.5.0",
+        "@comunica/runner": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/runner": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-4.5.0.tgz",
+      "integrity": "sha512-Xq5HUsuNQ2cKHBqQjJ3Xx1jpcdD9Oi+ef7t6wPeUCR6VzZKCmRNxEcwQ0Cz629KMicrZCyWnIkXoB322GRWMVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-init": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "componentsjs": "^6.2.0",
+        "process": "^0.11.10"
+      },
+      "bin": {
+        "comunica-compile-config": "bin/compile-config"
       },
       "funding": {
         "type": "opencollective",
@@ -16340,11 +17177,136 @@
         "url": "https://opencollective.com/comunica-association"
       }
     },
+    "node_modules/shacl-engine/node_modules/@comunica/utils-bindings-index": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-bindings-index/-/utils-bindings-index-4.5.0.tgz",
+      "integrity": "sha512-vV+POCwgVxR3DqtlAt/+q1EzTTghCTYMkx2yV0PJYWdrjsu/JEfoS4S7B1zgb0DjUS7zq0aoeB7FShBUWz/fuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/utils-data-factory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-data-factory/-/utils-data-factory-4.0.1.tgz",
+      "integrity": "sha512-6FTyTC0dNgXwnZN4/5QSDsfNT7AhWPJUcE3a9aa78kQodaq3LfQNW4fiG4tC2O4tcbSy4Ds7ZG/cflThCHwa2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/utils-expression-evaluator": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-expression-evaluator/-/utils-expression-evaluator-4.5.0.tgz",
+      "integrity": "sha512-i4kek6vg5yx/EqwoEEop7UyNy0aHp7MIMdId98opXa/hU64Z8icIaFD+3+1tv98M1LviuJAIPX6lCJwuB22jqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "lru-cache": "^10.0.0",
+        "rdf-data-factory": "^1.1.2",
+        "rdf-string": "^1.6.3",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/utils-iterator": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-iterator/-/utils-iterator-4.5.0.tgz",
+      "integrity": "sha512-Gnn6asz0xILR1f5lQrTjg1BgW5IiSibOETul4iJ+sjYnVncZH1eK5qJNG81f6fX40D3FEHyu+jWQSPNMFqdaoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynciterator": "^3.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/utils-metadata": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-metadata/-/utils-metadata-4.5.0.tgz",
+      "integrity": "sha512-NmWWz9F558NQXR5UOyAIdhLmi4tBMtI0N3kHee/DsPCFaxn0wjQ/ckZGrTVTGeP+sdYzobaYvGcIPpf8MmPALQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/@comunica/utils-query-operation": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-query-operation/-/utils-query-operation-4.5.0.tgz",
+      "integrity": "sha512-R5j61Awzyz+p0FbvACSxh8GuZ4IiBt824UfNZpgDipwzX0JnSaKP5yFKL2dcmb9LlElN8wmDjzy4o512HLK67w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@comunica/utils-bindings-factory": "^4.5.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.2",
+        "rdf-string": "^1.6.1",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/shacl-engine/node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
+    },
+    "node_modules/shacl-engine/node_modules/rdf-quad": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/rdf-quad/-/rdf-quad-1.5.0.tgz",
+      "integrity": "sha512-LnCYx8XbRVW1wr6UiZPSy2Tv7bXAtEwuyck/68dANhFu8VMnGS+QfUNP3b9YI6p4Bfd/fyDx5E3x81IxGV6BzA==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^1.0.1",
+        "rdf-literal": "^1.2.0",
+        "rdf-string": "^1.5.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/rdf-quad/node_modules/rdf-literal": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/rdf-literal/-/rdf-literal-1.3.2.tgz",
+      "integrity": "sha512-79Stlu3sXy0kq9/decHFLf3xNPuY6sfhFPhd/diWErgaFr0Ekyg38Vh9bnVcqDYu48CFRi0t+hrFii49n92Hbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0"
+      }
     },
     "node_modules/shacl-engine/node_modules/rdf-string": {
       "version": "1.6.3",
@@ -16354,6 +17316,17 @@
       "dependencies": {
         "@rdfjs/types": "*",
         "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "node_modules/shacl-engine/node_modules/rdf-terms": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.11.0.tgz",
+      "integrity": "sha512-iKlVgnMopRKl9pHVNrQrax7PtZKRCT/uJIgYqvuw1VVQb88zDvurtDr1xp0rt7N9JtKtFwUXoIQoEsjyRo20qQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-string": "^1.6.0"
       }
     },
     "node_modules/shaclc-parse": {
@@ -16460,6 +17433,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -16493,6 +17473,16 @@
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/spark-md5": {
@@ -16704,6 +17694,20 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.3.2",
@@ -16986,6 +17990,23 @@
       "version": "1.0.2",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
+      "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -17032,6 +18053,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -17223,6 +18254,200 @@
       "integrity": "sha512-gLXi7351CoyVVQw8XE5sgpYawRKatxE7kj/xmCxXOZS1kMdtcqC0ILIqLuVEVnAUQSL/evOGG3eQ+8VgbdnstA==",
       "license": "MIT"
     },
+    "node_modules/vite": {
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.2",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/wait-on": {
       "version": "8.0.5",
       "license": "MIT",
@@ -17280,6 +18505,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/winston": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "start": "node build/src/main.js",
     "dev": "tsc-watch --onSuccess 'npm run start'",
     "lint": "eslint . && prettier --check src/",
+    "test": "vitest run",
     "clean": "rm -rf build/",
     "compile": "tsc",
     "fix": "eslint --fix . && prettier --write src/"
@@ -44,6 +45,7 @@
     "rdf-dereference": "^5.0.0"
   },
   "devDependencies": {
+    "@comunica/query-sparql-rdfjs-lite": "^5.2.3",
     "@eslint/js": "^10.0.1",
     "@rdfjs/types": "^2.0.1",
     "@types/n3": "^1.16.4",
@@ -55,6 +57,7 @@
     "prettier": "^3.8.3",
     "tsc-watch": "^7.2.0",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.60.0"
+    "typescript-eslint": "^8.60.0",
+    "vitest": "^4.1.7"
   }
 }

--- a/queries/analysis/iiif.rq
+++ b/queries/analysis/iiif.rq
@@ -1,4 +1,4 @@
-PREFIX schema: <http://schema.org/>
+PREFIX schema: <https://schema.org/>
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX void: <http://rdfs.org/ns/void#>
 
@@ -13,8 +13,7 @@ WHERE {
     {
         SELECT (COUNT(DISTINCT ?s) AS ?count) {
             #subjectFilter#
-            ?s ?p ?format .
-            VALUES ?p { schema:encodingFormat <https://schema.org/encodingFormat> }
+            ?s schema:encodingFormat|<http://schema.org/encodingFormat> ?format .
             FILTER(isLiteral(?format) && REGEX(STR(?format), "^application/ld\\+json;profile='http://iiif\\.io/api/presentation/\\d+/context\\.json'$"))
         }
     }

--- a/queries/analysis/iiif.rq
+++ b/queries/analysis/iiif.rq
@@ -1,0 +1,22 @@
+PREFIX schema: <http://schema.org/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX void: <http://rdfs.org/ns/void#>
+
+CONSTRUCT {
+    ?dataset a void:Dataset ;
+        void:subset ?iiifSubset .
+    ?iiifSubset
+        dcterms:conformsTo <http://iiif.io/api/presentation/> ;
+        void:entities ?count .
+}
+WHERE {
+    {
+        SELECT (COUNT(DISTINCT ?manifest) AS ?count) {
+            #subjectFilter#
+            ?manifest schema:encodingFormat ?format .
+            FILTER(isLiteral(?format) && REGEX(STR(?format), "^application/ld\\+json;profile='http://iiif\\.io/api/presentation/\\d+/context\\.json'$"))
+        }
+    }
+    FILTER(?count > 0)
+    BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#iiif-", MD5("http://iiif.io/api/presentation/"))) AS ?iiifSubset)
+}

--- a/queries/analysis/iiif.rq
+++ b/queries/analysis/iiif.rq
@@ -11,9 +11,10 @@ CONSTRUCT {
 }
 WHERE {
     {
-        SELECT (COUNT(DISTINCT ?manifest) AS ?count) {
+        SELECT (COUNT(DISTINCT ?s) AS ?count) {
             #subjectFilter#
-            ?manifest schema:encodingFormat ?format .
+            ?s ?p ?format .
+            VALUES ?p { schema:encodingFormat <https://schema.org/encodingFormat> }
             FILTER(isLiteral(?format) && REGEX(STR(?format), "^application/ld\\+json;profile='http://iiif\\.io/api/presentation/\\d+/context\\.json'$"))
         }
     }

--- a/src/iiifStage.ts
+++ b/src/iiifStage.ts
@@ -1,0 +1,34 @@
+import {resolve} from 'node:path';
+import {Stage, SparqlConstructExecutor, readQueryFile} from '@lde/pipeline';
+
+const QUERY_FILE = resolve('queries/analysis/iiif.rq');
+
+export interface IiifStageOptions {
+  /**
+   * SPARQL query timeout in milliseconds.
+   * @default 60_000
+   */
+  timeout?: number;
+}
+
+/**
+ * Detect IIIF Presentation manifests in a dataset and emit a `void:subset`
+ * keyed on `dcterms:conformsTo <http://iiif.io/api/presentation/>` with a
+ * `void:entities` count of distinct manifests.
+ *
+ * Detection mirrors SCHEMA-AP-NDE’s `_:IIIFPresentationManifestShape`: a
+ * resource is a IIIF manifest iff its `schema:encodingFormat` literal matches
+ * the JSON-LD context-profile pattern for any IIIF Presentation version.
+ */
+export async function iiifStage(
+  options: IiifStageOptions = {},
+): Promise<Stage> {
+  const query = await readQueryFile(QUERY_FILE);
+  return new Stage({
+    name: 'iiif.rq',
+    executors: new SparqlConstructExecutor({
+      query,
+      timeout: options.timeout ?? 60_000,
+    }),
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import {config} from './config.js';
 import {createSubjectFilterSelector} from './subjectFilters.js';
 import {buildUriSpacesMap} from './uriSpaces.js';
 import {qualityMeasurementsStage} from './qualityMeasurementsStage.js';
+import {iiifStage} from './iiifStage.js';
 import {ConsoleReporter} from '@lde/pipeline-console-reporter';
 import {resolve} from 'node:path';
 import type {DatasetSelector} from '@lde/pipeline';
@@ -85,6 +86,7 @@ const sampleStages = await shaclSampleStages({
 const stages = [
   ...voidStageList,
   ...sampleStages,
+  await iiifStage(),
   qualityMeasurementsStage({
     validator: schemaApValidator,
     profile: SCHEMA_AP_NDE_PROFILE,

--- a/test/iiifStage.test.ts
+++ b/test/iiifStage.test.ts
@@ -37,21 +37,23 @@ beforeAll(async () => {
   queryTemplate = (await readFile(queryPath)).toString();
 });
 
-function buildQuery(): string {
-  // Mirror SparqlConstructExecutor's substitutions: empty subjectFilter,
+function buildQuery(subjectFilter = ''): string {
+  // Mirror SparqlConstructExecutor's substitutions: subjectFilter pattern,
   // and ?dataset → the dataset IRI literal.
   return queryTemplate
-    .replaceAll('#subjectFilter#', '')
+    .replaceAll('#subjectFilter#', subjectFilter)
     .replaceAll('?dataset', `<${DATASET_IRI}>`);
 }
 
-async function runQueryOn(turtle: string): Promise<Quad[]> {
+async function runQueryOn(turtle: string, subjectFilter = ''): Promise<Quad[]> {
   const store = new Store();
   const parser = new Parser();
   store.addQuads(parser.parse(PREFIXES + turtle));
 
   const engine = new QueryEngine();
-  const stream = await engine.queryQuads(buildQuery(), {sources: [store]});
+  const stream = await engine.queryQuads(buildQuery(subjectFilter), {
+    sources: [store],
+  });
   const quads: Quad[] = [];
   for await (const q of stream) quads.push(q);
   return quads;
@@ -204,5 +206,44 @@ describe('iiif.rq detection query', () => {
 
     const quads = await runQueryOn(turtle);
     expect(quads).toHaveLength(0);
+  });
+
+  it('detects manifests published under https://schema.org/encodingFormat', async () => {
+    const turtle = `
+      <http://example.org/work/1> <https://schema.org/encodingFormat>
+        "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json'" .
+      <http://example.org/work/2> <https://schema.org/encodingFormat>
+        "application/ld+json;profile='http://iiif.io/api/presentation/2/context.json'" .
+    `;
+
+    const quads = await runQueryOn(turtle);
+
+    const subsetIri = findSubsetIri(quads);
+    expect(subsetIri).toBeDefined();
+    expect(findEntitiesCount(quads, subsetIri!)).toBe(2);
+  });
+
+  it('honours the subjectFilter, scoping the count to the dataset', async () => {
+    // Two manifests inside the dataset, one outside. The subject filter is a
+    // graph pattern on ?s (the same convention subjectFilters.ts uses) so only
+    // the in-dataset manifests should be counted.
+    const turtle = `
+      <http://example.org/work/1> schema:isPartOf <${DATASET_IRI}> ;
+        schema:encodingFormat
+          "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json'" .
+      <http://example.org/work/2> schema:isPartOf <${DATASET_IRI}> ;
+        schema:encodingFormat
+          "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json'" .
+      <http://example.org/work/3> schema:isPartOf <http://example.org/dataset/other> ;
+        schema:encodingFormat
+          "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json'" .
+    `;
+
+    const subjectFilter = `?s schema:isPartOf <${DATASET_IRI}>.`;
+    const quads = await runQueryOn(turtle, subjectFilter);
+
+    const subsetIri = findSubsetIri(quads);
+    expect(subsetIri).toBeDefined();
+    expect(findEntitiesCount(quads, subsetIri!)).toBe(2);
   });
 });

--- a/test/iiifStage.test.ts
+++ b/test/iiifStage.test.ts
@@ -239,7 +239,10 @@ describe('iiif.rq detection query', () => {
           "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json'" .
     `;
 
-    const subjectFilter = `?s schema:isPartOf <${DATASET_IRI}>.`;
+    // Production subject filters (subjectFilters.ts) use full IRIs, not
+    // PREFIX-bound shortcuts — so the pattern is independent of which
+    // schema.org namespace the query template declares.
+    const subjectFilter = `?s <http://schema.org/isPartOf> <${DATASET_IRI}>.`;
     const quads = await runQueryOn(turtle, subjectFilter);
 
     const subsetIri = findSubsetIri(quads);

--- a/test/iiifStage.test.ts
+++ b/test/iiifStage.test.ts
@@ -1,0 +1,208 @@
+import {describe, it, expect, beforeAll} from 'vitest';
+import {readFile} from 'node:fs/promises';
+import {createHash} from 'node:crypto';
+import {resolve} from 'node:path';
+import {DataFactory, Parser, Store} from 'n3';
+import type {Quad} from '@rdfjs/types';
+import {QueryEngine} from '@comunica/query-sparql-rdfjs-lite';
+import {iiifStage} from '../src/iiifStage.js';
+import {Stage} from '@lde/pipeline';
+
+const {namedNode} = DataFactory;
+
+const VOID_SUBSET = namedNode('http://rdfs.org/ns/void#subset');
+const VOID_ENTITIES = namedNode('http://rdfs.org/ns/void#entities');
+const DCTERMS_CONFORMS_TO = namedNode('http://purl.org/dc/terms/conformsTo');
+const IIIF_PRESENTATION = namedNode('http://iiif.io/api/presentation/');
+const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
+
+const DATASET_IRI = 'http://example.org/dataset/1';
+const EXPECTED_SUBSET_IRI =
+  DATASET_IRI +
+  '/.well-known/void#iiif-' +
+  createHash('md5').update('http://iiif.io/api/presentation/').digest('hex');
+
+const queryPath = resolve(
+  new URL('../queries/analysis/iiif.rq', import.meta.url).pathname,
+);
+
+const PREFIXES = `
+@prefix schema: <http://schema.org/> .
+@prefix iana: <https://www.iana.org/assignments/media-types/> .
+`;
+
+let queryTemplate: string;
+
+beforeAll(async () => {
+  queryTemplate = (await readFile(queryPath)).toString();
+});
+
+function buildQuery(): string {
+  // Mirror SparqlConstructExecutor's substitutions: empty subjectFilter,
+  // and ?dataset → the dataset IRI literal.
+  return queryTemplate
+    .replaceAll('#subjectFilter#', '')
+    .replaceAll('?dataset', `<${DATASET_IRI}>`);
+}
+
+async function runQueryOn(turtle: string): Promise<Quad[]> {
+  const store = new Store();
+  const parser = new Parser();
+  store.addQuads(parser.parse(PREFIXES + turtle));
+
+  const engine = new QueryEngine();
+  const stream = await engine.queryQuads(buildQuery(), {sources: [store]});
+  const quads: Quad[] = [];
+  for await (const q of stream) quads.push(q);
+  return quads;
+}
+
+function findSubsetIri(quads: Quad[]): string | undefined {
+  return quads.find(
+    q => q.subject.value === DATASET_IRI && q.predicate.equals(VOID_SUBSET),
+  )?.object.value;
+}
+
+function findEntitiesCount(quads: Quad[], subset: string): number | undefined {
+  const entities = quads.find(
+    q => q.subject.value === subset && q.predicate.equals(VOID_ENTITIES),
+  );
+  return entities ? Number(entities.object.value) : undefined;
+}
+
+describe('iiifStage', () => {
+  it('returns a Stage named iiif.rq', async () => {
+    const stage = await iiifStage();
+    expect(stage).toBeInstanceOf(Stage);
+    expect(stage.name).toBe('iiif.rq');
+  });
+});
+
+describe('iiif.rq detection query', () => {
+  it('emits one subset with the expected count for v3 manifests', async () => {
+    const turtle = `
+      <http://example.org/work/1> schema:encodingFormat
+        "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json'" .
+      <http://example.org/work/2> schema:encodingFormat
+        "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json'" .
+    `;
+
+    const quads = await runQueryOn(turtle);
+
+    const subsetIri = findSubsetIri(quads);
+    expect(subsetIri).toBe(EXPECTED_SUBSET_IRI);
+    expect(findEntitiesCount(quads, subsetIri!)).toBe(2);
+
+    // dcterms:conformsTo points to the version-less IIIF Presentation namespace.
+    const conformsTo = quads.find(
+      q =>
+        q.subject.value === subsetIri &&
+        q.predicate.equals(DCTERMS_CONFORMS_TO),
+    );
+    expect(conformsTo?.object.equals(IIIF_PRESENTATION)).toBe(true);
+
+    // void:entities is typed xsd:integer.
+    const entities = quads.find(
+      q => q.subject.value === subsetIri && q.predicate.equals(VOID_ENTITIES),
+    );
+    expect(entities?.object.termType).toBe('Literal');
+    expect(
+      (entities?.object as {datatype: {value: string}}).datatype.value,
+    ).toBe(XSD_INTEGER);
+  });
+
+  it('detects v2 manifests', async () => {
+    const turtle = `
+      <http://example.org/work/1> schema:encodingFormat
+        "application/ld+json;profile='http://iiif.io/api/presentation/2/context.json'" .
+    `;
+
+    const quads = await runQueryOn(turtle);
+
+    const subsetIri = findSubsetIri(quads);
+    expect(subsetIri).toBeDefined();
+    expect(findEntitiesCount(quads, subsetIri!)).toBe(1);
+  });
+
+  it('collapses v2 and v3 into a single subset whose count is distinct manifests across versions', async () => {
+    const turtle = `
+      <http://example.org/work/1> schema:encodingFormat
+        "application/ld+json;profile='http://iiif.io/api/presentation/2/context.json'" .
+      <http://example.org/work/2> schema:encodingFormat
+        "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json'" .
+      <http://example.org/work/3> schema:encodingFormat
+        "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json'" .
+    `;
+
+    const quads = await runQueryOn(turtle);
+
+    const subsetIris = quads
+      .filter(
+        q => q.subject.value === DATASET_IRI && q.predicate.equals(VOID_SUBSET),
+      )
+      .map(q => q.object.value);
+
+    expect(subsetIris).toHaveLength(1);
+    expect(findEntitiesCount(quads, subsetIris[0])).toBe(3);
+  });
+
+  it('matches a hypothetical IIIF Presentation v4 manifest (forwards-compatible \\d+)', async () => {
+    const turtle = `
+      <http://example.org/work/1> schema:encodingFormat
+        "application/ld+json;profile='http://iiif.io/api/presentation/4/context.json'" .
+    `;
+
+    const quads = await runQueryOn(turtle);
+
+    const subsetIri = findSubsetIri(quads);
+    expect(subsetIri).toBeDefined();
+    expect(findEntitiesCount(quads, subsetIri!)).toBe(1);
+  });
+
+  it('counts each manifest once even when reached via multiple paths', async () => {
+    const turtle = `
+      <http://example.org/work/1> schema:associatedMedia <http://example.org/manifest/1> .
+      <http://example.org/work/1> schema:encodingFormat
+        "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json'" .
+      <http://example.org/manifest/1> schema:encodingFormat
+        "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json'" .
+    `;
+
+    const quads = await runQueryOn(turtle);
+
+    const subsetIri = findSubsetIri(quads);
+    expect(subsetIri).toBeDefined();
+    // Two distinct manifest resources, both carrying the encodingFormat literal.
+    expect(findEntitiesCount(quads, subsetIri!)).toBe(2);
+  });
+
+  it('emits nothing when there are no IIIF manifests', async () => {
+    const turtle = `
+      <http://example.org/work/1> schema:encodingFormat "image/jpeg" .
+      <http://example.org/work/2> schema:encodingFormat "application/pdf" .
+    `;
+
+    const quads = await runQueryOn(turtle);
+    expect(quads).toHaveLength(0);
+  });
+
+  it('does not match near-miss encodingFormat literals', async () => {
+    const turtle = `
+      # Different profile URL.
+      <http://example.org/work/1> schema:encodingFormat
+        "application/ld+json;profile='http://iiif.io/api/image/3/context.json'" .
+      # Missing the trailing context.json segment.
+      <http://example.org/work/2> schema:encodingFormat
+        "application/ld+json;profile='http://iiif.io/api/presentation/3/'" .
+      # Malformed: no quotes around the profile URL.
+      <http://example.org/work/3> schema:encodingFormat
+        "application/ld+json;profile=http://iiif.io/api/presentation/3/context.json" .
+      # Extra trailing characters.
+      <http://example.org/work/4> schema:encodingFormat
+        "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json' charset=utf-8" .
+    `;
+
+    const quads = await runQueryOn(turtle);
+    expect(quads).toHaveLength(0);
+  });
+});

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts", "test/**/*.ts", "vitest.config.ts"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

DKG side of netwerk-digitaal-erfgoed/dataset-register#1996: detect IIIF Presentation manifests inside each registered dataset and emit a version-less `void:subset` row with a `void:entities` count of distinct manifests.

- New `queries/analysis/iiif.rq` matches `schema:encodingFormat` literals against `^application/ld\+json;profile='http://iiif\.io/api/presentation/\d+/context\.json'$`. The `\d+` mirrors SCHEMA-AP-NDE’s `_:IIIFPresentationManifestShape` pattern and is forwards-compatible with future Presentation API versions; v2 and v3 collapse into a single subset keyed on `dcterms:conformsTo <http://iiif.io/api/presentation/>`.
- New `src/iiifStage.ts` wraps the query in a `Stage` via `SparqlConstructExecutor`. Wired into the pipeline’s `stages` array next to the existing VoID and SHACL-sampler stages.
- Subset IRI follows the `licenses.rq` pattern: `{dataset}/.well-known/void#iiif-{md5}`.
- Test infrastructure: vitest + Comunica (`@comunica/query-sparql-rdfjs-lite`) for fixture-driven black-box CONSTRUCT tests. Cases cover v2-only, v3-only, mixed v2+v3, a hypothetical v4 (forwards-compat), multi-path dedup, no-IIIF, and near-miss literals. CI runs `npm test`.
- README gets a new “IIIF Presentation manifests” section in Dataset Summaries.

Browser-side changes (card icon, NDE compatibility section on the detail page) live in the dataset-register repo per the issue’s split — the two pieces are independently mergeable.

Refs netwerk-digitaal-erfgoed/dataset-register#1996.
