### PR TITLE
build(deps): update @lde packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@lde/pipeline-shacl-sampler": "^0.4.4",
         "@lde/pipeline-shacl-validator": "^0.12.4",
         "@lde/pipeline-void": "^0.28.4",
-        "@lde/sparql-qlever": "^0.14.4",
+        "@lde/sparql-qlever": "^0.14.5",
         "@netwerk-digitaal-erfgoed/network-of-terms-catalog": "^10.19.22",
         "env-schema": "^7.0.0",
         "n3": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@lde/pipeline-shacl-sampler": "^0.4.4",
     "@lde/pipeline-shacl-validator": "^0.12.4",
     "@lde/pipeline-void": "^0.28.4",
-    "@lde/sparql-qlever": "^0.14.4",
+    "@lde/sparql-qlever": "^0.14.5",
     "@netwerk-digitaal-erfgoed/network-of-terms-catalog": "^10.19.22",
     "env-schema": "^7.0.0",
     "n3": "^2.0.1",


### PR DESCRIPTION
Bump `@lde/sparql-qlever` from `^0.14.4` to `^0.14.5`.

All other `@lde/*` packages were already at their latest published versions, so this is the only change.
