### PR TITLE
perf: detect IIIF profile media type without REGEX in iiif.rq

### DIFF
--- a/queries/analysis/iiif.rq
+++ b/queries/analysis/iiif.rq
@@ -14,7 +14,14 @@ WHERE {
         SELECT (COUNT(DISTINCT ?s) AS ?count) {
             #subjectFilter#
             ?s schema:encodingFormat|<http://schema.org/encodingFormat> ?format .
-            FILTER(isLiteral(?format) && REGEX(STR(?format), "^application/ld\\+json;profile='http://iiif\\.io/api/presentation/[0-9]+/context\\.json'$"))
+            # Match the IIIF Presentation profile media type without REGEX: a regex
+            # over every encodingFormat literal is costly on QLever and on remote
+            # SPARQL endpoints alike. STRSTARTS lets engines prefix-scan instead.
+            # The version segment (e.g. /2/, /3/) is left unconstrained, which is
+            # intentionally forwards-compatible.
+            FILTER(isLiteral(?format)
+                && STRSTARTS(STR(?format), "application/ld+json;profile='http://iiif.io/api/presentation/")
+                && STRENDS(STR(?format), "/context.json'"))
         }
     }
     FILTER(?count > 0)

--- a/test/iiifStage.test.ts
+++ b/test/iiifStage.test.ts
@@ -148,10 +148,26 @@ describe('iiif.rq detection query', () => {
     expect(findEntitiesCount(quads, subsetIris[0])).toBe(3);
   });
 
-  it('matches a hypothetical IIIF Presentation v4 manifest (forwards-compatible [0-9]+)', async () => {
+  it('matches a hypothetical IIIF Presentation v4 manifest (forwards-compatible version segment)', async () => {
     const turtle = `
       <http://example.org/work/1> schema:encodingFormat
         "application/ld+json;profile='http://iiif.io/api/presentation/4/context.json'" .
+    `;
+
+    const quads = await runQueryOn(turtle);
+
+    const subsetIri = findSubsetIri(quads);
+    expect(subsetIri).toBeDefined();
+    expect(findEntitiesCount(quads, subsetIri!)).toBe(1);
+  });
+
+  it('matches any version segment, not only numeric ones (deliberate forwards-compatibility)', async () => {
+    // The detection avoids REGEX for performance and so no longer constrains the
+    // version segment to digits. A non-numeric segment is matched too; in practice
+    // the IIIF profile segment is always a version number, so this is acceptable.
+    const turtle = `
+      <http://example.org/work/1> schema:encodingFormat
+        "application/ld+json;profile='http://iiif.io/api/presentation/beta/context.json'" .
     `;
 
     const quads = await runQueryOn(turtle);


### PR DESCRIPTION
## Problem

The `iiif.rq` analysis stage detects IIIF Presentation manifests by running a `REGEX` over every `schema:encodingFormat` literal. A regex filter is expensive — QLever evaluates it by scanning literals, and remote SPARQL endpoints fare no better. In a live run this showed up as a slow `iiif.rq` stage that, on a large remote endpoint, took ~150s before the endpoint returned a 502.

This is a follow-up to #302 (which fixed the QLever-incompatible `\d` escape) and ad-freiburg/qlever#2920.

## Change

Replace the `REGEX` with `STRSTARTS` + `STRENDS`:

```sparql
FILTER(isLiteral(?format)
    && STRSTARTS(STR(?format), "application/ld+json;profile='http://iiif.io/api/presentation/")
    && STRENDS(STR(?format), "/context.json'"))
```

- Engines can prefix-scan for `STRSTARTS` instead of regex-scanning the whole literal set, lowering cost on both the local QLever and remote endpoints (reducing timeout/502 risk).
- The version segment (`/2/`, `/3/`, …) is no longer constrained to digits. This is intentionally forwards-compatible; in practice the IIIF profile segment is always a version number. All existing near-miss rejections are unchanged.

## Tests

`test/iiifStage.test.ts` — 11/11 pass, including a new test documenting the loosened (non-numeric) version segment. Note these tests run on Comunica; the QLever-specific cost characteristic is not observable there (see #302 discussion).
