### PR TITLE
fix: set QLever memory and timeout defaults to survive large datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,8 +614,8 @@ The embedded QLever server can be tuned via these environment variables (default
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `QLEVER_MEMORY_MAX_SIZE` | `12G` | Maximum memory QLever uses for query processing. Keep it below the container memory limit (16 GiB in production): a query that would exceed it is aborted with an HTTP 500 that the pipeline catches per stage and continues, instead of the container being OOM-killed. |
-| `QLEVER_QUERY_TIMEOUT` | `600s` | Per-query time budget. A backstop above the pipeline’s own per-request timeout policy (300s by default), which is the effective upper bound. |
+| `QLEVER_MEMORY_MAX_SIZE` | `12G` | Maximum memory QLever uses for query processing and caching (the result cache is part of this budget). Keep it below the container memory limit (16 GiB in production): a query that would exceed it is aborted with an HTTP 500 that the pipeline catches per stage and continues, instead of the container being OOM-killed. |
+| `QLEVER_QUERY_TIMEOUT` | `600s` | QLever’s per-query timeout. Keep it above the pipeline’s per-request timeout (hardcoded at 300s in `main.ts`, not an env var) so QLever only acts as a backstop. Raised from 120s, which cut off the ~2-minute analysis queries on large datasets. |
 
 ## Pipeline Steps
 

--- a/README.md
+++ b/README.md
@@ -610,6 +610,13 @@ QLEVER_ENV=native
 
 Native mode is ~2x faster than Docker on macOS (see [index tuning benchmarks](docs/qlever-index-tuning.md)).
 
+The embedded QLever server can be tuned via these environment variables (defaults shown):
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `QLEVER_MEMORY_MAX_SIZE` | `12G` | Maximum memory QLever uses for query processing. Keep it below the container memory limit (16 GiB in production): a query that would exceed it is aborted with an HTTP 500 that the pipeline catches per stage and continues, instead of the container being OOM-killed. |
+| `QLEVER_QUERY_TIMEOUT` | `600s` | Per-query time budget. A backstop above the pipeline’s own per-request timeout policy (300s by default), which is the effective upper bound. |
+
 ## Pipeline Steps
 
 The pipeline consists of the following steps.

--- a/README.md
+++ b/README.md
@@ -615,7 +615,8 @@ The embedded QLever server can be tuned via these environment variables (default
 | Variable | Default | Description |
 | --- | --- | --- |
 | `QLEVER_MEMORY_MAX_SIZE` | `12G` | Maximum memory QLever uses for query processing and caching (the result cache is part of this budget). Keep it below the container memory limit (16 GiB in production): a query that would exceed it is aborted with an HTTP 500 that the pipeline catches per stage and continues, instead of the container being OOM-killed. |
-| `QLEVER_QUERY_TIMEOUT` | `600s` | QLever’s per-query timeout. Keep it above the pipeline’s per-request timeout (hardcoded at 300s in `main.ts`, not an env var) so QLever only acts as a backstop. Raised from 120s, which cut off the ~2-minute analysis queries on large datasets. |
+| `QLEVER_QUERY_TIMEOUT` | `600s` | QLever’s per-query timeout. Keep it above `SPARQL_REQUEST_TIMEOUT_MS` so QLever only acts as a backstop. Raised from 120s, which cut off the ~2-minute analysis queries on large datasets. |
+| `SPARQL_REQUEST_TIMEOUT_MS` | `300000` | Per-request timeout (milliseconds) for SPARQL queries against endpoints, including the local QLever server. Applied as the `adaptiveTimeoutPolicy` default budget in `main.ts`; this is the effective upper bound on a single query. Covers SPARQL query requests only — not data-dump downloads or imports, which are timed out separately by the downloader. |
 
 ## Pipeline Steps
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,24 @@ const schema = {
     QLEVER_IMAGE: {
       type: 'string',
     },
+    // QLever’s own memory ceiling for query processing. Kept safely below
+    // the container memory limit (16 GiB in production): when an analysis query
+    // over a large dataset would exceed this, QLever aborts it with an HTTP 500
+    // that the pipeline catches per stage and continues, instead of growing past
+    // the container limit and getting the whole pod OOM-killed (in native mode
+    // QLever shares the pod’s memory budget with this process, so an OOM kill
+    // would take the run down with it).
+    QLEVER_MEMORY_MAX_SIZE: {
+      type: 'string',
+      default: '12G',
+    },
+    // Per-query time budget. Several analysis queries on large datasets take
+    // ~2 minutes, so the previous 120s aborted them spuriously. The pipeline’s
+    // own per-request timeout policy remains the effective upper bound.
+    QLEVER_QUERY_TIMEOUT: {
+      type: 'string',
+      default: '600s',
+    },
   },
 } as const;
 
@@ -30,6 +48,8 @@ interface Config {
   QLEVER_ENV: 'docker' | 'native';
   QLEVER_PORT: number;
   QLEVER_IMAGE?: string;
+  QLEVER_MEMORY_MAX_SIZE: string;
+  QLEVER_QUERY_TIMEOUT: string;
 }
 
 export const config = envSchema({

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,15 +33,25 @@ const schema = {
       type: 'string',
       default: '12G',
     },
-    // QLever’s server-side per-query timeout. Keep it higher than the
-    // pipeline’s per-request timeout (the adaptiveTimeoutPolicy defaultMs in
-    // main.ts, currently 300s and not exposed as an env var) so that the client
-    // policy stays the binding limit and this only acts as a backstop. Set it
-    // below that and QLever cuts queries off before the client budget is spent,
-    // as the old 120s did to the ~2-minute analysis queries on large datasets.
+    // QLever’s server-side per-query timeout. Keep it higher than the pipeline’s
+    // per-request timeout (SPARQL_REQUEST_TIMEOUT_MS, applied as the
+    // adaptiveTimeoutPolicy defaultMs in main.ts) so that the client policy stays
+    // the binding limit and this only acts as a backstop. Set it below that and
+    // QLever cuts queries off before the client budget is spent, as the old 120s
+    // did to the ~2-minute analysis queries on large datasets.
     QLEVER_QUERY_TIMEOUT: {
       type: 'string',
       default: '600s',
+    },
+    // Per-request timeout (milliseconds) for SPARQL queries against endpoints,
+    // including the local QLever server. Applied by adaptiveTimeoutPolicy in
+    // main.ts as the default budget, so it is the effective upper bound on a
+    // single query; keep QLEVER_QUERY_TIMEOUT above it. Covers SPARQL query
+    // requests only (remote endpoints and the local QLever), not data-dump
+    // downloads or imports, which are timed out separately by the downloader.
+    SPARQL_REQUEST_TIMEOUT_MS: {
+      type: 'number',
+      default: 300_000,
     },
   },
 } as const;
@@ -54,6 +64,7 @@ interface Config {
   QLEVER_IMAGE?: string;
   QLEVER_MEMORY_MAX_SIZE: string;
   QLEVER_QUERY_TIMEOUT: string;
+  SPARQL_REQUEST_TIMEOUT_MS: number;
 }
 
 export const config = envSchema({

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,7 +34,8 @@ const schema = {
     },
     // Per-query time budget. Several analysis queries on large datasets take
     // ~2 minutes, so the previous 120s aborted them spuriously. The pipeline’s
-    // own per-request timeout policy remains the effective upper bound.
+    // own per-request timeout policy (main.ts, 300s by default), which becomes
+    // the effective upper bound now that this sits above it.
     QLEVER_QUERY_TIMEOUT: {
       type: 'string',
       default: '600s',

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,8 @@ const schema = {
     QLEVER_IMAGE: {
       type: 'string',
     },
-    // QLever’s own memory ceiling for query processing. Kept safely below
+    // QLever’s own memory ceiling for query processing and caching (the result
+    // cache is part of this budget, so it bounds cache-max-size too). Kept below
     // the container memory limit (16 GiB in production): when an analysis query
     // over a large dataset would exceed this, QLever aborts it with an HTTP 500
     // that the pipeline catches per stage and continues, instead of growing past
@@ -32,10 +33,12 @@ const schema = {
       type: 'string',
       default: '12G',
     },
-    // Per-query time budget. Several analysis queries on large datasets take
-    // ~2 minutes, so the previous 120s aborted them spuriously. The pipeline’s
-    // own per-request timeout policy (main.ts, 300s by default), which becomes
-    // the effective upper bound now that this sits above it.
+    // QLever’s server-side per-query timeout. Keep it higher than the
+    // pipeline’s per-request timeout (the adaptiveTimeoutPolicy defaultMs in
+    // main.ts, currently 300s and not exposed as an env var) so that the client
+    // policy stays the binding limit and this only acts as a backstop. Set it
+    // below that and QLever cuts queries off before the client budget is spent,
+    // as the old 120s did to the ~2-minute analysis queries on large datasets.
     QLEVER_QUERY_TIMEOUT: {
       type: 'string',
       default: '600s',

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,8 +38,8 @@ const {importer, server} = createQlever({
   port: config.QLEVER_PORT,
   indexName: 'data',
   serverOptions: {
-    'memory-max-size': '16G',
-    'default-query-timeout': '120s',
+    'memory-max-size': config.QLEVER_MEMORY_MAX_SIZE,
+    'default-query-timeout': config.QLEVER_QUERY_TIMEOUT,
   },
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -126,10 +126,10 @@ await new Pipeline({
   plugins: [schemaOrgNormalizationPlugin(), provenancePlugin()],
   // Fast-fail endpoints that repeatedly time out so one bad dataset doesn’t
   // hold up the run for hours. After two consecutive timeouts on the same
-  // endpoint, subsequent requests get a 10s budget instead of 5min; a single
-  // successful request relaxes back to the default.
+  // endpoint, subsequent requests get a 10s budget instead of the default; a
+  // single successful request relaxes back to the default.
   timeout: adaptiveTimeoutPolicy({
-    defaultMs: 300_000,
+    defaultMs: config.SPARQL_REQUEST_TIMEOUT_MS,
     tightenedMs: 10_000,
     tightenAfterTimeouts: 2,
   }),


### PR DESCRIPTION
## Problem

The daily Dataset Knowledge Graph run was failing partway through: it processed ~260 of 300 datasets and then the pod disappeared, taking the rest of the run with it. Because the pod was gone, its logs were unrecoverable.

By capturing the logs of a manual run, the failure was localized to the **largest dataset in the run** (an openarchieven linkset, **219.9M triples**) on the `class-properties-subjects.rq` analysis stage.

## Investigation

Reproduced locally against just that dataset:

- The dataset processes **cleanly given enough time** (full run in ~20 min, Node peaked at 178 MB RSS). So the data is fine.
- `class-properties-subjects.rq` legitimately takes ~115 s, right on the edge of the old `default-query-timeout` of **120 s**.
- The OOM is **QLever’s own working set**, not Node. QLever’s `memory-max-size` was set equal to the container memory limit (both 16 G / 16 Gi), leaving **no headroom** — so a heavy query grows past the limit and the kernel OOM-kills the whole pod. In native mode QLever shares the pod with this process, so the run dies with it, bypassing the pipeline’s per-stage error handling.

Two behaviours were verified by forcing each abort locally:

- **Query timeout** → QLever returns HTTP 429 → the pipeline catches it per stage and continues.
- **Memory cap exceeded** → QLever returns HTTP 500 (`Tried to allocate … but only … available`) → the pipeline catches it per stage and continues.

So QLever aborting a query is already survivable; the problem was that `memory-max-size == container limit` let the kernel OOM-kill the pod *before* QLever’s own limit could fire.

## Change

Both values flow through `@lde/sparql-qlever`’s `serverOptions` and are now configurable in `config.ts` with safer defaults:

- `QLEVER_MEMORY_MAX_SIZE` default **`12G`** (was hardcoded `16G`). Below the 16 Gi container limit, so an over-budget query aborts with a catchable HTTP 500 instead of OOM-killing the pod. 12 G is well above the ~8 G this dataset actually needs, so well-behaved datasets are unaffected.
- `QLEVER_QUERY_TIMEOUT` default **`600s`** (was `120s`). Stops spurious aborts on large datasets; the pipeline’s own per-request timeout policy remains the effective upper bound.

No cluster/container memory change is required — the fix fits within the existing 16 Gi budget.

## Validation

`tsc`, `eslint` + `prettier`, and the full test suite (19/19) pass.
