### PR TITLE
feat: sample persistent URIs and measure subject-URI resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,128 @@ SELECT ?dataset WHERE {
 }
 ```
 
+### Subject URI resolution
+
+Every dataset mints URIs for its own resources in some namespace. The
+`subject-uri-space` VoID stage ranks subject namespaces by entity count; this
+feature takes the single most common one – excluding known terminology-source
+prefixes, so a dataset that mostly references RKD or GeoNames URIs is still
+measured on the namespace it owns – and asks whether those URIs resolve, layering
+persistent-identifier (PID) detection on top.
+
+Resolution is measured for the chosen namespace regardless of whether it is a
+recognised PID scheme: an unrecognised-but-resolving namespace still gets a
+ratio; only the scheme and organisation layer is PID-specific.
+
+A first-N sample (default 10) of subject URIs from the namespace is dereferenced,
+following redirects (ARK and Handle URIs are resolver links that redirect to an
+institutional landing page). A URI counts as resolved when the final response is
+`200`, is `text/html`, and the landing page advertises the original URI back to
+the user (raw or HTML-entity-escaped) – which matters precisely because we landed
+on a different, redirected URL. Dereferencing is throttled (≤ 4 concurrent),
+with no retries: a broken URI is one tick in a ratio.
+
+The measurements hang off the namespace’s `void:subset` node (not the
+dataset, unlike IIIF), so the whole persistent-identifier story is reachable in
+one hop:
+
+```ttl
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix void:    <http://rdfs.org/ns/void#> .
+@prefix dqv:     <http://www.w3.org/ns/dqv#> .
+@prefix prov:    <http://www.w3.org/ns/prov#> .
+
+<https://example.org/dataset> void:subset <https://example.org/dataset/.well-known/void#subject-uri-space-…> .
+
+<https://example.org/dataset/.well-known/void#subject-uri-space-…>
+    void:uriSpace "https://n2t.net/ark:/60537/" ;
+    void:entities 312000 ;
+    dcterms:conformsTo <https://def.nde.nl/pid-scheme#ark> ;   # declared, only if recognised
+    dcterms:publisher "Gouda Tijdmachine" ;                    # ARK only, non-fatal
+    dqv:hasQualityMeasurement
+        [ a dqv:QualityMeasurement ;
+          dqv:computedOn <https://example.org/dataset/.well-known/void#subject-uri-space-…> ;
+          dqv:isMeasurementOf <https://def.nde.nl/metric#subject-uris-sampled> ;
+          dqv:value 10 ;
+          prov:wasGeneratedBy _:sampling ] ,
+        [ a dqv:QualityMeasurement ;
+          dqv:computedOn <https://example.org/dataset/.well-known/void#subject-uri-space-…> ;
+          dqv:isMeasurementOf <https://def.nde.nl/metric#subject-uris-resolved> ;
+          dqv:value 8 ;
+          prov:wasGeneratedBy _:sampling ] .
+
+_:sampling
+    a prov:Activity ;
+    prov:used <https://example.org/dataset/.well-known/void#subject-uri-space-…> ;
+    prov:wasAssociatedWith <https://github.com/netwerk-digitaal-erfgoed/dataset-knowledge-graph> .
+```
+
+#### Persistent identifiers
+
+`dcterms:conformsTo` is attached only when the namespace matches a recognised PID
+scheme. The metric names stay neutral (`subject-uris-*`, not `persistent-uris-*`)
+because the resolution ratio applies to any namespace – PID-ness lives only in
+the scheme label.
+
+| Scheme | Matched on | `dcterms:conformsTo` | Organisation |
+|---|---|---|---|
+| ARK | `n2t.net/ark:`, `arks.org/ark:` | `…/pid-scheme#ark` | NAAN looked up via `arks.org` `who.name`, emitted as `dcterms:publisher` (non-fatal) |
+| Handle | `hdl.handle.net`, `handle.net` | `…/pid-scheme#handle` | none – the Global Handle Registry exposes no public org name |
+
+Host matching tolerates `http`/`https`; at most one scheme is assigned per
+namespace.
+
+| Metric IRI | Type | Meaning |
+|---|---|---|
+| `…/metric#subject-uris-sampled` | `xsd:integer` | Number of subject URIs dereferenced – the denominator `N`, capped at the sample size (10). |
+| `…/metric#subject-uris-resolved` | `xsd:integer` | How many of the sampled URIs `k` resolved to a self-describing landing page. |
+
+Combining the chosen namespace, the optional scheme and org, and the resolved
+count yields five observable states:
+
+| Namespace | scheme / org | `subject-uris-resolved` |
+|---|---|---|
+| recognised PID, resolves | emitted | > 0 |
+| recognised PID, none resolve | emitted | 0 (claims a PID, nothing resolves) |
+| unrecognised, resolves | absent | > 0 |
+| unrecognised, none resolve | absent | 0 |
+| no surviving namespace | – | nothing emitted |
+
+#### Querying
+
+“Find datasets whose own subject URIs resolve”:
+
+```sparql
+PREFIX void: <http://rdfs.org/ns/void#>
+PREFIX dqv: <http://www.w3.org/ns/dqv#>
+
+SELECT ?dataset WHERE {
+    ?dataset void:subset/dqv:hasQualityMeasurement [
+        dqv:isMeasurementOf <https://def.nde.nl/metric#subject-uris-resolved> ;
+        dqv:value ?resolved
+    ] .
+    FILTER(?resolved > 0)
+}
+```
+
+“Find datasets that mint a persistent identifier but whose sampled URIs all
+fail” (the diagnostic query for giving publishers feedback):
+
+```sparql
+PREFIX void: <http://rdfs.org/ns/void#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX dqv: <http://www.w3.org/ns/dqv#>
+
+SELECT ?dataset WHERE {
+    ?dataset void:subset ?ns .
+    ?ns dcterms:conformsTo ?scheme ;
+        dqv:hasQualityMeasurement [
+            dqv:isMeasurementOf <https://def.nde.nl/metric#subject-uris-resolved> ;
+            dqv:value 0
+        ] .
+}
+```
+
 ### Distributions
 
 All declared RDF distributions are validated:

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@lde/sparql-qlever": "^0.14.6",
         "@netwerk-digitaal-erfgoed/network-of-terms-catalog": "^10.19.22",
         "env-schema": "^7.0.0",
+        "fetch-sparql-endpoint": "^7.1.0",
         "n3": "^2.0.1",
         "p-limit": "^7.3.0",
         "rdf-dereference": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@lde/sparql-qlever": "^0.14.6",
     "@netwerk-digitaal-erfgoed/network-of-terms-catalog": "^10.19.22",
     "env-schema": "^7.0.0",
+    "fetch-sparql-endpoint": "^7.1.0",
     "n3": "^2.0.1",
     "p-limit": "^7.3.0",
     "rdf-dereference": "^5.0.0"

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import {
   schemaOrgNormalizationPlugin,
   type Writer,
 } from '@lde/pipeline';
-import {voidStages} from '@lde/pipeline-void';
+import {voidStages, VOID_STAGE_NAMES} from '@lde/pipeline-void';
 import {shaclSampleStages} from '@lde/pipeline-shacl-sampler';
 import {ShaclValidator} from '@lde/pipeline-shacl-validator';
 import {createQlever} from '@lde/sparql-qlever';
@@ -19,6 +19,7 @@ import {buildUriSpacesMap} from './uriSpaces.js';
 import {qualityMeasurementsStage} from './qualityMeasurementsStage.js';
 import {iiifStage} from './iiifStage.js';
 import {mediaStage} from './mediaStage.js';
+import {subjectUriResolution} from './subjectUriResolution.js';
 import {ConsoleReporter} from '@lde/pipeline-console-reporter';
 import {resolve} from 'node:path';
 import type {DatasetSelector} from '@lde/pipeline';
@@ -29,6 +30,7 @@ const SCHEMA_AP_NDE_SHAPES =
 const SCHEMA_AP_NDE_PROFILE = 'https://docs.nde.nl/schema-profile/';
 const SAMPLES_PER_CLASS = 50;
 const IIIF_MANIFEST_SAMPLE_SIZE = 10;
+const SUBJECT_URI_SAMPLE_SIZE = 10;
 
 const uriSpaces = await buildUriSpacesMap();
 const {importer, server} = createQlever({
@@ -52,6 +54,16 @@ const voidStageList = await voidStages({
     'https://schema.org/',
   ],
   batchSize: 1,
+  // Enrich the subject-uri-space stage: sample the dataset’s own subject
+  // namespace and measure whether those URIs resolve, layering PID detection
+  // on top. The terminology prefixes are excluded so we pick the namespace the
+  // dataset mints for its own resources, not a referenced terminology source.
+  transforms: {
+    [VOID_STAGE_NAMES.subjectUriSpace]: subjectUriResolution({
+      terminologyPrefixes: uriSpaces.keys(),
+      sampleSize: SUBJECT_URI_SAMPLE_SIZE,
+    }),
+  },
 });
 
 // Validation reports go to:

--- a/src/subjectUriResolution.ts
+++ b/src/subjectUriResolution.ts
@@ -1,0 +1,426 @@
+import {DataFactory} from 'n3';
+import pLimit from 'p-limit';
+import type {Quad} from '@rdfjs/types';
+import type {Dataset, Distribution} from '@lde/dataset';
+import {
+  SparqlConstructExecutor,
+  NotSupported,
+  type ExecutorContext,
+  type QuadTransform,
+} from '@lde/pipeline';
+
+const {namedNode, literal, blankNode, quad} = DataFactory;
+
+const RDF_TYPE = namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+const VOID_URI_SPACE = namedNode('http://rdfs.org/ns/void#uriSpace');
+const VOID_ENTITIES = namedNode('http://rdfs.org/ns/void#entities');
+const DCTERMS_CONFORMS_TO = namedNode('http://purl.org/dc/terms/conformsTo');
+const DCTERMS_PUBLISHER = namedNode('http://purl.org/dc/terms/publisher');
+const DQV_HAS_QUALITY_MEASUREMENT = namedNode(
+  'http://www.w3.org/ns/dqv#hasQualityMeasurement',
+);
+const DQV_QUALITY_MEASUREMENT = namedNode(
+  'http://www.w3.org/ns/dqv#QualityMeasurement',
+);
+const DQV_COMPUTED_ON = namedNode('http://www.w3.org/ns/dqv#computedOn');
+const DQV_IS_MEASUREMENT_OF = namedNode(
+  'http://www.w3.org/ns/dqv#isMeasurementOf',
+);
+const DQV_VALUE = namedNode('http://www.w3.org/ns/dqv#value');
+const PROV_ACTIVITY = namedNode('http://www.w3.org/ns/prov#Activity');
+const PROV_USED = namedNode('http://www.w3.org/ns/prov#used');
+const PROV_WAS_ASSOCIATED_WITH = namedNode(
+  'http://www.w3.org/ns/prov#wasAssociatedWith',
+);
+const PROV_WAS_GENERATED_BY = namedNode(
+  'http://www.w3.org/ns/prov#wasGeneratedBy',
+);
+const XSD_INTEGER = namedNode('http://www.w3.org/2001/XMLSchema#integer');
+
+const METRIC_BASE = 'https://def.nde.nl/metric#';
+const SUBJECT_URIS_SAMPLED_METRIC = namedNode(
+  `${METRIC_BASE}subject-uris-sampled`,
+);
+const SUBJECT_URIS_RESOLVED_METRIC = namedNode(
+  `${METRIC_BASE}subject-uris-resolved`,
+);
+
+const PID_SCHEME_BASE = 'https://def.nde.nl/pid-scheme#';
+const PID_SCHEMES = {
+  ark: namedNode(`${PID_SCHEME_BASE}ark`),
+  handle: namedNode(`${PID_SCHEME_BASE}handle`),
+} as const;
+type PidScheme = keyof typeof PID_SCHEMES;
+
+/**
+ * Host+path prefixes identifying a PID scheme, tolerant of `http`/`https` and
+ * known resolver hosts. At most one scheme is assigned per namespace.
+ */
+const PID_PREFIXES: ReadonlyArray<{scheme: PidScheme; prefix: string}> = [
+  {scheme: 'ark', prefix: 'n2t.net/ark:'},
+  {scheme: 'ark', prefix: 'arks.org/ark:'},
+  {scheme: 'handle', prefix: 'hdl.handle.net'},
+  {scheme: 'handle', prefix: 'handle.net'},
+];
+
+const DEFAULT_SOFTWARE = namedNode(
+  'https://github.com/netwerk-digitaal-erfgoed/dataset-knowledge-graph',
+);
+
+/** Default number of subject URIs sampled per dataset. */
+export const DEFAULT_SAMPLE_SIZE = 10;
+
+/**
+ * Default in-flight dereference cap. Kept low because the sampled URIs
+ * typically share a single resolver host that we must not overload.
+ */
+const DEFAULT_CONCURRENCY = 4;
+
+/** Marker predicate/object for the internal sampling CONSTRUCT. */
+const SAMPLE_MARKER = namedNode('https://def.nde.nl/internal#sampled-subject');
+
+/** Samples up to `sampleSize` distinct subject IRIs from `uriSpace`. */
+export type SampleUris = (
+  uriSpace: string,
+  sampleSize: number,
+  context: {dataset: Dataset; distribution: Distribution},
+) => Promise<string[]>;
+
+/**
+ * Resolves a sampled URI and reports whether it lands on a self-describing
+ * page: a `200`, `text/html` response whose body advertises the original URI.
+ */
+export type ResolveUri = (uri: string) => Promise<boolean>;
+
+/** Looks up the issuing organisation’s name for an ARK NAAN, if available. */
+export type LookupOrg = (naan: string) => Promise<string | undefined>;
+
+export interface SubjectUriResolutionOptions {
+  /**
+   * URI prefixes to exclude as terminology sources when picking the dataset’s
+   * own subject namespace — typically the keys of `buildUriSpacesMap()`.
+   * Matched with `startsWith`.
+   */
+  terminologyPrefixes: Iterable<string>;
+  /** Number of subject URIs to sample and dereference. @default 10 */
+  sampleSize?: number;
+  /** Maximum concurrent dereferences. @default 4 */
+  concurrency?: number;
+  /** Subject-URI sampler. Injectable for testing; defaults to a SPARQL query. */
+  sampleUris?: SampleUris;
+  /** Resolution check. Injectable for testing; defaults to an HTTP fetch. */
+  resolve?: ResolveUri;
+  /** ARK organisation lookup. Injectable for testing; defaults to arks.org. */
+  lookupOrg?: LookupOrg;
+  /**
+   * IRI identifying the software for the `prov:wasAssociatedWith` link.
+   * Defaults to the DKG repository.
+   */
+  software?: string;
+}
+
+/**
+ * A {@link QuadTransform} for the `subject-uri-space` VoID stage that turns the
+ * dataset’s subject namespaces into a *resolution* measurement, layering
+ * persistent-identifier (PID) detection on top.
+ *
+ * It harvests the `void:uriSpace`/`void:entities` subsets from the stage
+ * output (passing them through unchanged), picks the single most common
+ * non-terminology namespace — the one the dataset mints for its own resources —
+ * samples URIs from it, and dereferences them. The outcome is appended,
+ * scoped to that namespace’s subset node:
+ *
+ * - **declared** facts: `dcterms:conformsTo` a PID scheme (ARK/Handle, only if
+ *   recognised) and `dcterms:publisher` the ARK issuing org (non-fatal);
+ * - **validated** facts: `subject-uris-sampled` / `subject-uris-resolved` DQV
+ *   measurements plus a PROV activity.
+ *
+ * The metric names are namespace-neutral because the ratio applies to any
+ * namespace; PID-ness lives only in the scheme label. If no non-terminology
+ * namespace survives, nothing is appended.
+ *
+ * Attach it to {@link VOID_STAGE_NAMES.subjectUriSpace} via `voidStages`.
+ */
+export function subjectUriResolution(
+  options: SubjectUriResolutionOptions,
+): QuadTransform<ExecutorContext> {
+  const terminologyPrefixes = [...options.terminologyPrefixes];
+  const sampleSize = options.sampleSize ?? DEFAULT_SAMPLE_SIZE;
+  const concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
+  const sampleUris = options.sampleUris ?? defaultSampleUris;
+  const resolve = options.resolve ?? defaultResolve;
+  const lookupOrg = options.lookupOrg ?? defaultLookupOrg;
+  const software = options.software
+    ? namedNode(options.software)
+    : DEFAULT_SOFTWARE;
+
+  return async function* (quads, {dataset, distribution}) {
+    // Harvest the subsets while passing every quad through unchanged.
+    const uriSpaceBySubset = new Map<string, string>();
+    const entitiesBySubset = new Map<string, number>();
+    for await (const q of quads) {
+      yield q;
+      if (q.predicate.equals(VOID_URI_SPACE)) {
+        uriSpaceBySubset.set(q.subject.value, q.object.value);
+      } else if (q.predicate.equals(VOID_ENTITIES)) {
+        entitiesBySubset.set(q.subject.value, Number(q.object.value));
+      }
+    }
+
+    const winner = pickWinner(
+      uriSpaceBySubset,
+      entitiesBySubset,
+      terminologyPrefixes,
+    );
+    // No non-terminology namespace survived: emit nothing extra.
+    if (winner === undefined) {
+      return;
+    }
+
+    // Enrichment is best-effort: a failed sample must not drop the VoID output
+    // that already streamed through, so swallow and emit nothing extra.
+    let measurements: Quad[];
+    try {
+      const sampled = await sampleUris(winner.uriSpace, sampleSize, {
+        dataset,
+        distribution,
+      });
+      const limit = pLimit(concurrency);
+      const outcomes = await Promise.allSettled(
+        sampled.map(uri => limit(() => resolve(uri))),
+      );
+      const resolved = outcomes.filter(
+        outcome => outcome.status === 'fulfilled' && outcome.value,
+      ).length;
+
+      const scheme = detectPidScheme(winner.uriSpace);
+      const org =
+        scheme === 'ark'
+          ? await lookupArkOrg(winner.uriSpace, lookupOrg)
+          : undefined;
+
+      measurements = [
+        ...measurementQuads(
+          namedNode(winner.subset),
+          sampled.length,
+          resolved,
+          scheme,
+          org,
+          software,
+        ),
+      ];
+    } catch {
+      return;
+    }
+
+    yield* measurements;
+  };
+}
+
+/** Pick the subset with the most entities whose namespace is not a terminology source. */
+function pickWinner(
+  uriSpaceBySubset: ReadonlyMap<string, string>,
+  entitiesBySubset: ReadonlyMap<string, number>,
+  terminologyPrefixes: readonly string[],
+): {subset: string; uriSpace: string} | undefined {
+  let best: {subset: string; uriSpace: string; entities: number} | undefined;
+  for (const [subset, uriSpace] of uriSpaceBySubset) {
+    if (terminologyPrefixes.some(prefix => uriSpace.startsWith(prefix))) {
+      continue;
+    }
+    const entities = entitiesBySubset.get(subset) ?? 0;
+    if (best === undefined || entities > best.entities) {
+      best = {subset, uriSpace, entities};
+    }
+  }
+  return best && {subset: best.subset, uriSpace: best.uriSpace};
+}
+
+/** Classify a namespace as an ARK/Handle PID scheme, tolerant of http/https. */
+function detectPidScheme(uriSpace: string): PidScheme | undefined {
+  const withoutScheme = uriSpace.replace(/^https?:\/\//, '');
+  return PID_PREFIXES.find(({prefix}) => withoutScheme.startsWith(prefix))
+    ?.scheme;
+}
+
+/** Extract the NAAN from an ARK namespace, e.g. `…/ark:/60537/` → `60537`. */
+function arkNaan(uriSpace: string): string | undefined {
+  return uriSpace.match(/ark:\/?([^/]+)/)?.[1];
+}
+
+async function lookupArkOrg(
+  uriSpace: string,
+  lookupOrg: LookupOrg,
+): Promise<string | undefined> {
+  const naan = arkNaan(uriSpace);
+  if (naan === undefined) return undefined;
+  try {
+    return await lookupOrg(naan);
+  } catch {
+    // Non-fatal: emit the scheme without an org.
+    return undefined;
+  }
+}
+
+function* measurementQuads(
+  subset: ReturnType<typeof namedNode>,
+  sampled: number,
+  resolved: number,
+  scheme: PidScheme | undefined,
+  org: string | undefined,
+  software: ReturnType<typeof namedNode>,
+): Generator<Quad> {
+  // Declared facts — only for a recognised PID scheme.
+  if (scheme !== undefined) {
+    yield quad(subset, DCTERMS_CONFORMS_TO, PID_SCHEMES[scheme]);
+  }
+  if (org !== undefined) {
+    yield quad(subset, DCTERMS_PUBLISHER, literal(org));
+  }
+
+  // PROV: the sampling/dereferencing activity.
+  const activity = blankNode();
+  yield quad(activity, RDF_TYPE, PROV_ACTIVITY);
+  yield quad(activity, PROV_USED, subset);
+  yield quad(activity, PROV_WAS_ASSOCIATED_WITH, software);
+
+  // Validated facts — the sampled/resolved ratio, for any namespace.
+  const sampledMeasurement = blankNode();
+  const resolvedMeasurement = blankNode();
+  yield quad(subset, DQV_HAS_QUALITY_MEASUREMENT, sampledMeasurement);
+  yield quad(subset, DQV_HAS_QUALITY_MEASUREMENT, resolvedMeasurement);
+
+  yield* integerMeasurement(
+    sampledMeasurement,
+    subset,
+    SUBJECT_URIS_SAMPLED_METRIC,
+    sampled,
+    activity,
+  );
+  yield* integerMeasurement(
+    resolvedMeasurement,
+    subset,
+    SUBJECT_URIS_RESOLVED_METRIC,
+    resolved,
+    activity,
+  );
+}
+
+function* integerMeasurement(
+  measurement: ReturnType<typeof blankNode>,
+  computedOn: ReturnType<typeof namedNode>,
+  metric: ReturnType<typeof namedNode>,
+  value: number,
+  activity: ReturnType<typeof blankNode>,
+): Generator<Quad> {
+  yield quad(measurement, RDF_TYPE, DQV_QUALITY_MEASUREMENT);
+  yield quad(measurement, DQV_COMPUTED_ON, computedOn);
+  yield quad(measurement, DQV_IS_MEASUREMENT_OF, metric);
+  yield quad(measurement, DQV_VALUE, literal(String(value), XSD_INTEGER));
+  yield quad(measurement, PROV_WAS_GENERATED_BY, activity);
+}
+
+/**
+ * Default sampler: a `SELECT DISTINCT ?s … LIMIT n` short-circuited on the
+ * namespace prefix, run through {@link SparqlConstructExecutor} so it reuses the
+ * distribution’s endpoint, subject filter, and named-graph handling.
+ */
+const defaultSampleUris: SampleUris = async (
+  uriSpace,
+  sampleSize,
+  {dataset, distribution},
+) => {
+  const query = [
+    `CONSTRUCT { ?s <${SAMPLE_MARKER.value}> <${SAMPLE_MARKER.value}> }`,
+    'WHERE {',
+    '  {',
+    '    SELECT DISTINCT ?s WHERE {',
+    '      #subjectFilter#',
+    '      ?s ?p ?o .',
+    `      FILTER(ISIRI(?s) && STRSTARTS(STR(?s), ${sparqlString(uriSpace)}))`,
+    '    }',
+    `    LIMIT ${sampleSize}`,
+    '  }',
+    '}',
+  ].join('\n');
+
+  const result = await new SparqlConstructExecutor({query}).execute(
+    dataset,
+    distribution,
+  );
+  if (result instanceof NotSupported) return [];
+
+  const subjects = new Set<string>();
+  for await (const q of result) {
+    subjects.add(q.subject.value);
+  }
+  return [...subjects];
+};
+
+/**
+ * Default resolution check: follow redirects to the landing page and require a
+ * `200`, `text/html` response that advertises the original sampled URI (raw or
+ * HTML-entity-escaped) — the permanent link back to the user, which matters
+ * because we landed on a different, redirected URL.
+ */
+const defaultResolve: ResolveUri = async uri => {
+  let response: Response;
+  try {
+    response = await fetch(uri, {
+      redirect: 'follow',
+      headers: {accept: 'text/html'},
+    });
+  } catch {
+    return false;
+  }
+  if (!response.ok) return false;
+  if (!(response.headers.get('content-type') ?? '').includes('text/html')) {
+    return false;
+  }
+  let body: string;
+  try {
+    body = await response.text();
+  } catch {
+    return false;
+  }
+  return body.includes(uri) || body.includes(htmlEscape(uri));
+};
+
+/**
+ * Default ARK org lookup: read `properties.who.name` from the arks.org NAAN
+ * record (e.g. `ark:60537` → `Gouda Tijdmachine`).
+ */
+const defaultLookupOrg: LookupOrg = async naan => {
+  let response: Response;
+  try {
+    response = await fetch(`https://arks.org/ark:${naan}`, {
+      redirect: 'follow',
+      headers: {accept: 'application/json'},
+    });
+  } catch {
+    return undefined;
+  }
+  if (!response.ok) return undefined;
+  let data: unknown;
+  try {
+    data = await response.json();
+  } catch {
+    return undefined;
+  }
+  const name = (data as {properties?: {who?: {name?: unknown}}} | null)
+    ?.properties?.who?.name;
+  return typeof name === 'string' ? name : undefined;
+};
+
+function htmlEscape(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function sparqlString(value: string): string {
+  return `"${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`;
+}

--- a/src/subjectUriResolution.ts
+++ b/src/subjectUriResolution.ts
@@ -1,10 +1,10 @@
 import {DataFactory} from 'n3';
 import pLimit from 'p-limit';
 import type {Quad} from '@rdfjs/types';
-import type {Dataset, Distribution} from '@lde/dataset';
+import {assertSafeIri, type Dataset, type Distribution} from '@lde/dataset';
 import {
-  SparqlConstructExecutor,
-  NotSupported,
+  ConstantTimeoutPolicy,
+  SparqlItemSelector,
   type ExecutorContext,
   type QuadTransform,
 } from '@lde/pipeline';
@@ -59,8 +59,8 @@ type PidScheme = keyof typeof PID_SCHEMES;
 const PID_PREFIXES: ReadonlyArray<{scheme: PidScheme; prefix: string}> = [
   {scheme: 'ark', prefix: 'n2t.net/ark:'},
   {scheme: 'ark', prefix: 'arks.org/ark:'},
-  {scheme: 'handle', prefix: 'hdl.handle.net'},
-  {scheme: 'handle', prefix: 'handle.net'},
+  {scheme: 'handle', prefix: 'hdl.handle.net/'},
+  {scheme: 'handle', prefix: 'handle.net/'},
 ];
 
 const DEFAULT_SOFTWARE = namedNode(
@@ -76,8 +76,15 @@ export const DEFAULT_SAMPLE_SIZE = 10;
  */
 const DEFAULT_CONCURRENCY = 4;
 
-/** Marker predicate/object for the internal sampling CONSTRUCT. */
-const SAMPLE_MARKER = namedNode('https://def.nde.nl/internal#sampled-subject');
+/**
+ * Budget for the sample SELECT. The transform runs outside the stage runner, so
+ * the Pipeline's adaptive timeout policy is out of reach; a bounded constant
+ * keeps one slow endpoint from stalling the run.
+ */
+const SAMPLE_TIMEOUT_MS = 60_000;
+
+/** Per-request budget for dereferencing a sampled URI and the arks.org lookup. */
+const DEREFERENCE_TIMEOUT_MS = 10_000;
 
 /** Samples up to `sampleSize` distinct subject IRIs from `uriSpace`. */
 export type SampleUris = (
@@ -321,40 +328,43 @@ function* integerMeasurement(
 }
 
 /**
- * Default sampler: a `SELECT DISTINCT ?s … LIMIT n` short-circuited on the
- * namespace prefix, run through {@link SparqlConstructExecutor} so it reuses the
- * distribution’s endpoint, subject filter, and named-graph handling.
+ * Default sampler: a `SELECT DISTINCT ?s` short-circuited on the namespace
+ * prefix, paged through {@link SparqlItemSelector} and capped at `sampleSize`.
+ * A bounded {@link ConstantTimeoutPolicy} fast-fails a slow endpoint, since the
+ * transform runs outside the stage runner where the Pipeline's adaptive policy
+ * would normally apply. The distribution's subject filter and named graph are
+ * woven into the query, mirroring the VoID class selector.
  */
 const defaultSampleUris: SampleUris = async (
   uriSpace,
   sampleSize,
-  {dataset, distribution},
+  {distribution},
 ) => {
+  const subjectFilter = distribution.subjectFilter ?? '';
+  let fromClause = '';
+  if (distribution.namedGraph) {
+    assertSafeIri(distribution.namedGraph);
+    fromClause = `FROM <${distribution.namedGraph}>`;
+  }
   const query = [
-    `CONSTRUCT { ?s <${SAMPLE_MARKER.value}> <${SAMPLE_MARKER.value}> }`,
+    'SELECT DISTINCT ?s',
+    fromClause,
     'WHERE {',
-    '  {',
-    '    SELECT DISTINCT ?s WHERE {',
-    '      #subjectFilter#',
-    '      ?s ?p ?o .',
-    `      FILTER(ISIRI(?s) && STRSTARTS(STR(?s), ${sparqlString(uriSpace)}))`,
-    '    }',
-    `    LIMIT ${sampleSize}`,
-    '  }',
+    `  ${subjectFilter}`,
+    '  ?s ?p ?o .',
+    `  FILTER(ISIRI(?s) && STRSTARTS(STR(?s), ${sparqlString(uriSpace)}))`,
     '}',
   ].join('\n');
 
-  const result = await new SparqlConstructExecutor({query}).execute(
-    dataset,
-    distribution,
-  );
-  if (result instanceof NotSupported) return [];
-
-  const subjects = new Set<string>();
-  for await (const q of result) {
-    subjects.add(q.subject.value);
+  const selector = new SparqlItemSelector({query, maxResults: sampleSize});
+  const timeout = new ConstantTimeoutPolicy(SAMPLE_TIMEOUT_MS);
+  const subjects: string[] = [];
+  for await (const row of selector.select(distribution, sampleSize, {
+    timeout,
+  })) {
+    if (row.s) subjects.push(row.s.value);
   }
-  return [...subjects];
+  return subjects;
 };
 
 /**
@@ -369,6 +379,7 @@ const defaultResolve: ResolveUri = async uri => {
     response = await fetch(uri, {
       redirect: 'follow',
       headers: {accept: 'text/html'},
+      signal: AbortSignal.timeout(DEREFERENCE_TIMEOUT_MS),
     });
   } catch {
     return false;
@@ -393,9 +404,10 @@ const defaultResolve: ResolveUri = async uri => {
 const defaultLookupOrg: LookupOrg = async naan => {
   let response: Response;
   try {
-    response = await fetch(`https://arks.org/ark:${naan}`, {
+    response = await fetch(`https://arks.org/ark:${encodeURIComponent(naan)}`, {
       redirect: 'follow',
       headers: {accept: 'application/json'},
+      signal: AbortSignal.timeout(DEREFERENCE_TIMEOUT_MS),
     });
   } catch {
     return undefined;
@@ -422,5 +434,11 @@ function htmlEscape(value: string): string {
 }
 
 function sparqlString(value: string): string {
-  return `"${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`;
+  const escaped = value
+    .replaceAll('\\', '\\\\')
+    .replaceAll('"', '\\"')
+    .replaceAll('\n', '\\n')
+    .replaceAll('\r', '\\r')
+    .replaceAll('\t', '\\t');
+  return `"${escaped}"`;
 }

--- a/src/subjectUriResolution.ts
+++ b/src/subjectUriResolution.ts
@@ -1,13 +1,9 @@
 import {DataFactory} from 'n3';
 import pLimit from 'p-limit';
+import {SparqlEndpointFetcher, type IBindings} from 'fetch-sparql-endpoint';
 import type {Quad} from '@rdfjs/types';
 import {assertSafeIri, type Dataset, type Distribution} from '@lde/dataset';
-import {
-  ConstantTimeoutPolicy,
-  SparqlItemSelector,
-  type ExecutorContext,
-  type QuadTransform,
-} from '@lde/pipeline';
+import type {ExecutorContext, QuadTransform} from '@lde/pipeline';
 
 const {namedNode, literal, blankNode, quad} = DataFactory;
 
@@ -328,9 +324,9 @@ function* integerMeasurement(
 }
 
 /**
- * Default sampler: a `SELECT DISTINCT ?s` short-circuited on the namespace
- * prefix, paged through {@link SparqlItemSelector} and capped at `sampleSize`.
- * A bounded {@link ConstantTimeoutPolicy} fast-fails a slow endpoint, since the
+ * Default sampler: a `SELECT DISTINCT ?s … LIMIT n` short-circuited on the
+ * namespace prefix, run as a plain SPARQL SELECT against the distribution's
+ * endpoint. The fetcher's own timeout fast-fails a slow endpoint, since the
  * transform runs outside the stage runner where the Pipeline's adaptive policy
  * would normally apply. The distribution's subject filter and named graph are
  * woven into the query, mirroring the VoID class selector.
@@ -354,15 +350,19 @@ const defaultSampleUris: SampleUris = async (
     '  ?s ?p ?o .',
     `  FILTER(ISIRI(?s) && STRSTARTS(STR(?s), ${sparqlString(uriSpace)}))`,
     '}',
+    `LIMIT ${sampleSize}`,
   ].join('\n');
 
-  const selector = new SparqlItemSelector({query, maxResults: sampleSize});
-  const timeout = new ConstantTimeoutPolicy(SAMPLE_TIMEOUT_MS);
+  const fetcher = new SparqlEndpointFetcher({timeout: SAMPLE_TIMEOUT_MS});
+  // fetchBindings yields IBindings (object mode), not the string/Buffer the
+  // NodeJS.ReadableStream type implies.
+  const bindings = (await fetcher.fetchBindings(
+    distribution.accessUrl.toString(),
+    query,
+  )) as unknown as AsyncIterable<IBindings>;
   const subjects: string[] = [];
-  for await (const row of selector.select(distribution, sampleSize, {
-    timeout,
-  })) {
-    if (row.s) subjects.push(row.s.value);
+  for await (const row of bindings) {
+    if (row.s?.termType === 'NamedNode') subjects.push(row.s.value);
   }
   return subjects;
 };

--- a/test/subjectUriResolution.test.ts
+++ b/test/subjectUriResolution.test.ts
@@ -1,0 +1,346 @@
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {DataFactory} from 'n3';
+import type {NamedNode, Quad} from '@rdfjs/types';
+import {Dataset, Distribution} from '@lde/dataset';
+import type {ExecutorContext} from '@lde/pipeline';
+import {
+  subjectUriResolution,
+  type LookupOrg,
+  type ResolveUri,
+  type SampleUris,
+} from '../src/subjectUriResolution.js';
+
+const {namedNode, literal, quad} = DataFactory;
+
+const DATASET_IRI = 'http://example.org/dataset/1';
+
+const RDF_TYPE = namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+const VOID_DATASET = namedNode('http://rdfs.org/ns/void#Dataset');
+const VOID_SUBSET = namedNode('http://rdfs.org/ns/void#subset');
+const VOID_URI_SPACE = namedNode('http://rdfs.org/ns/void#uriSpace');
+const VOID_ENTITIES = namedNode('http://rdfs.org/ns/void#entities');
+const DCTERMS_CONFORMS_TO = namedNode('http://purl.org/dc/terms/conformsTo');
+const DCTERMS_PUBLISHER = namedNode('http://purl.org/dc/terms/publisher');
+const DQV_HAS_QUALITY_MEASUREMENT = namedNode(
+  'http://www.w3.org/ns/dqv#hasQualityMeasurement',
+);
+const DQV_COMPUTED_ON = namedNode('http://www.w3.org/ns/dqv#computedOn');
+const DQV_IS_MEASUREMENT_OF = namedNode(
+  'http://www.w3.org/ns/dqv#isMeasurementOf',
+);
+const DQV_VALUE = namedNode('http://www.w3.org/ns/dqv#value');
+const XSD_INTEGER = namedNode('http://www.w3.org/2001/XMLSchema#integer');
+
+const METRIC_BASE = 'https://def.nde.nl/metric#';
+const SAMPLED_METRIC = `${METRIC_BASE}subject-uris-sampled`;
+const RESOLVED_METRIC = `${METRIC_BASE}subject-uris-resolved`;
+const ARK_SCHEME = namedNode('https://def.nde.nl/pid-scheme#ark');
+const HANDLE_SCHEME = namedNode('https://def.nde.nl/pid-scheme#handle');
+
+const dataset = new Dataset({iri: new URL(DATASET_IRI), distributions: []});
+const distribution = Distribution.sparql(new URL('http://example.org/sparql'));
+const context: ExecutorContext = {
+  dataset,
+  distribution,
+  stage: 'subject-uri-space.rq',
+};
+
+/** Build the subset quads `subject-uri-space.rq` emits for one namespace. */
+function subset(
+  uriSpace: string,
+  entities: number,
+): {node: NamedNode; quads: Quad[]} {
+  const node = namedNode(
+    `${DATASET_IRI}/.well-known/void#subject-uri-space-${encodeURIComponent(uriSpace)}`,
+  );
+  return {
+    node,
+    quads: [
+      quad(namedNode(DATASET_IRI), RDF_TYPE, VOID_DATASET),
+      quad(namedNode(DATASET_IRI), VOID_SUBSET, node),
+      quad(node, VOID_URI_SPACE, literal(uriSpace)),
+      quad(node, VOID_ENTITIES, literal(String(entities), XSD_INTEGER)),
+    ],
+  };
+}
+
+function stream(quads: Quad[]): AsyncIterable<Quad> {
+  return (async function* () {
+    for (const q of quads) yield q;
+  })();
+}
+
+async function collect(quads: AsyncIterable<Quad>): Promise<Quad[]> {
+  const result: Quad[] = [];
+  for await (const q of quads) result.push(q);
+  return result;
+}
+
+/** Read the integer value of the measurement of `metric`, computed on `node`. */
+function measurementValue(
+  quads: Quad[],
+  metric: string,
+  node: NamedNode,
+): number | undefined {
+  const measurement = quads.find(
+    q => q.predicate.equals(DQV_IS_MEASUREMENT_OF) && q.object.value === metric,
+  )?.subject;
+  if (!measurement) return undefined;
+  const onNode = quads.some(
+    q =>
+      q.subject.equals(measurement) &&
+      q.predicate.equals(DQV_COMPUTED_ON) &&
+      q.object.equals(node),
+  );
+  if (!onNode) return undefined;
+  const value = quads.find(
+    q => q.subject.equals(measurement) && q.predicate.equals(DQV_VALUE),
+  );
+  return value ? Number(value.object.value) : undefined;
+}
+
+const sampleFixed =
+  (uris: string[]): SampleUris =>
+  async () =>
+    uris;
+const resolveByName: ResolveUri = async uri => uri.includes('good');
+const noOrg: LookupOrg = async () => undefined;
+
+describe('subjectUriResolution', () => {
+  it('passes the subsets through and appends sampled/resolved measurements', async () => {
+    const ns = subset('http://example.org/id/', 312000);
+    const transform = subjectUriResolution({
+      terminologyPrefixes: [],
+      sampleUris: sampleFixed([
+        'http://example.org/id/good-1',
+        'http://example.org/id/good-2',
+        'http://example.org/id/bad-3',
+      ]),
+      resolve: resolveByName,
+    });
+
+    const out = await collect(transform(stream(ns.quads), context));
+
+    // The subset quads survive unchanged.
+    expect(
+      out.some(q => q.predicate.equals(VOID_URI_SPACE)) &&
+        out.some(q => q.predicate.equals(VOID_ENTITIES)),
+    ).toBe(true);
+
+    // Measurements are computed on the subset node, not the dataset.
+    expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBe(3);
+    expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(2);
+    expect(
+      out.filter(
+        q =>
+          q.subject.equals(ns.node) &&
+          q.predicate.equals(DQV_HAS_QUALITY_MEASUREMENT),
+      ),
+    ).toHaveLength(2);
+  });
+
+  it('picks the most common non-terminology namespace', async () => {
+    const terminology = subset('http://data.rkd.nl/artists/', 900000);
+    const own = subset('http://example.org/id/', 5000);
+    const seen: string[] = [];
+    const transform = subjectUriResolution({
+      terminologyPrefixes: ['http://data.rkd.nl/artists/'],
+      sampleUris: async uriSpace => {
+        seen.push(uriSpace);
+        return [];
+      },
+      resolve: resolveByName,
+    });
+
+    await collect(
+      transform(stream([...terminology.quads, ...own.quads]), context),
+    );
+
+    // The bigger terminology namespace is skipped; the dataset’s own one wins.
+    expect(seen).toEqual(['http://example.org/id/']);
+  });
+
+  it('emits nothing extra when only terminology namespaces survive', async () => {
+    const terminology = subset('http://data.rkd.nl/artists/', 900000);
+    const transform = subjectUriResolution({
+      terminologyPrefixes: ['http://data.rkd.nl/artists/'],
+      sampleUris: sampleFixed(['http://data.rkd.nl/artists/1']),
+      resolve: resolveByName,
+    });
+
+    const out = await collect(transform(stream(terminology.quads), context));
+
+    expect(out).toHaveLength(terminology.quads.length);
+    expect(out.some(q => q.predicate.equals(DQV_HAS_QUALITY_MEASUREMENT))).toBe(
+      false,
+    );
+  });
+
+  it('detects an ARK scheme and attaches the issuing organisation', async () => {
+    const ns = subset('https://n2t.net/ark:/60537/', 312000);
+    const lookupOrg: LookupOrg = async naan =>
+      naan === '60537' ? 'Gouda Tijdmachine' : undefined;
+    const transform = subjectUriResolution({
+      terminologyPrefixes: [],
+      sampleUris: sampleFixed(['https://n2t.net/ark:/60537/good-1']),
+      resolve: resolveByName,
+      lookupOrg,
+    });
+
+    const out = await collect(transform(stream(ns.quads), context));
+
+    expect(
+      out.some(
+        q =>
+          q.subject.equals(ns.node) &&
+          q.predicate.equals(DCTERMS_CONFORMS_TO) &&
+          q.object.equals(ARK_SCHEME),
+      ),
+    ).toBe(true);
+    expect(
+      out.some(
+        q =>
+          q.subject.equals(ns.node) &&
+          q.predicate.equals(DCTERMS_PUBLISHER) &&
+          q.object.value === 'Gouda Tijdmachine',
+      ),
+    ).toBe(true);
+  });
+
+  it('detects a Handle scheme but attaches no organisation', async () => {
+    const ns = subset('http://hdl.handle.net/21.12102/', 100);
+    const transform = subjectUriResolution({
+      terminologyPrefixes: [],
+      sampleUris: sampleFixed(['http://hdl.handle.net/21.12102/good']),
+      resolve: resolveByName,
+      lookupOrg: noOrg,
+    });
+
+    const out = await collect(transform(stream(ns.quads), context));
+
+    expect(
+      out.some(
+        q =>
+          q.predicate.equals(DCTERMS_CONFORMS_TO) &&
+          q.object.equals(HANDLE_SCHEME),
+      ),
+    ).toBe(true);
+    expect(out.some(q => q.predicate.equals(DCTERMS_PUBLISHER))).toBe(false);
+  });
+
+  it('measures an unrecognised namespace without a scheme or org', async () => {
+    const ns = subset('http://example.org/id/', 42);
+    const transform = subjectUriResolution({
+      terminologyPrefixes: [],
+      sampleUris: sampleFixed(['http://example.org/id/good']),
+      resolve: resolveByName,
+    });
+
+    const out = await collect(transform(stream(ns.quads), context));
+
+    expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
+    expect(out.some(q => q.predicate.equals(DCTERMS_CONFORMS_TO))).toBe(false);
+    expect(out.some(q => q.predicate.equals(DCTERMS_PUBLISHER))).toBe(false);
+  });
+
+  it('emits the ARK scheme without an org when the lookup fails', async () => {
+    const ns = subset('https://n2t.net/ark:/60537/', 10);
+    const transform = subjectUriResolution({
+      terminologyPrefixes: [],
+      sampleUris: sampleFixed(['https://n2t.net/ark:/60537/good']),
+      resolve: resolveByName,
+      lookupOrg: async () => {
+        throw new Error('arks.org unreachable');
+      },
+    });
+
+    const out = await collect(transform(stream(ns.quads), context));
+
+    expect(out.some(q => q.object.equals(ARK_SCHEME))).toBe(true);
+    expect(out.some(q => q.predicate.equals(DCTERMS_PUBLISHER))).toBe(false);
+    // The measurements are still emitted.
+    expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBe(1);
+  });
+
+  it('counts a resolution that throws as unresolved', async () => {
+    const ns = subset('http://example.org/id/', 10);
+    const transform = subjectUriResolution({
+      terminologyPrefixes: [],
+      sampleUris: sampleFixed([
+        'http://example.org/id/good',
+        'http://example.org/id/throws',
+      ]),
+      resolve: async uri => {
+        if (uri.includes('throws')) throw new Error('boom');
+        return true;
+      },
+    });
+
+    const out = await collect(transform(stream(ns.quads), context));
+
+    expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBe(2);
+    expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
+  });
+
+  it('keeps the VoID output when sampling fails', async () => {
+    const ns = subset('http://example.org/id/', 10);
+    const transform = subjectUriResolution({
+      terminologyPrefixes: [],
+      sampleUris: async () => {
+        throw new Error('endpoint timeout');
+      },
+      resolve: resolveByName,
+    });
+
+    const out = await collect(transform(stream(ns.quads), context));
+
+    // The subsets pass through; no measurements are appended.
+    expect(out).toHaveLength(ns.quads.length);
+    expect(out.some(q => q.predicate.equals(DQV_HAS_QUALITY_MEASUREMENT))).toBe(
+      false,
+    );
+  });
+
+  describe('default ARK organisation lookup', () => {
+    afterEach(() => vi.unstubAllGlobals());
+
+    // The arks.org NAAN record nests the organisation under `properties.who`.
+    const arksRecord = {
+      pid: 'ark:60537',
+      properties: {who: {name: 'Gouda Tijdmachine', acronym: 'GTM'}},
+    };
+
+    it('reads properties.who.name from the arks.org record', async () => {
+      const fetchStub = vi.fn(
+        async () =>
+          new Response(JSON.stringify(arksRecord), {
+            status: 200,
+            headers: {'content-type': 'application/json'},
+          }),
+      );
+      vi.stubGlobal('fetch', fetchStub);
+
+      const ns = subset('https://n2t.net/ark:/60537/', 10);
+      // lookupOrg left to the default → exercises the arks.org parsing.
+      const transform = subjectUriResolution({
+        terminologyPrefixes: [],
+        sampleUris: sampleFixed(['https://n2t.net/ark:/60537/good']),
+        resolve: resolveByName,
+      });
+
+      const out = await collect(transform(stream(ns.quads), context));
+
+      expect(fetchStub).toHaveBeenCalledWith(
+        'https://arks.org/ark:60537',
+        expect.anything(),
+      );
+      expect(
+        out.some(
+          q =>
+            q.predicate.equals(DCTERMS_PUBLISHER) &&
+            q.object.value === 'Gouda Tijdmachine',
+        ),
+      ).toBe(true);
+    });
+  });
+});

--- a/test/subjectUriResolution.test.ts
+++ b/test/subjectUriResolution.test.ts
@@ -228,6 +228,23 @@ describe('subjectUriResolution', () => {
     expect(out.some(q => q.predicate.equals(DCTERMS_PUBLISHER))).toBe(false);
   });
 
+  it('does not classify a look-alike host as a Handle scheme', async () => {
+    // The host merely starts with 'hdl.handle.net' — the trailing-slash
+    // boundary must stop it from matching the Handle prefix.
+    const ns = subset('https://hdl.handle.net.evil.example/123/', 50);
+    const transform = subjectUriResolution({
+      terminologyPrefixes: [],
+      sampleUris: sampleFixed(['https://hdl.handle.net.evil.example/123/good']),
+      resolve: resolveByName,
+    });
+
+    const out = await collect(transform(stream(ns.quads), context));
+
+    expect(out.some(q => q.predicate.equals(DCTERMS_CONFORMS_TO))).toBe(false);
+    // The resolution measurement is still emitted for the namespace.
+    expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
+  });
+
   it('measures an unrecognised namespace without a scheme or org', async () => {
     const ns = subset('http://example.org/id/', 42);
     const transform = subjectUriResolution({


### PR DESCRIPTION
Samples a dataset’s own subject URIs and measures whether they resolve, layering persistent-identifier (PID) detection on top — the IIIF declared-vs-validated pattern applied to subject namespaces.

Built on [ldelements/lde#434](https://github.com/ldelements/lde/pull/438): the VoID stage executors are now first-class wrappable, so this attaches a `QuadTransform` to the `subject-uri-space` stage rather than forking the query or subclassing `Executor` (per lde ADR 0002, which superseded the executor-decorator design the issue originally described).

## What it does

`src/subjectUriResolution.ts` is a `QuadTransform<ExecutorContext>` routed onto `VOID_STAGE_NAMES.subjectUriSpace` via `voidStages({ transforms: … })`. It:

- harvests the `void:uriSpace`/`void:entities` subsets from the stage output (passing them through unchanged) and picks the single most common **non-terminology** namespace (terminology-source prefixes from `buildUriSpacesMap()` are excluded with `startsWith`) — the namespace the dataset mints for its own resources;
- samples up to N URIs (default 10) from it via a `SELECT DISTINCT … LIMIT N` short-circuited on the prefix, run through `SparqlConstructExecutor` so it reuses the distribution’s endpoint, subject filter and named-graph handling;
- dereferences the sample (≤ 4 concurrent, no retries), counting a URI as resolved when the final redirected response is `200`, `text/html`, and the landing page advertises the original URI back;
- detects ARK / Handle PID schemes from the namespace and looks up the ARK issuing organisation via `arks.org` (`properties.who.name`, verified against `ark:60537`);
- appends, scoped to the namespace’s `void:subset` node: `dcterms:conformsTo` a PID scheme (only if recognised), `dcterms:publisher` the ARK org (non-fatal), `subject-uris-sampled` / `subject-uris-resolved` DQV measurements, and a PROV activity.

Metric names stay namespace-neutral (`subject-uris-*`, not `persistent-uris-*`) — the ratio applies to any namespace; PID-ness lives only in the scheme label. If no non-terminology namespace survives, nothing is appended.

## Notes

- `sampleUris`, `resolve` and `lookupOrg` are injectable for testing; enrichment is best-effort, so a failed sample never drops the VoID output that already streamed through.
- The external docs repo (`docs/docs/services`) update mentioned in the issue is a separate repository and is not included here.

Fix #316
