### PR TITLE
build(deps): bump @lde/sparql-qlever from 0.14.4 to 0.14.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6752,9 +6752,9 @@
       }
     },
     "node_modules/@lde/sparql-qlever": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/@lde/sparql-qlever/-/sparql-qlever-0.14.4.tgz",
-      "integrity": "sha512-/YKC7aJU0tZJr43yzDY3zWFpffgFAIt2nePYLqfTALQ5oDMPVrZH6iB9t6P+6nGZ/840g+BnlkSp46VgqiGj9A==",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/@lde/sparql-qlever/-/sparql-qlever-0.14.5.tgz",
+      "integrity": "sha512-9ZostcfNMfNh9obtmgcNpzZX1HMhsXIY2V9TXuY9Y1SEY8eZK0/22gdX7b+ZXXqSsAqa0tT3QVdcjzcg8+Db1g==",
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "0.7.4",
@@ -6768,7 +6768,7 @@
         "rdf-parse": "^5.0.0",
         "rdf-serialize": "^5.1.0",
         "tslib": "^2.3.0",
-        "yauzl": "^3.2.0"
+        "yauzl": "^3.3.1"
       }
     },
     "node_modules/@lde/sparql-server": {


### PR DESCRIPTION
Bumps `@lde/sparql-qlever` from 0.14.4 to 0.14.5, pulling in the upstream fix [ldelements/lde#424](https://github.com/ldelements/lde/pull/424): `fix(sparql-qlever): shell-escape data filenames in the QLever index command`.

This addresses filename handling during the QLever import step. Done manually because the fix was published Friday evening (after that day’s Dependabot run) and Dependabot’s `daily` schedule skips weekends, so it had not yet been picked up.

The `^0.14.4` caret in `package.json` already permitted this, so only `package-lock.json` changed. Compile and tests pass locally.
