### PR TITLE
feat: validate IIIF conformance by resolving sampled manifest URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,8 +310,11 @@ manifests — detected by matching `schema:encodingFormat` literals against the
 [SCHEMA-AP-NDE](https://docs.nde.nl/schema-profile/) IIIF profile pattern — get
 a `void:subset` keyed on `dcterms:conformsTo <http://iiif.io/api/presentation/>`
 with a `void:entities` count of distinct manifests. v2 and v3 manifests are
-collapsed into a single, version-less subset; the `\d+` in the regex makes the
-detection forwards-compatible with future Presentation API versions.
+collapsed into a single, version-less subset. Detection uses `STRSTARTS` /
+`STRENDS` rather than a regex (a regex over every `encodingFormat` literal is
+costly on QLever and on remote endpoints alike); the version segment is left
+unconstrained, which is intentionally forwards-compatible with future
+Presentation API versions.
 
 ```ttl
 <https://example.com/dataset> a void:Dataset;
@@ -319,6 +322,95 @@ detection forwards-compatible with future Presentation API versions.
         dcterms:conformsTo <http://iiif.io/api/presentation/> ;
         void:entities 42 .
     ].
+```
+
+#### Validated conformance
+
+The `dcterms:conformsTo` marker above is **declared**: it records only that the
+dataset’s own RDF claims IIIF conformance. To distinguish a dataset that serves
+working manifests from one that merely claims to, a first-N sample (default 10)
+of the matched manifest IRIs is dereferenced via
+[`@lde/iiif-validator`](https://www.npmjs.com/package/@lde/iiif-validator) —
+each is checked to be a real IIIF Presentation Manifest (HTTP 2xx, parses as
+JSON, an IIIF Presentation `@context`, and a manifest `type`). Throttled
+dereferencing (≤ 4 concurrent) keeps the load off heritage hosts; a single
+broken manifest is one tick in a ratio, so there are no retries.
+
+The declared marker is **never removed** — it is the neutral statistic. The
+validation outcome is added alongside it as two
+[DQV](https://www.w3.org/TR/vocab-dqv/) integer measurements plus a
+[PROV](https://www.w3.org/TR/prov-o/) activity:
+
+```ttl
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dqv:     <http://www.w3.org/ns/dqv#> .
+@prefix prov:    <http://www.w3.org/ns/prov#> .
+
+<https://example.org/dataset>
+    dqv:hasQualityMeasurement
+        [ a dqv:QualityMeasurement ;
+          dqv:computedOn <https://example.org/dataset> ;
+          dqv:isMeasurementOf <https://data.netwerkdigitaalerfgoed.nl/def/metric/iiif-manifests-sampled> ;
+          dqv:value 10 ;
+          dcterms:conformsTo <http://iiif.io/api/presentation/> ;
+          prov:wasGeneratedBy _:validation ] ,
+        [ a dqv:QualityMeasurement ;
+          dqv:computedOn <https://example.org/dataset> ;
+          dqv:isMeasurementOf <https://data.netwerkdigitaalerfgoed.nl/def/metric/iiif-manifests-validated> ;
+          dqv:value 7 ;
+          dcterms:conformsTo <http://iiif.io/api/presentation/> ;
+          prov:wasGeneratedBy _:validation ] .
+
+_:validation
+    a prov:Activity ;
+    prov:used <https://example.org/dataset>, <http://iiif.io/api/presentation/> ;
+    prov:wasAssociatedWith <https://www.npmjs.com/package/@lde/iiif-validator> .
+```
+
+| Metric IRI | Type | Meaning |
+|---|---|---|
+| `…/metric/iiif-manifests-sampled` | `xsd:integer` | Number of manifest IRIs dereferenced — the denominator `N`. At most the configured sample size (10). |
+| `…/metric/iiif-manifests-validated` | `xsd:integer` | How many of the sampled manifests `k` resolved to a valid IIIF Presentation Manifest. |
+
+No float ratio and no baked threshold are emitted: consumers derive `k / N` and
+pick their own bar. The only non-arbitrary cut is `validated = 0` versus
+`validated > 0`. Combining the declared subset with the validated count yields
+three observable states:
+
+| State | subset + `conformsTo` | `void:entities` | sampled / validated |
+|---|---|---|---|
+| No IIIF | absent | – | – |
+| Declared but failing | present | declared count | sampled = N, validated = 0 |
+| Declared and working | present | declared count | sampled = N, validated ≥ 1 |
+
+#### Querying
+
+“Find datasets whose IIIF manifests actually resolve”:
+
+```sparql
+PREFIX dqv: <http://www.w3.org/ns/dqv#>
+
+SELECT ?dataset WHERE {
+    ?dataset dqv:hasQualityMeasurement [
+        dqv:isMeasurementOf <https://data.netwerkdigitaalerfgoed.nl/def/metric/iiif-manifests-validated> ;
+        dqv:value ?validated
+    ] .
+    FILTER(?validated > 0)
+}
+```
+
+“Find datasets that declare IIIF but whose sampled manifests all fail” (the
+diagnostic query for giving publishers feedback):
+
+```sparql
+PREFIX dqv: <http://www.w3.org/ns/dqv#>
+
+SELECT ?dataset WHERE {
+    ?dataset dqv:hasQualityMeasurement [
+        dqv:isMeasurementOf <https://data.netwerkdigitaalerfgoed.nl/def/metric/iiif-manifests-validated> ;
+        dqv:value 0
+    ] .
+}
 ```
 
 ### Distributions

--- a/README.md
+++ b/README.md
@@ -350,13 +350,13 @@ validation outcome is added alongside it as two
     dqv:hasQualityMeasurement
         [ a dqv:QualityMeasurement ;
           dqv:computedOn <https://example.org/dataset> ;
-          dqv:isMeasurementOf <https://data.netwerkdigitaalerfgoed.nl/def/metric/iiif-manifests-sampled> ;
+          dqv:isMeasurementOf <https://def.nde.nl/metric#manifests-sampled> ;
           dqv:value 10 ;
           dcterms:conformsTo <http://iiif.io/api/presentation/> ;
           prov:wasGeneratedBy _:validation ] ,
         [ a dqv:QualityMeasurement ;
           dqv:computedOn <https://example.org/dataset> ;
-          dqv:isMeasurementOf <https://data.netwerkdigitaalerfgoed.nl/def/metric/iiif-manifests-validated> ;
+          dqv:isMeasurementOf <https://def.nde.nl/metric#manifests-validated> ;
           dqv:value 7 ;
           dcterms:conformsTo <http://iiif.io/api/presentation/> ;
           prov:wasGeneratedBy _:validation ] .
@@ -369,8 +369,8 @@ _:validation
 
 | Metric IRI | Type | Meaning |
 |---|---|---|
-| `…/metric/iiif-manifests-sampled` | `xsd:integer` | Number of manifest IRIs dereferenced — the denominator `N`. At most the configured sample size (10). |
-| `…/metric/iiif-manifests-validated` | `xsd:integer` | How many of the sampled manifests `k` resolved to a valid IIIF Presentation Manifest. |
+| `…/metric#manifests-sampled` | `xsd:integer` | Number of manifest IRIs dereferenced — the denominator `N`. At most the configured sample size (10). |
+| `…/metric#manifests-validated` | `xsd:integer` | How many of the sampled manifests `k` resolved to a valid IIIF Presentation Manifest. |
 
 No float ratio and no baked threshold are emitted: consumers derive `k / N` and
 pick their own bar. The only non-arbitrary cut is `validated = 0` versus
@@ -392,7 +392,7 @@ PREFIX dqv: <http://www.w3.org/ns/dqv#>
 
 SELECT ?dataset WHERE {
     ?dataset dqv:hasQualityMeasurement [
-        dqv:isMeasurementOf <https://data.netwerkdigitaalerfgoed.nl/def/metric/iiif-manifests-validated> ;
+        dqv:isMeasurementOf <https://def.nde.nl/metric#manifests-validated> ;
         dqv:value ?validated
     ] .
     FILTER(?validated > 0)
@@ -407,7 +407,7 @@ PREFIX dqv: <http://www.w3.org/ns/dqv#>
 
 SELECT ?dataset WHERE {
     ?dataset dqv:hasQualityMeasurement [
-        dqv:isMeasurementOf <https://data.netwerkdigitaalerfgoed.nl/def/metric/iiif-manifests-validated> ;
+        dqv:isMeasurementOf <https://def.nde.nl/metric#manifests-validated> ;
         dqv:value 0
     ] .
 }
@@ -478,18 +478,18 @@ validation run:
     dqv:hasQualityMeasurement
         [ a dqv:QualityMeasurement ;
           dqv:computedOn <https://example.org/dataset> ;
-          dqv:isMeasurementOf <https://data.netwerkdigitaalerfgoed.nl/def/metric/schema-ap-nde-sample-conformance> ;
+          dqv:isMeasurementOf <https://def.nde.nl/metric#schema-ap-nde-sample-conformance> ;
           dqv:value true ;
           dcterms:conformsTo <https://docs.nde.nl/schema-profile/> ;
           prov:wasGeneratedBy _:validation ],
         [ a dqv:QualityMeasurement ;
           dqv:computedOn <https://example.org/dataset> ;
-          dqv:isMeasurementOf <https://data.netwerkdigitaalerfgoed.nl/def/metric/quads-validated> ;
+          dqv:isMeasurementOf <https://def.nde.nl/metric#quads-validated> ;
           dqv:value 5234 ;
           prov:wasGeneratedBy _:validation ],
         [ a dqv:QualityMeasurement ;
           dqv:computedOn <https://example.org/dataset> ;
-          dqv:isMeasurementOf <https://data.netwerkdigitaalerfgoed.nl/def/metric/samples-per-class> ;
+          dqv:isMeasurementOf <https://def.nde.nl/metric#samples-per-class> ;
           dqv:value 50 ;
           prov:wasGeneratedBy _:validation ] .
 
@@ -503,9 +503,9 @@ Three measurements are emitted per dataset:
 
 | Metric IRI | Type | Meaning |
 |---|---|---|
-| `…/metric/schema-ap-nde-sample-conformance` | `xsd:boolean` | Whether the sampled resources conformed to SCHEMA-AP-NDE’s SHACL shapes. Carries `dcterms:conformsTo` so consumers reach the profile IRI via the DQV path alone. |
-| `…/metric/quads-validated` | `xsd:integer` | Number of quads the validator inspected — the union of the per-class sample subgraphs. Contextualises the conformance verdict by indicating coverage. |
-| `…/metric/samples-per-class` | `xsd:integer` | Configured sample cap per `sh:targetClass`. Currently 50. Same value across all datasets in a given pipeline run; included so consumers can interpret the coverage figure. |
+| `…/metric#schema-ap-nde-sample-conformance` | `xsd:boolean` | Whether the sampled resources conformed to SCHEMA-AP-NDE’s SHACL shapes. Carries `dcterms:conformsTo` so consumers reach the profile IRI via the DQV path alone. |
+| `…/metric#quads-validated` | `xsd:integer` | Number of quads the validator inspected — the union of the per-class sample subgraphs. Contextualises the conformance verdict by indicating coverage. |
+| `…/metric#samples-per-class` | `xsd:integer` | Configured sample cap per `sh:targetClass`. Currently 50. Same value across all datasets in a given pipeline run; included so consumers can interpret the coverage figure. |
 
 The conformance measurement has three observable states, distinguished by combining `dqv:value` with `quads-validated`:
 
@@ -533,7 +533,7 @@ SELECT ?dataset WHERE {
     ?dataset dqv:hasQualityMeasurement
         [ dqv:value true ;
           dcterms:conformsTo <https://docs.nde.nl/schema-profile/> ],
-        [ dqv:isMeasurementOf <https://data.netwerkdigitaalerfgoed.nl/def/metric/quads-validated> ;
+        [ dqv:isMeasurementOf <https://def.nde.nl/metric#quads-validated> ;
           dqv:value ?n ] .
     FILTER(?n > 0)
 }
@@ -560,7 +560,7 @@ PREFIX dqv:  <http://www.w3.org/ns/dqv#>
 
 SELECT ?dataset WHERE {
     ?dataset dqv:hasQualityMeasurement [
-        dqv:isMeasurementOf <https://data.netwerkdigitaalerfgoed.nl/def/metric/quads-validated> ;
+        dqv:isMeasurementOf <https://def.nde.nl/metric#quads-validated> ;
         dqv:value 0
     ] .
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@lde/dataset": "^0.7.4",
         "@lde/dataset-registry-client": "^0.8.0",
+        "@lde/iiif-validator": "^0.1.1",
         "@lde/pipeline": "^0.30.4",
         "@lde/pipeline-console-reporter": "^0.21.4",
         "@lde/pipeline-shacl-sampler": "^0.4.4",
@@ -20,6 +21,7 @@
         "@netwerk-digitaal-erfgoed/network-of-terms-catalog": "^10.19.22",
         "env-schema": "^7.0.0",
         "n3": "^2.0.1",
+        "p-limit": "^3.1.0",
         "rdf-dereference": "^5.0.0"
       },
       "devDependencies": {
@@ -6649,6 +6651,15 @@
         "tslib": "^2.3.0"
       }
     },
+    "node_modules/@lde/iiif-validator": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@lde/iiif-validator/-/iiif-validator-0.1.1.tgz",
+      "integrity": "sha512-SFCPnFHBfNCu0+FqyqSwiGqeVHuJHrsXeGoSpbN4KHl+U6Hq4WFJwJ0+g1W82u+tQFw9hWygZJiou91tcaIMbw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
     "node_modules/@lde/pipeline": {
       "version": "0.30.4",
       "resolved": "https://registry.npmjs.org/@lde/pipeline/-/pipeline-0.30.4.tgz",
@@ -12682,7 +12693,6 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -18648,7 +18658,6 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@lde/dataset": "^0.7.4",
     "@lde/dataset-registry-client": "^0.8.0",
+    "@lde/iiif-validator": "^0.1.1",
     "@lde/pipeline": "^0.30.4",
     "@lde/pipeline-console-reporter": "^0.21.4",
     "@lde/pipeline-shacl-sampler": "^0.4.4",
@@ -42,6 +43,7 @@
     "@netwerk-digitaal-erfgoed/network-of-terms-catalog": "^10.19.22",
     "env-schema": "^7.0.0",
     "n3": "^2.0.1",
+    "p-limit": "^3.1.0",
     "rdf-dereference": "^5.0.0"
   },
   "devDependencies": {

--- a/queries/analysis/iiif.rq
+++ b/queries/analysis/iiif.rq
@@ -7,7 +7,14 @@ CONSTRUCT {
         void:subset ?iiifSubset .
     ?iiifSubset
         dcterms:conformsTo <http://iiif.io/api/presentation/> ;
-        void:entities ?count .
+        void:entities ?count ;
+        # Intermediate triple: a capped, first-N sample of the matched manifest
+        # IRIs, consumed and stripped by the verification executor before
+        # output. It is never published. The combined query (a COUNT sub-select
+        # cross-joined with a LIMIT sub-select) keeps detection a single
+        # round-trip, which matters because most datasets are queried against
+        # their own remote SPARQL endpoint.
+        <https://data.netwerkdigitaalerfgoed.nl/def/internal/iiif-manifest-sample> ?manifest .
 }
 WHERE {
     {
@@ -23,6 +30,19 @@ WHERE {
                 && STRSTARTS(STR(?format), "application/ld+json;profile='http://iiif.io/api/presentation/")
                 && STRENDS(STR(?format), "/context.json'"))
         }
+    }
+    {
+        # First-N sample of distinct manifest IRIs. First-N (not random) is
+        # cheap and reproducible: the failure mode is systemic, so the first N
+        # manifests are a sufficient probe. #limit# is substituted by iiifStage.
+        SELECT DISTINCT ?manifest {
+            #subjectFilter#
+            ?manifest schema:encodingFormat|<http://schema.org/encodingFormat> ?format .
+            FILTER(isLiteral(?format)
+                && STRSTARTS(STR(?format), "application/ld+json;profile='http://iiif.io/api/presentation/")
+                && STRENDS(STR(?format), "/context.json'"))
+        }
+        LIMIT #limit#
     }
     FILTER(?count > 0)
     BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#iiif-", MD5("http://iiif.io/api/presentation/"))) AS ?iiifSubset)

--- a/queries/analysis/iiif.rq
+++ b/queries/analysis/iiif.rq
@@ -9,12 +9,12 @@ CONSTRUCT {
         dcterms:conformsTo <http://iiif.io/api/presentation/> ;
         void:entities ?count ;
         # Intermediate triple: a capped, first-N sample of the matched manifest
-        # IRIs, consumed and stripped by the verification executor before
-        # output. It is never published. The combined query (a COUNT sub-select
-        # cross-joined with a LIMIT sub-select) keeps detection a single
-        # round-trip, which matters because most datasets are queried against
-        # their own remote SPARQL endpoint.
-        <https://data.netwerkdigitaalerfgoed.nl/def/internal/iiif-manifest-sample> ?manifest .
+        # IRIs, consumed and stripped by the validation executor before output;
+        # it never reaches the published graph. The combined query (a COUNT
+        # sub-select cross-joined with a LIMIT sub-select) keeps detection a
+        # single round-trip, which matters because most datasets are queried
+        # against their own remote SPARQL endpoint.
+        <https://def.nde.nl/iiif#manifest-sample> ?manifest .
 }
 WHERE {
     {

--- a/src/iiifStage.ts
+++ b/src/iiifStage.ts
@@ -1,24 +1,54 @@
 import {resolve} from 'node:path';
 import {Stage, SparqlConstructExecutor, readQueryFile} from '@lde/pipeline';
+import {IiifValidationExecutor} from './iiifValidationExecutor.js';
 
 const QUERY_FILE = resolve('queries/analysis/iiif.rq');
+
+/** Default number of manifest IRIs sampled per dataset for verification. */
+export const DEFAULT_MANIFEST_SAMPLE_SIZE = 10;
+
+export interface IiifStageOptions {
+  /**
+   * Number of manifest IRIs to sample and dereference per dataset. Threaded
+   * into the detection query's `#limit#` placeholder. First-N (not random)
+   * sampling: cheap and reproducible for a provenance-bearing measurement.
+   *
+   * @default 10
+   */
+  manifestSampleSize?: number;
+}
 
 /**
  * Detect IIIF Presentation manifests in a dataset and emit a `void:subset`
  * keyed on `dcterms:conformsTo <http://iiif.io/api/presentation/>` with a
- * `void:entities` count of distinct manifests.
+ * `void:entities` count of distinct manifests, then *verify* a sample of those
+ * manifests by dereferencing them.
  *
  * Detection mirrors SCHEMA-AP-NDE’s `_:IIIFPresentationManifestShape`: a
  * resource is a IIIF manifest iff its `schema:encodingFormat` literal matches
- * the JSON-LD context-profile pattern for any IIIF Presentation version.
+ * the JSON-LD context-profile pattern for any IIIF Presentation version. The
+ * declared `dcterms:conformsTo` marker is never removed — it distinguishes
+ * “no IIIF” from “declared but failing”. Validation adds two DQV
+ * measurements (`iiif-manifests-sampled`, `iiif-manifests-validated`) so
+ * consumers can tell working manifests apart from broken ones.
  *
- * Per-request timeout is configured at the {@link Pipeline} level via
- * `PipelineOptions.timeout`.
+ * Per-request timeout for the SPARQL query is configured at the
+ * {@link Pipeline} level via `PipelineOptions.timeout`; the manifest
+ * dereference timeout is owned by `@lde/iiif-validator`.
  */
-export async function iiifStage(): Promise<Stage> {
-  const query = await readQueryFile(QUERY_FILE);
+export async function iiifStage(
+  options: IiifStageOptions = {},
+): Promise<Stage> {
+  const sampleSize = options.manifestSampleSize ?? DEFAULT_MANIFEST_SAMPLE_SIZE;
+  const query = (await readQueryFile(QUERY_FILE)).replaceAll(
+    '#limit#',
+    String(sampleSize),
+  );
+  // `deduplicate` collapses the constant subset/conformsTo/entities triples,
+  // which the COUNT × sample cross-join repeats once per sampled row.
+  const detection = new SparqlConstructExecutor({query, deduplicate: true});
   return new Stage({
     name: 'iiif.rq',
-    executors: new SparqlConstructExecutor({query}),
+    executors: new IiifValidationExecutor(detection),
   });
 }

--- a/src/iiifStage.ts
+++ b/src/iiifStage.ts
@@ -29,7 +29,7 @@ export interface IiifStageOptions {
  * the JSON-LD context-profile pattern for any IIIF Presentation version. The
  * declared `dcterms:conformsTo` marker is never removed — it distinguishes
  * “no IIIF” from “declared but failing”. Validation adds two DQV
- * measurements (`iiif-manifests-sampled`, `iiif-manifests-validated`) so
+ * measurements (`manifests-sampled`, `manifests-validated`) so
  * consumers can tell working manifests apart from broken ones.
  *
  * Per-request timeout for the SPARQL query is configured at the

--- a/src/iiifValidationExecutor.ts
+++ b/src/iiifValidationExecutor.ts
@@ -31,22 +31,18 @@ const PROV_WAS_GENERATED_BY = namedNode(
 const XSD_INTEGER = namedNode('http://www.w3.org/2001/XMLSchema#integer');
 const IIIF_PRESENTATION = namedNode('http://iiif.io/api/presentation/');
 
-const METRIC_BASE = 'https://data.netwerkdigitaalerfgoed.nl/def/metric/';
-const MANIFESTS_SAMPLED_METRIC = namedNode(
-  `${METRIC_BASE}iiif-manifests-sampled`,
-);
+const METRIC_BASE = 'https://def.nde.nl/metric#';
+const MANIFESTS_SAMPLED_METRIC = namedNode(`${METRIC_BASE}manifests-sampled`);
 const MANIFESTS_VALIDATED_METRIC = namedNode(
-  `${METRIC_BASE}iiif-manifests-validated`,
+  `${METRIC_BASE}manifests-validated`,
 );
 
 /**
  * Predicate of the intermediate triple emitted by `iiif.rq` carrying a sampled
- * manifest IRI. Consumed and stripped here; never published. Must match the
- * IRI hard-coded in `queries/analysis/iiif.rq`.
+ * manifest IRI. Consumed and stripped here; never reaches output. Must match
+ * the IRI hard-coded in `queries/analysis/iiif.rq`.
  */
-const MANIFEST_SAMPLE = namedNode(
-  'https://data.netwerkdigitaalerfgoed.nl/def/internal/iiif-manifest-sample',
-);
+const MANIFEST_SAMPLE = namedNode('https://def.nde.nl/iiif#manifest-sample');
 
 const DEFAULT_VALIDATOR_SOFTWARE = namedNode(
   'https://www.npmjs.com/package/@lde/iiif-validator',
@@ -83,7 +79,7 @@ export interface IiifValidationExecutorOptions {
  * declared marker is never removed), the intermediate manifest-sample triples
  * are stripped, and the sampled manifest URIs are dereferenced via
  * `@lde/iiif-validator`. The outcome is appended as two DQV integer
- * measurements (`iiif-manifests-sampled`, `iiif-manifests-validated`) plus a
+ * measurements (`manifests-sampled`, `manifests-validated`) plus a
  * PROV activity, mirroring {@link qualityMeasurementsStage}. Consumers derive
  * `k / N` and pick their own trust threshold; the only non-arbitrary cut is
  * `validated = 0` (failing) versus `validated > 0` (working).

--- a/src/iiifValidationExecutor.ts
+++ b/src/iiifValidationExecutor.ts
@@ -1,0 +1,204 @@
+import {DataFactory} from 'n3';
+import pLimit from 'p-limit';
+import type {Quad} from '@rdfjs/types';
+import type {Dataset, Distribution} from '@lde/dataset';
+import {NotSupported, type Executor, type ExecuteOptions} from '@lde/pipeline';
+import {validateManifest, type ManifestValidation} from '@lde/iiif-validator';
+
+const {namedNode, literal, blankNode, quad} = DataFactory;
+
+const RDF_TYPE = namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+const DQV_HAS_QUALITY_MEASUREMENT = namedNode(
+  'http://www.w3.org/ns/dqv#hasQualityMeasurement',
+);
+const DQV_QUALITY_MEASUREMENT = namedNode(
+  'http://www.w3.org/ns/dqv#QualityMeasurement',
+);
+const DQV_COMPUTED_ON = namedNode('http://www.w3.org/ns/dqv#computedOn');
+const DQV_IS_MEASUREMENT_OF = namedNode(
+  'http://www.w3.org/ns/dqv#isMeasurementOf',
+);
+const DQV_VALUE = namedNode('http://www.w3.org/ns/dqv#value');
+const DCTERMS_CONFORMS_TO = namedNode('http://purl.org/dc/terms/conformsTo');
+const PROV_ACTIVITY = namedNode('http://www.w3.org/ns/prov#Activity');
+const PROV_USED = namedNode('http://www.w3.org/ns/prov#used');
+const PROV_WAS_ASSOCIATED_WITH = namedNode(
+  'http://www.w3.org/ns/prov#wasAssociatedWith',
+);
+const PROV_WAS_GENERATED_BY = namedNode(
+  'http://www.w3.org/ns/prov#wasGeneratedBy',
+);
+const XSD_INTEGER = namedNode('http://www.w3.org/2001/XMLSchema#integer');
+const IIIF_PRESENTATION = namedNode('http://iiif.io/api/presentation/');
+
+const METRIC_BASE = 'https://data.netwerkdigitaalerfgoed.nl/def/metric/';
+const MANIFESTS_SAMPLED_METRIC = namedNode(
+  `${METRIC_BASE}iiif-manifests-sampled`,
+);
+const MANIFESTS_VALIDATED_METRIC = namedNode(
+  `${METRIC_BASE}iiif-manifests-validated`,
+);
+
+/**
+ * Predicate of the intermediate triple emitted by `iiif.rq` carrying a sampled
+ * manifest IRI. Consumed and stripped here; never published. Must match the
+ * IRI hard-coded in `queries/analysis/iiif.rq`.
+ */
+const MANIFEST_SAMPLE = namedNode(
+  'https://data.netwerkdigitaalerfgoed.nl/def/internal/iiif-manifest-sample',
+);
+
+const DEFAULT_VALIDATOR_SOFTWARE = namedNode(
+  'https://www.npmjs.com/package/@lde/iiif-validator',
+);
+
+/**
+ * Default in-flight dereference cap. Kept low because the sampled manifests
+ * typically share a single heritage host that we must not overload.
+ */
+const DEFAULT_CONCURRENCY = 4;
+
+/** Validates a single manifest URL and reports the verdict. */
+export type ValidateManifest = (url: string) => Promise<ManifestValidation>;
+
+export interface IiifValidationExecutorOptions {
+  /**
+   * Manifest validator. Injectable for testing; defaults to dereferencing via
+   * `@lde/iiif-validator`.
+   */
+  validate?: ValidateManifest;
+  /** Maximum concurrent dereferences. Defaults to 4. */
+  concurrency?: number;
+  /**
+   * IRI identifying the validator software for the `prov:wasAssociatedWith`
+   * link. Defaults to the npm page for `@lde/iiif-validator`.
+   */
+  validatorSoftware?: string;
+}
+
+/**
+ * Executor decorator that turns *declared* IIIF conformance into *validated*
+ * conformance. It wraps the detection {@link Executor}: the VoID `void:subset`,
+ * `dcterms:conformsTo`, and `void:entities` quads pass through unchanged (the
+ * declared marker is never removed), the intermediate manifest-sample triples
+ * are stripped, and the sampled manifest URIs are dereferenced via
+ * `@lde/iiif-validator`. The outcome is appended as two DQV integer
+ * measurements (`iiif-manifests-sampled`, `iiif-manifests-validated`) plus a
+ * PROV activity, mirroring {@link qualityMeasurementsStage}. Consumers derive
+ * `k / N` and pick their own trust threshold; the only non-arbitrary cut is
+ * `validated = 0` (failing) versus `validated > 0` (working).
+ */
+export class IiifValidationExecutor implements Executor {
+  private readonly validate: ValidateManifest;
+  private readonly concurrency: number;
+  private readonly validatorSoftware;
+
+  constructor(
+    private readonly inner: Executor,
+    options: IiifValidationExecutorOptions = {},
+  ) {
+    this.validate = options.validate ?? (url => validateManifest(url));
+    this.concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
+    this.validatorSoftware = options.validatorSoftware
+      ? namedNode(options.validatorSoftware)
+      : DEFAULT_VALIDATOR_SOFTWARE;
+  }
+
+  async execute(
+    dataset: Dataset,
+    distribution: Distribution,
+    options?: ExecuteOptions,
+  ): Promise<AsyncIterable<Quad> | NotSupported> {
+    const result = await this.inner.execute(dataset, distribution, options);
+    if (result instanceof NotSupported) {
+      return result;
+    }
+    return this.withValidation(result, dataset);
+  }
+
+  /**
+   * Pass the inner VoID quads through unchanged while intercepting the
+   * intermediate manifest-sample triples; after the inner stream is exhausted,
+   * dereference the sampled URIs and append the measurement quads.
+   */
+  private async *withValidation(
+    quads: AsyncIterable<Quad>,
+    dataset: Dataset,
+  ): AsyncIterable<Quad> {
+    const sampledManifests: string[] = [];
+    for await (const q of quads) {
+      if (q.predicate.equals(MANIFEST_SAMPLE)) {
+        sampledManifests.push(q.object.value);
+        continue;
+      }
+      yield q;
+    }
+
+    // No IIIF subset detected: emit nothing extra (state 1, “no IIIF”).
+    if (sampledManifests.length === 0) {
+      return;
+    }
+
+    const limit = pLimit(this.concurrency);
+    const verdicts = await Promise.allSettled(
+      sampledManifests.map(url => limit(() => this.validate(url))),
+    );
+    const validated = verdicts.filter(
+      verdict => verdict.status === 'fulfilled' && verdict.value.valid,
+    ).length;
+
+    yield* this.measurementQuads(dataset, sampledManifests.length, validated);
+  }
+
+  private *measurementQuads(
+    dataset: Dataset,
+    sampled: number,
+    validated: number,
+  ): Generator<Quad> {
+    const subject = namedNode(dataset.iri.toString());
+    const activity = blankNode();
+    const sampledMeasurement = blankNode();
+    const validatedMeasurement = blankNode();
+
+    // PROV: the dereferencing activity.
+    yield quad(activity, RDF_TYPE, PROV_ACTIVITY);
+    yield quad(activity, PROV_USED, subject);
+    yield quad(activity, PROV_USED, IIIF_PRESENTATION);
+    yield quad(activity, PROV_WAS_ASSOCIATED_WITH, this.validatorSoftware);
+
+    yield quad(subject, DQV_HAS_QUALITY_MEASUREMENT, sampledMeasurement);
+    yield quad(subject, DQV_HAS_QUALITY_MEASUREMENT, validatedMeasurement);
+
+    yield* this.integerMeasurement(
+      sampledMeasurement,
+      subject,
+      MANIFESTS_SAMPLED_METRIC,
+      sampled,
+      activity,
+    );
+    yield* this.integerMeasurement(
+      validatedMeasurement,
+      subject,
+      MANIFESTS_VALIDATED_METRIC,
+      validated,
+      activity,
+    );
+  }
+
+  private *integerMeasurement(
+    measurement: ReturnType<typeof blankNode>,
+    subject: ReturnType<typeof namedNode>,
+    metric: ReturnType<typeof namedNode>,
+    value: number,
+    activity: ReturnType<typeof blankNode>,
+  ): Generator<Quad> {
+    yield quad(measurement, RDF_TYPE, DQV_QUALITY_MEASUREMENT);
+    yield quad(measurement, DQV_COMPUTED_ON, subject);
+    yield quad(measurement, DQV_IS_MEASUREMENT_OF, metric);
+    yield quad(measurement, DQV_VALUE, literal(String(value), XSD_INTEGER));
+    // Carry the IIIF profile so the DQV navigation path reaches what was
+    // validated without leaving DQV (mirrors the conformance measurement).
+    yield quad(measurement, DCTERMS_CONFORMS_TO, IIIF_PRESENTATION);
+    yield quad(measurement, PROV_WAS_GENERATED_BY, activity);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ const SCHEMA_AP_NDE_SHAPES =
   'https://raw.githubusercontent.com/netwerk-digitaal-erfgoed/schema-profile/main/shacl.ttl';
 const SCHEMA_AP_NDE_PROFILE = 'https://docs.nde.nl/schema-profile/';
 const SAMPLES_PER_CLASS = 50;
+const IIIF_MANIFEST_SAMPLE_SIZE = 10;
 
 const uriSpaces = await buildUriSpacesMap();
 const {importer, server} = createQlever({
@@ -87,7 +88,7 @@ const sampleStages = await shaclSampleStages({
 const stages = [
   ...voidStageList,
   ...sampleStages,
-  await iiifStage(),
+  await iiifStage({manifestSampleSize: IIIF_MANIFEST_SAMPLE_SIZE}),
   qualityMeasurementsStage({
     validator: schemaApValidator,
     profile: SCHEMA_AP_NDE_PROFILE,

--- a/src/qualityMeasurementsStage.ts
+++ b/src/qualityMeasurementsStage.ts
@@ -29,7 +29,7 @@ const PROV_WAS_GENERATED_BY = namedNode(
 const XSD_BOOLEAN = namedNode('http://www.w3.org/2001/XMLSchema#boolean');
 const XSD_INTEGER = namedNode('http://www.w3.org/2001/XMLSchema#integer');
 
-const METRIC_BASE = 'https://data.netwerkdigitaalerfgoed.nl/def/metric/';
+const METRIC_BASE = 'https://def.nde.nl/metric#';
 const CONFORMANCE_METRIC = namedNode(
   `${METRIC_BASE}schema-ap-nde-sample-conformance`,
 );

--- a/test/iiifStage.test.ts
+++ b/test/iiifStage.test.ts
@@ -14,9 +14,7 @@ const VOID_SUBSET = namedNode('http://rdfs.org/ns/void#subset');
 const VOID_ENTITIES = namedNode('http://rdfs.org/ns/void#entities');
 const DCTERMS_CONFORMS_TO = namedNode('http://purl.org/dc/terms/conformsTo');
 const IIIF_PRESENTATION = namedNode('http://iiif.io/api/presentation/');
-const MANIFEST_SAMPLE = namedNode(
-  'https://data.netwerkdigitaalerfgoed.nl/def/internal/iiif-manifest-sample',
-);
+const MANIFEST_SAMPLE = namedNode('https://def.nde.nl/iiif#manifest-sample');
 const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
 
 const DATASET_IRI = 'http://example.org/dataset/1';

--- a/test/iiifStage.test.ts
+++ b/test/iiifStage.test.ts
@@ -14,6 +14,9 @@ const VOID_SUBSET = namedNode('http://rdfs.org/ns/void#subset');
 const VOID_ENTITIES = namedNode('http://rdfs.org/ns/void#entities');
 const DCTERMS_CONFORMS_TO = namedNode('http://purl.org/dc/terms/conformsTo');
 const IIIF_PRESENTATION = namedNode('http://iiif.io/api/presentation/');
+const MANIFEST_SAMPLE = namedNode(
+  'https://data.netwerkdigitaalerfgoed.nl/def/internal/iiif-manifest-sample',
+);
 const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
 
 const DATASET_IRI = 'http://example.org/dataset/1';
@@ -37,26 +40,51 @@ beforeAll(async () => {
   queryTemplate = (await readFile(queryPath)).toString();
 });
 
-function buildQuery(subjectFilter = ''): string {
-  // Mirror SparqlConstructExecutor's substitutions: subjectFilter pattern,
+function buildQuery(subjectFilter = '', limit = 10): string {
+  // Mirror iiifStage's and SparqlConstructExecutor's substitutions: the
+  // #limit# sample cap (threaded by iiifStage), the subjectFilter pattern,
   // and ?dataset → the dataset IRI literal.
   return queryTemplate
+    .replaceAll('#limit#', String(limit))
     .replaceAll('#subjectFilter#', subjectFilter)
     .replaceAll('?dataset', `<${DATASET_IRI}>`);
 }
 
-async function runQueryOn(turtle: string, subjectFilter = ''): Promise<Quad[]> {
+async function runQueryOn(
+  turtle: string,
+  subjectFilter = '',
+  limit = 10,
+): Promise<Quad[]> {
   const store = new Store();
   const parser = new Parser();
   store.addQuads(parser.parse(PREFIXES + turtle));
 
   const engine = new QueryEngine();
-  const stream = await engine.queryQuads(buildQuery(subjectFilter), {
+  const stream = await engine.queryQuads(buildQuery(subjectFilter, limit), {
     sources: [store],
   });
+  // CONSTRUCT is set-semantics, but the cross-join of the COUNT and sample
+  // sub-selects makes the engine's stream repeat the constant triples once per
+  // sampled row. Production collapses these via the executor's `deduplicate`
+  // option; mirror that here so the test asserts the query's logical graph.
+  const seen = new Set<string>();
   const quads: Quad[] = [];
-  for await (const q of stream) quads.push(q);
+  for await (const q of stream) {
+    const key = `${q.subject.value}|${q.predicate.value}|${q.object.value}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      quads.push(q);
+    }
+  }
   return quads;
+}
+
+function findSampleManifests(quads: Quad[], subset: string): string[] {
+  return quads
+    .filter(
+      q => q.subject.value === subset && q.predicate.equals(MANIFEST_SAMPLE),
+    )
+    .map(q => q.object.value);
 }
 
 function findSubsetIri(quads: Quad[]): string | undefined {
@@ -237,6 +265,55 @@ describe('iiif.rq detection query', () => {
     const subsetIri = findSubsetIri(quads);
     expect(subsetIri).toBeDefined();
     expect(findEntitiesCount(quads, subsetIri!)).toBe(2);
+  });
+
+  it('emits a sample of the matched manifest IRIs alongside the declared count', async () => {
+    const turtle = `
+      <http://example.org/work/1> schema:encodingFormat
+        "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json'" .
+      <http://example.org/work/2> schema:encodingFormat
+        "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json'" .
+    `;
+
+    const quads = await runQueryOn(turtle);
+
+    const subsetIri = findSubsetIri(quads);
+    expect(subsetIri).toBeDefined();
+    // Declared count is preserved unchanged.
+    expect(findEntitiesCount(quads, subsetIri!)).toBe(2);
+    // Every matched manifest is sampled (count ≤ limit).
+    expect(findSampleManifests(quads, subsetIri!).sort()).toEqual([
+      'http://example.org/work/1',
+      'http://example.org/work/2',
+    ]);
+  });
+
+  it('caps the manifest sample at the configured limit', async () => {
+    const turtle = `
+      <http://example.org/work/1> schema:encodingFormat
+        "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json'" .
+      <http://example.org/work/2> schema:encodingFormat
+        "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json'" .
+      <http://example.org/work/3> schema:encodingFormat
+        "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json'" .
+    `;
+
+    const quads = await runQueryOn(turtle, '', 2);
+
+    const subsetIri = findSubsetIri(quads);
+    expect(subsetIri).toBeDefined();
+    // The declared count covers all three manifests …
+    expect(findEntitiesCount(quads, subsetIri!)).toBe(3);
+    // … but only two are sampled, and each is one of the matched manifests.
+    const sampled = findSampleManifests(quads, subsetIri!);
+    expect(sampled).toHaveLength(2);
+    for (const manifest of sampled) {
+      expect([
+        'http://example.org/work/1',
+        'http://example.org/work/2',
+        'http://example.org/work/3',
+      ]).toContain(manifest);
+    }
   });
 
   it('honours the subjectFilter, scoping the count to the dataset', async () => {

--- a/test/iiifValidationExecutor.test.ts
+++ b/test/iiifValidationExecutor.test.ts
@@ -1,0 +1,251 @@
+import {describe, it, expect} from 'vitest';
+import {DataFactory} from 'n3';
+import type {Quad} from '@rdfjs/types';
+import {Dataset, Distribution} from '@lde/dataset';
+import {NotSupported, type Executor} from '@lde/pipeline';
+import {
+  IiifValidationExecutor,
+  type ValidateManifest,
+} from '../src/iiifValidationExecutor.js';
+
+const {namedNode, literal, quad} = DataFactory;
+
+const DATASET_IRI = 'http://example.org/dataset/1';
+const SUBSET_IRI = `${DATASET_IRI}/.well-known/void#iiif`;
+
+const RDF_TYPE = namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+const VOID_DATASET = namedNode('http://rdfs.org/ns/void#Dataset');
+const VOID_SUBSET = namedNode('http://rdfs.org/ns/void#subset');
+const VOID_ENTITIES = namedNode('http://rdfs.org/ns/void#entities');
+const DCTERMS_CONFORMS_TO = namedNode('http://purl.org/dc/terms/conformsTo');
+const IIIF_PRESENTATION = namedNode('http://iiif.io/api/presentation/');
+const MANIFEST_SAMPLE = namedNode(
+  'https://data.netwerkdigitaalerfgoed.nl/def/internal/iiif-manifest-sample',
+);
+const XSD_INTEGER = namedNode('http://www.w3.org/2001/XMLSchema#integer');
+const DQV_HAS_QUALITY_MEASUREMENT = namedNode(
+  'http://www.w3.org/ns/dqv#hasQualityMeasurement',
+);
+const DQV_IS_MEASUREMENT_OF = namedNode(
+  'http://www.w3.org/ns/dqv#isMeasurementOf',
+);
+const DQV_VALUE = namedNode('http://www.w3.org/ns/dqv#value');
+const DQV_COMPUTED_ON = namedNode('http://www.w3.org/ns/dqv#computedOn');
+const METRIC_BASE = 'https://data.netwerkdigitaalerfgoed.nl/def/metric/';
+const MANIFESTS_SAMPLED_METRIC = namedNode(
+  `${METRIC_BASE}iiif-manifests-sampled`,
+);
+const MANIFESTS_VALIDATED_METRIC = namedNode(
+  `${METRIC_BASE}iiif-manifests-validated`,
+);
+
+/** Find the integer value of the measurement of the given metric. */
+function measurementValue(quads: Quad[], metric: string): number | undefined {
+  const measurement = quads.find(
+    q => q.predicate.equals(DQV_IS_MEASUREMENT_OF) && q.object.value === metric,
+  )?.subject;
+  if (!measurement) return undefined;
+  const value = quads.find(
+    q => q.subject.equals(measurement) && q.predicate.equals(DQV_VALUE),
+  );
+  return value ? Number(value.object.value) : undefined;
+}
+
+const dataset = new Dataset({iri: new URL(DATASET_IRI), distributions: []});
+const distribution = Distribution.sparql(new URL('http://example.org/sparql'));
+
+/** A fake inner executor that yields a fixed synthetic quad stream. */
+function innerYielding(quads: Quad[]): Executor {
+  return {
+    async execute() {
+      return (async function* () {
+        for (const q of quads) yield q;
+      })();
+    },
+  };
+}
+
+async function collect(
+  result: AsyncIterable<Quad> | NotSupported,
+): Promise<Quad[]> {
+  if (result instanceof NotSupported)
+    throw new Error('unexpected NotSupported');
+  const quads: Quad[] = [];
+  for await (const q of result) quads.push(q);
+  return quads;
+}
+
+/** The VoID quads the detection query emits for a dataset with IIIF. */
+function voidQuads(): Quad[] {
+  const dataset = namedNode(DATASET_IRI);
+  const subset = namedNode(SUBSET_IRI);
+  return [
+    quad(dataset, RDF_TYPE, VOID_DATASET),
+    quad(dataset, VOID_SUBSET, subset),
+    quad(subset, DCTERMS_CONFORMS_TO, IIIF_PRESENTATION),
+    quad(subset, VOID_ENTITIES, literal('2', XSD_INTEGER)),
+  ];
+}
+
+function sampleQuad(manifestUrl: string): Quad {
+  return quad(namedNode(SUBSET_IRI), MANIFEST_SAMPLE, namedNode(manifestUrl));
+}
+
+const validateByName: ValidateManifest = async (url: string) =>
+  url.includes('good')
+    ? {valid: true, reason: 'valid-manifest'}
+    : {valid: false, reason: 'http-error'};
+
+describe('IiifValidationExecutor', () => {
+  it('passes VoID quads through and strips the manifest-sample triples', async () => {
+    const inner = innerYielding([
+      ...voidQuads(),
+      sampleQuad('http://example.org/good/1'),
+      sampleQuad('http://example.org/bad/2'),
+    ]);
+
+    const executor = new IiifValidationExecutor(inner, {
+      validate: validateByName,
+    });
+    const out = await collect(await executor.execute(dataset, distribution));
+
+    // VoID subset quads survive unchanged.
+    expect(
+      out.some(
+        q =>
+          q.predicate.equals(VOID_SUBSET) &&
+          q.object.equals(namedNode(SUBSET_IRI)),
+      ),
+    ).toBe(true);
+    expect(out.some(q => q.predicate.equals(DCTERMS_CONFORMS_TO))).toBe(true);
+    expect(out.some(q => q.predicate.equals(VOID_ENTITIES))).toBe(true);
+
+    // The intermediate manifest-sample triples never leak into the output.
+    expect(out.some(q => q.predicate.equals(MANIFEST_SAMPLE))).toBe(false);
+  });
+
+  it('records DQV sampled and validated counts (k > 0)', async () => {
+    const inner = innerYielding([
+      ...voidQuads(),
+      sampleQuad('http://example.org/good/1'),
+      sampleQuad('http://example.org/bad/2'),
+    ]);
+
+    const executor = new IiifValidationExecutor(inner, {
+      validate: validateByName,
+    });
+    const out = await collect(await executor.execute(dataset, distribution));
+
+    expect(measurementValue(out, MANIFESTS_SAMPLED_METRIC.value)).toBe(2);
+    expect(measurementValue(out, MANIFESTS_VALIDATED_METRIC.value)).toBe(1);
+
+    // Measurements are computed on the dataset and carry the IIIF profile.
+    const sampledMeasurement = out.find(
+      q =>
+        q.predicate.equals(DQV_IS_MEASUREMENT_OF) &&
+        q.object.equals(MANIFESTS_SAMPLED_METRIC),
+    )?.subject;
+    expect(sampledMeasurement).toBeDefined();
+    expect(
+      out.some(
+        q =>
+          q.subject.equals(sampledMeasurement!) &&
+          q.predicate.equals(DQV_COMPUTED_ON) &&
+          q.object.equals(namedNode(DATASET_IRI)),
+      ),
+    ).toBe(true);
+    expect(
+      out.some(
+        q =>
+          q.subject.equals(sampledMeasurement!) &&
+          q.predicate.equals(DCTERMS_CONFORMS_TO) &&
+          q.object.equals(IIIF_PRESENTATION),
+      ),
+    ).toBe(true);
+
+    // The dataset links to both measurements.
+    expect(
+      out.filter(
+        q =>
+          q.subject.equals(namedNode(DATASET_IRI)) &&
+          q.predicate.equals(DQV_HAS_QUALITY_MEASUREMENT),
+      ),
+    ).toHaveLength(2);
+  });
+
+  it('records validated = 0 when every sampled manifest fails (k = 0)', async () => {
+    const inner = innerYielding([
+      ...voidQuads(),
+      sampleQuad('http://example.org/bad/1'),
+      sampleQuad('http://example.org/bad/2'),
+    ]);
+
+    const executor = new IiifValidationExecutor(inner, {
+      validate: validateByName,
+    });
+    const out = await collect(await executor.execute(dataset, distribution));
+
+    // The declared subset still passes through (state 2: declared but failing).
+    expect(
+      out.some(
+        q =>
+          q.predicate.equals(DCTERMS_CONFORMS_TO) &&
+          q.object.equals(IIIF_PRESENTATION),
+      ),
+    ).toBe(true);
+    expect(measurementValue(out, MANIFESTS_SAMPLED_METRIC.value)).toBe(2);
+    expect(measurementValue(out, MANIFESTS_VALIDATED_METRIC.value)).toBe(0);
+  });
+
+  it('counts a manifest that throws during dereferencing as not validated', async () => {
+    const validateThrowing: ValidateManifest = async (url: string) => {
+      if (url.includes('throws')) throw new Error('boom');
+      return {valid: true, reason: 'valid-manifest'};
+    };
+    const inner = innerYielding([
+      ...voidQuads(),
+      sampleQuad('http://example.org/good/1'),
+      sampleQuad('http://example.org/throws/2'),
+    ]);
+
+    const executor = new IiifValidationExecutor(inner, {
+      validate: validateThrowing,
+    });
+    const out = await collect(await executor.execute(dataset, distribution));
+
+    // One validator rejection must not fail or drop the others.
+    expect(measurementValue(out, MANIFESTS_SAMPLED_METRIC.value)).toBe(2);
+    expect(measurementValue(out, MANIFESTS_VALIDATED_METRIC.value)).toBe(1);
+  });
+
+  it('emits no measurements when no IIIF is detected (no sample triples)', async () => {
+    const inner = innerYielding([
+      quad(namedNode(DATASET_IRI), RDF_TYPE, VOID_DATASET),
+    ]);
+
+    const executor = new IiifValidationExecutor(inner, {
+      validate: validateByName,
+    });
+    const out = await collect(await executor.execute(dataset, distribution));
+
+    expect(out).toHaveLength(1);
+    expect(out.some(q => q.predicate.equals(DQV_HAS_QUALITY_MEASUREMENT))).toBe(
+      false,
+    );
+  });
+
+  it('passes NotSupported through unchanged', async () => {
+    const inner: Executor = {
+      async execute() {
+        return new NotSupported('no distribution');
+      },
+    };
+
+    const executor = new IiifValidationExecutor(inner, {
+      validate: validateByName,
+    });
+    const result = await executor.execute(dataset, distribution);
+
+    expect(result).toBeInstanceOf(NotSupported);
+  });
+});

--- a/test/iiifValidationExecutor.test.ts
+++ b/test/iiifValidationExecutor.test.ts
@@ -19,9 +19,7 @@ const VOID_SUBSET = namedNode('http://rdfs.org/ns/void#subset');
 const VOID_ENTITIES = namedNode('http://rdfs.org/ns/void#entities');
 const DCTERMS_CONFORMS_TO = namedNode('http://purl.org/dc/terms/conformsTo');
 const IIIF_PRESENTATION = namedNode('http://iiif.io/api/presentation/');
-const MANIFEST_SAMPLE = namedNode(
-  'https://data.netwerkdigitaalerfgoed.nl/def/internal/iiif-manifest-sample',
-);
+const MANIFEST_SAMPLE = namedNode('https://def.nde.nl/iiif#manifest-sample');
 const XSD_INTEGER = namedNode('http://www.w3.org/2001/XMLSchema#integer');
 const DQV_HAS_QUALITY_MEASUREMENT = namedNode(
   'http://www.w3.org/ns/dqv#hasQualityMeasurement',
@@ -31,12 +29,10 @@ const DQV_IS_MEASUREMENT_OF = namedNode(
 );
 const DQV_VALUE = namedNode('http://www.w3.org/ns/dqv#value');
 const DQV_COMPUTED_ON = namedNode('http://www.w3.org/ns/dqv#computedOn');
-const METRIC_BASE = 'https://data.netwerkdigitaalerfgoed.nl/def/metric/';
-const MANIFESTS_SAMPLED_METRIC = namedNode(
-  `${METRIC_BASE}iiif-manifests-sampled`,
-);
+const METRIC_BASE = 'https://def.nde.nl/metric#';
+const MANIFESTS_SAMPLED_METRIC = namedNode(`${METRIC_BASE}manifests-sampled`);
 const MANIFESTS_VALIDATED_METRIC = namedNode(
-  `${METRIC_BASE}iiif-manifests-validated`,
+  `${METRIC_BASE}manifests-validated`,
 );
 
 /** Find the integer value of the measurement of the given metric. */


### PR DESCRIPTION
Closes #307.

## What

Moves IIIF-compliance from **declared** to **validated**: instead of trusting the `schema:encodingFormat` profile literal alone, a sample of the detected manifest URIs is dereferenced and checked to be real IIIF Presentation Manifests, and the outcome is published alongside the existing declared count.

## How

- **`iiif.rq`** — one combined `CONSTRUCT` now also emits a capped, first-N sample of matched manifest IRIs as an intermediate triple (`COUNT` sub-select cross-joined with a `LIMIT #limit#` sub-select). Detection stays a single round-trip. `#limit#` is threaded from `main.ts` (default 10).
- **`IiifValidationExecutor`** (new) — an executor decorator (the `UriSpaceExecutor` pattern) wrapping `SparqlConstructExecutor`. It passes `void:subset` / `dcterms:conformsTo` / `void:entities` through unchanged, **strips** the intermediate sample triples, then dereferences the sampled URIs via [`@lde/iiif-validator`](https://www.npmjs.com/package/@lde/iiif-validator) (≤ 4 concurrent, `Promise.allSettled`), and appends the result as two DQV integer measurements plus a PROV activity.
- The declared `dcterms:conformsTo` marker is **never removed** — it is the neutral statistic. Validation adds `iiif-manifests-sampled` (`N`) and `iiif-manifests-validated` (`k`).

## Three states made distinguishable

| State | subset + `conformsTo` | `void:entities` | sampled / validated |
|---|---|---|---|
| No IIIF | absent | – | – |
| Declared but failing | present | declared count | sampled = N, validated = 0 |
| Declared and working | present | declared count | sampled = N, validated ≥ 1 |

## Tests

- `iiifStage.test.ts` (Comunica, in-memory): the combined count + `LIMIT N` sample emission, plus the existing v2/v3/version-segment/near-miss/subjectFilter cases.
- `iiifValidationExecutor.test.ts` (synthetic quad stream + injected validator): pass-through, sample-triple stripping, and DQV counts for `k = 0` and `k > 0`, including a validator that throws.

The generic manifest check lives in the new `@lde/iiif-validator` package (LDE monorepo). Docs (services chapter) updated separately.
