### PR TITLE
feat: decouple IIIF detection from conformance and add a media signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,24 +303,65 @@ Licenses that apply to resources in the dataset.
     ].
 ```
 
-### IIIF Presentation manifests
+### Media
 
-Datasets that expose [IIIF Presentation API](http://iiif.io/api/presentation/)
-manifests — detected by matching `schema:encodingFormat` literals against the
-[SCHEMA-AP-NDE](https://docs.nde.nl/schema-profile/) IIIF profile pattern — get
-a `void:subset` keyed on `dcterms:conformsTo <http://iiif.io/api/presentation/>`
-with a `void:entities` count of distinct manifests. v2 and v3 manifests are
-collapsed into a single, version-less subset. Detection uses `STRSTARTS` /
-`STRENDS` rather than a regex (a regex over every `encodingFormat` literal is
-costly on QLever and on remote endpoints alike); the version segment is left
-unconstrained, which is intentionally forwards-compatible with future
-Presentation API versions.
+Whether a dataset exposes *any* media — images, audio, video, 3D — is reported
+as a `void:subset` marked
+`<https://def.nde.nl/probe#detects> <https://def.nde.nl/probe#media>`. The
+subset exists iff the dataset has media, so its presence is the `has-media`
+signal: a media-bearing dataset that offers no IIIF is then observable as
+“media, but no IIIF” rather than indistinguishable from “no media”.
+
+Media is detected by a deliberately wide but curated allowlist of media
+*predicates* spanning schema.org, EDM, CIDOC-CRM, Linked Art, FOAF, Omeka and a
+few bespoke heritage vocabularies (see `queries/analysis/media.rq`). False
+friends are excluded — e.g. `crm:P16_used_specific_object` (a tool, not a
+digital object) and `schema:depicts` (subject matter, not a media link). Each
+present predicate becomes a self-describing `void:propertyPartition`; the
+subset’s aggregate `void:entities` is the **MAX** over those partitions — a
+double-count-safe lower bound on the number of media objects (one record often
+carries `image` + `thumbnailUrl` + `contentUrl`, so summing would treble-count
+it).
 
 ```ttl
 <https://example.com/dataset> a void:Dataset;
     void:subset [
-        dcterms:conformsTo <http://iiif.io/api/presentation/> ;
-        void:entities 42 .
+        <https://def.nde.nl/probe#detects> <https://def.nde.nl/probe#media> ;
+        void:entities 104276 ;
+        void:propertyPartition
+            [ void:property <https://schema.org/contentUrl> ; void:entities 104276 ],
+            [ void:property <https://schema.org/thumbnailUrl> ; void:entities 104276 ] .
+    ].
+```
+
+### IIIF Presentation manifests
+
+Datasets that expose [IIIF Presentation API](http://iiif.io/api/presentation/)
+manifests get a `void:subset` keyed on
+`dcterms:conformsTo <http://iiif.io/api/presentation/>` with a `void:entities`
+count of distinct manifests. Detection is **decoupled** from
+[SCHEMA-AP-NDE](https://docs.nde.nl/schema-profile/) conformance (issue #314): a
+manifest counts as IIIF *capability* if its `schema:encodingFormat` literal is
+either the full profile pattern *or* the bare `application/ld+json` media type —
+so a working manifest declared without the `;profile=` parameter is not missed.
+The profile-conformant manifests are emitted as a *nested* `void:subset` keyed
+on `dcterms:conformsTo <https://docs.nde.nl/schema-profile/>`, encoding
+`conformant ⊆ capability`. The capability subset in turn nests under the
+dataset’s media subset (`iiif ⊆ media`). v2 and v3 manifests are collapsed into
+a single, version-less subset. Detection uses `STRSTARTS` / `STRENDS` rather
+than a regex (a regex over every `encodingFormat` literal is costly on QLever
+and on remote endpoints alike); the version segment is left unconstrained, which
+is intentionally forwards-compatible with future Presentation API versions.
+
+```ttl
+<https://example.com/dataset> a void:Dataset;
+    void:subset [
+        dcterms:conformsTo <http://iiif.io/api/presentation/> ;  # capability
+        void:entities 42 ;
+        void:subset [
+            dcterms:conformsTo <https://docs.nde.nl/schema-profile/> ;  # conformance
+            void:entities 37 .
+        ] .
     ].
 ```
 
@@ -339,26 +380,29 @@ broken manifest is one tick in a ratio, so there are no retries.
 The declared marker is **never removed** — it is the neutral statistic. The
 validation outcome is added alongside it as two
 [DQV](https://www.w3.org/TR/vocab-dqv/) integer measurements plus a
-[PROV](https://www.w3.org/TR/prov-o/) activity:
+[PROV](https://www.w3.org/TR/prov-o/) activity. The measurements are
+`dqv:computedOn` the **capability subset** — the resource they actually describe
+— which already carries the `dcterms:conformsTo` marker, so no per-measurement
+profile back-link is needed. For backward compatibility the measurements are
+*also* linked from the dataset (`?dataset dqv:hasQualityMeasurement …`), the
+path earlier consumers read; that link is transitional and will be dropped once
+consumers navigate via `void:subset`:
 
 ```ttl
-@prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix dqv:     <http://www.w3.org/ns/dqv#> .
-@prefix prov:    <http://www.w3.org/ns/prov#> .
+@prefix dqv:  <http://www.w3.org/ns/dqv#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
 
-<https://example.org/dataset>
+<https://example.org/dataset/.well-known/void#iiif-…>
     dqv:hasQualityMeasurement
         [ a dqv:QualityMeasurement ;
-          dqv:computedOn <https://example.org/dataset> ;
+          dqv:computedOn <https://example.org/dataset/.well-known/void#iiif-…> ;
           dqv:isMeasurementOf <https://def.nde.nl/metric#manifests-sampled> ;
           dqv:value 10 ;
-          dcterms:conformsTo <http://iiif.io/api/presentation/> ;
           prov:wasGeneratedBy _:validation ] ,
         [ a dqv:QualityMeasurement ;
-          dqv:computedOn <https://example.org/dataset> ;
+          dqv:computedOn <https://example.org/dataset/.well-known/void#iiif-…> ;
           dqv:isMeasurementOf <https://def.nde.nl/metric#manifests-validated> ;
           dqv:value 7 ;
-          dcterms:conformsTo <http://iiif.io/api/presentation/> ;
           prov:wasGeneratedBy _:validation ] .
 
 _:validation
@@ -374,14 +418,17 @@ _:validation
 
 No float ratio and no baked threshold are emitted: consumers derive `k / N` and
 pick their own bar. The only non-arbitrary cut is `validated = 0` versus
-`validated > 0`. Combining the declared subset with the validated count yields
-three observable states:
+`validated > 0`. The DKG stays signal-only; a consumer composes these orthogonal
+signals into a verdict. Combining the media subset, the capability/conformance
+subsets and the validated count yields a gradient:
 
-| State | subset + `conformsTo` | `void:entities` | sampled / validated |
-|---|---|---|---|
-| No IIIF | absent | – | – |
-| Declared but failing | present | declared count | sampled = N, validated = 0 |
-| Declared and working | present | declared count | sampled = N, validated ≥ 1 |
+| State | media subset | capability subset | conformance sub-subset | validated |
+|---|---|---|---|---|
+| No media | absent | – | – | – |
+| Media, no IIIF | present | absent | – | – |
+| IIIF declared but failing | present | present | – | 0 |
+| IIIF working, non-conformant | present | present | absent / 0 | ≥ 1 |
+| IIIF working and conformant | present | present | present, ≥ 1 | ≥ 1 |
 
 #### Querying
 
@@ -389,13 +436,32 @@ three observable states:
 
 ```sparql
 PREFIX dqv: <http://www.w3.org/ns/dqv#>
+PREFIX void: <http://rdfs.org/ns/void#>
 
 SELECT ?dataset WHERE {
-    ?dataset dqv:hasQualityMeasurement [
+    ?dataset void:subset/dqv:hasQualityMeasurement [
         dqv:isMeasurementOf <https://def.nde.nl/metric#manifests-validated> ;
         dqv:value ?validated
     ] .
     FILTER(?validated > 0)
+}
+```
+
+“Find datasets that have media but expose no IIIF” (the publishers to nudge):
+
+```sparql
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX void: <http://rdfs.org/ns/void#>
+
+SELECT ?dataset WHERE {
+    ?dataset void:subset [
+        <https://def.nde.nl/probe#detects> <https://def.nde.nl/probe#media>
+    ] .
+    FILTER NOT EXISTS {
+        ?dataset void:subset/void:subset [
+            dcterms:conformsTo <http://iiif.io/api/presentation/>
+        ] .
+    }
 }
 ```
 
@@ -404,9 +470,10 @@ diagnostic query for giving publishers feedback):
 
 ```sparql
 PREFIX dqv: <http://www.w3.org/ns/dqv#>
+PREFIX void: <http://rdfs.org/ns/void#>
 
 SELECT ?dataset WHERE {
-    ?dataset dqv:hasQualityMeasurement [
+    ?dataset void:subset/dqv:hasQualityMeasurement [
         dqv:isMeasurementOf <https://def.nde.nl/metric#manifests-validated> ;
         dqv:value 0
     ] .

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@lde/dataset": "^0.7.4",
         "@lde/dataset-registry-client": "^0.8.0",
-        "@lde/iiif-validator": "^0.1.1",
+        "@lde/iiif-validator": "^0.1.2",
         "@lde/pipeline": "^0.30.4",
         "@lde/pipeline-console-reporter": "^0.21.4",
         "@lde/pipeline-shacl-sampler": "^0.4.4",
@@ -6652,9 +6652,9 @@
       }
     },
     "node_modules/@lde/iiif-validator": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@lde/iiif-validator/-/iiif-validator-0.1.1.tgz",
-      "integrity": "sha512-SFCPnFHBfNCu0+FqyqSwiGqeVHuJHrsXeGoSpbN4KHl+U6Hq4WFJwJ0+g1W82u+tQFw9hWygZJiou91tcaIMbw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@lde/iiif-validator/-/iiif-validator-0.1.2.tgz",
+      "integrity": "sha512-08NKxFVLgYG0WmIEdoNIpWD4IjbQ+DBZVX+ChFC2+6zHVED0VfCdTmzmdM9EDBP1Nf4x6/DNlvkPUc4K4as53Q==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@lde/dataset": "^0.7.4",
     "@lde/dataset-registry-client": "^0.8.0",
-    "@lde/iiif-validator": "^0.1.1",
+    "@lde/iiif-validator": "^0.1.2",
     "@lde/pipeline": "^0.30.4",
     "@lde/pipeline-console-reporter": "^0.21.4",
     "@lde/pipeline-shacl-sampler": "^0.4.4",

--- a/queries/analysis/iiif.rq
+++ b/queries/analysis/iiif.rq
@@ -5,45 +5,96 @@ PREFIX void: <http://rdfs.org/ns/void#>
 CONSTRUCT {
     ?dataset a void:Dataset ;
         void:subset ?iiifSubset .
+    # IIIF manifests are media, so the capability subset also nests under the
+    # dataset’s media subset (`iiif ⊆ media`, issue #314). The media subset
+    # itself is described by media.rq; this only asserts the containment edge,
+    # using the same deterministic IRI. The direct dataset→iiif edge above is
+    # kept so the IIIF subset stays reachable even if media.rq did not run.
+    ?mediaSubset void:subset ?iiifSubset .
     ?iiifSubset
         dcterms:conformsTo <http://iiif.io/api/presentation/> ;
         void:entities ?count ;
         # Intermediate triple: a capped, first-N sample of the matched manifest
         # IRIs, consumed and stripped by the validation executor before output;
-        # it never reaches the published graph. The combined query (a COUNT
-        # sub-select cross-joined with a LIMIT sub-select) keeps detection a
+        # it never reaches the published graph. The combined query (COUNT
+        # sub-selects cross-joined with a LIMIT sub-select) keeps detection a
         # single round-trip, which matters because most datasets are queried
         # against their own remote SPARQL endpoint.
-        <https://def.nde.nl/iiif#manifest-sample> ?manifest .
+        <https://def.nde.nl/iiif#manifest-sample> ?manifest ;
+        # The SCHEMA-AP-NDE-conformant manifests are a *sub*-subset of the IIIF
+        # capability subset: detection (capability) is decoupled from profile
+        # conformance, so a dataset can expose working IIIF without conforming.
+        # The nesting encodes `conformant ⊆ candidate` (issue #314).
+        void:subset ?conformantSubset .
+    ?conformantSubset
+        dcterms:conformsTo <https://docs.nde.nl/schema-profile/> ;
+        void:entities ?conformantCount .
 }
 WHERE {
     {
+        # Capability count: every manifest the dataset exposes, conformant or not.
+        # A manifest is detected by its `schema:encodingFormat` literal being
+        # either the SCHEMA-AP-NDE profile media type *or* the bare JSON-LD media
+        # type `application/ld+json` (issue #314: a functional manifest declared
+        # without the `;profile=` parameter must still count). Matched without
+        # REGEX — a regex over every encodingFormat literal is costly on QLever
+        # and on remote endpoints alike; STRSTARTS lets engines prefix-scan.
         SELECT (COUNT(DISTINCT ?s) AS ?count) {
             #subjectFilter#
             ?s schema:encodingFormat|<http://schema.org/encodingFormat> ?format .
-            # Match the IIIF Presentation profile media type without REGEX: a regex
-            # over every encodingFormat literal is costly on QLever and on remote
-            # SPARQL endpoints alike. STRSTARTS lets engines prefix-scan instead.
-            # The version segment (e.g. /2/, /3/) is left unconstrained, which is
-            # intentionally forwards-compatible.
+            FILTER(isLiteral(?format) && (
+                (STRSTARTS(STR(?format), "application/ld+json;profile='http://iiif.io/api/presentation/")
+                    && STRENDS(STR(?format), "/context.json'"))
+                || STR(?format) = "application/ld+json"
+            ))
+        }
+    }
+    {
+        # Conformance count: only manifests whose encodingFormat carries the full
+        # SCHEMA-AP-NDE profile pattern. The version segment (e.g. /2/, /3/) is
+        # left unconstrained, which is intentionally forwards-compatible.
+        SELECT (COUNT(DISTINCT ?s) AS ?conformantCount) {
+            #subjectFilter#
+            ?s schema:encodingFormat|<http://schema.org/encodingFormat> ?format .
             FILTER(isLiteral(?format)
                 && STRSTARTS(STR(?format), "application/ld+json;profile='http://iiif.io/api/presentation/")
                 && STRENDS(STR(?format), "/context.json'"))
         }
     }
-    {
-        # First-N sample of distinct manifest IRIs. First-N (not random) is
-        # cheap and reproducible: the failure mode is systemic, so the first N
-        # manifests are a sufficient probe. #limit# is substituted by iiifStage.
+    # OPTIONAL so detection survives an empty sample: if every matched manifest
+    # is a blank node with no contentUrl, the sample is empty but the capability
+    # subset and its count must still be emitted (the cross-join would otherwise
+    # collapse to zero rows).
+    OPTIONAL {
+        # First-N sample of distinct dereferenceable manifest IRIs. First-N (not
+        # random) is cheap and reproducible: the failure mode is systemic, so the
+        # first N manifests are a sufficient probe. The dereference target is the
+        # manifest URL in `schema:contentUrl` when present, falling back to the
+        # encodingFormat-bearing node — issue #314 defect #2: the encodingFormat
+        # often sits on a blank node while the real manifest IRI lives in
+        # `schema:contentUrl`. #limit# is substituted by iiifStage.
         SELECT DISTINCT ?manifest {
             #subjectFilter#
-            ?manifest schema:encodingFormat|<http://schema.org/encodingFormat> ?format .
-            FILTER(isLiteral(?format)
-                && STRSTARTS(STR(?format), "application/ld+json;profile='http://iiif.io/api/presentation/")
-                && STRENDS(STR(?format), "/context.json'"))
+            ?s schema:encodingFormat|<http://schema.org/encodingFormat> ?format .
+            FILTER(isLiteral(?format) && (
+                (STRSTARTS(STR(?format), "application/ld+json;profile='http://iiif.io/api/presentation/")
+                    && STRENDS(STR(?format), "/context.json'"))
+                || STR(?format) = "application/ld+json"
+            ))
+            OPTIONAL {
+                ?s schema:contentUrl|<http://schema.org/contentUrl> ?contentUrl .
+            }
+            BIND(COALESCE(?contentUrl, ?s) AS ?manifest)
+            # Never sample a blank node: when encodingFormat sits on a blank node
+            # with no schema:contentUrl, COALESCE falls back to ?s, whose label
+            # is not a dereferenceable URL — passing it to the validator would
+            # always count as a failure and deflate manifests-validated.
+            FILTER(!isBlank(?manifest))
         }
         LIMIT #limit#
     }
     FILTER(?count > 0)
+    BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#media")) AS ?mediaSubset)
     BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#iiif-", MD5("http://iiif.io/api/presentation/"))) AS ?iiifSubset)
+    BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#iiif-conformant-", MD5("https://docs.nde.nl/schema-profile/"))) AS ?conformantSubset)
 }

--- a/queries/analysis/media.rq
+++ b/queries/analysis/media.rq
@@ -1,0 +1,66 @@
+PREFIX void: <http://rdfs.org/ns/void#>
+
+# Detect whether a dataset exposes *any* media — images, audio, video, 3D — so a
+# media-bearing dataset that offers no IIIF is observable (issue #314: “no media”
+# and “media but no IIIF” are different states). The net is cast deliberately
+# wide across vocabularies (schema.org, EDM, CIDOC-CRM, Linked Art, FOAF, Omeka
+# and a few bespoke heritage predicates), but curated: media *predicates* only,
+# excluding false friends like `crm:P16_used_specific_object` (a tool, not a
+# digital object) and `schema:depicts` (subject matter, not a media link).
+#
+# Each present predicate becomes a self-describing `void:propertyPartition` with
+# its own `void:entities` (distinct subjects bearing it ≈ records with media);
+# the aggregate `void:entities` of the subset is computed by MediaSubsetExecutor
+# as the MAX over these partitions — a double-count-safe lower bound on the
+# number of media objects. Counting is via predicates here (correctly scoped by
+# `#subjectFilter#`, which binds ?s); class-typed media objects are a documented
+# follow-up.
+CONSTRUCT {
+    ?dataset a void:Dataset ;
+        void:subset ?mediaSubset .
+    ?mediaSubset
+        a void:Dataset ;
+        <https://def.nde.nl/probe#detects> <https://def.nde.nl/probe#media> ;
+        void:propertyPartition [
+            void:property ?property ;
+            void:entities ?count
+        ] .
+}
+WHERE {
+    {
+        SELECT ?property (COUNT(DISTINCT ?s) AS ?count) {
+            #subjectFilter#
+            VALUES ?property {
+                # encodingFormat denotes a media/file object and is the signal
+                # iiif.rq detects manifests on, so including it guarantees every
+                # IIIF manifest is also counted as media — the `iiif ⊆ media`
+                # nesting invariant holds structurally (issue #314).
+                <https://schema.org/encodingFormat> <http://schema.org/encodingFormat>
+                <https://schema.org/contentUrl> <http://schema.org/contentUrl>
+                <https://schema.org/image> <http://schema.org/image>
+                <https://schema.org/thumbnailUrl> <http://schema.org/thumbnailUrl>
+                <https://schema.org/thumbnail> <http://schema.org/thumbnail>
+                <https://schema.org/associatedMedia> <http://schema.org/associatedMedia>
+                <https://schema.org/hasRepresentation> <http://schema.org/hasRepresentation>
+                <http://www.europeana.eu/schemas/edm/isShownBy>
+                <http://www.europeana.eu/schemas/edm/isShownAt>
+                <http://www.europeana.eu/schemas/edm/object>
+                <http://www.europeana.eu/schemas/edm/hasView>
+                <http://www.cidoc-crm.org/cidoc-crm/P138i_has_representation>
+                <http://www.cidoc-crm.org/cidoc-crm/P65_shows_visual_item>
+                <http://xmlns.com/foaf/0.1/depiction>
+                <http://xmlns.com/foaf/0.1/thumbnail>
+                <https://linked.art/ns/terms/digitally_carried_by>
+                <https://linked.art/ns/terms/digitally_shown_by>
+                <http://omeka.org/s/vocabs/o#media>
+                <http://omeka.org/s/vocabs/o#primary_media>
+                <http://omeka.org/s/vocabs/o#thumbnail>
+                <http://memorix.io/ontology#hasDigitalDocument>
+                <https://data.cultureelerfgoed.nl/id/rnce#image>
+            }
+            ?s ?property ?o .
+        }
+        GROUP BY ?property
+    }
+    BIND(URI(CONCAT(STR(?dataset), "/.well-known/void#media")) AS ?mediaSubset)
+}

--- a/src/iiifStage.ts
+++ b/src/iiifStage.ts
@@ -24,13 +24,17 @@ export interface IiifStageOptions {
  * `void:entities` count of distinct manifests, then *verify* a sample of those
  * manifests by dereferencing them.
  *
- * Detection mirrors SCHEMA-AP-NDE’s `_:IIIFPresentationManifestShape`: a
- * resource is a IIIF manifest iff its `schema:encodingFormat` literal matches
- * the JSON-LD context-profile pattern for any IIIF Presentation version. The
- * declared `dcterms:conformsTo` marker is never removed — it distinguishes
- * “no IIIF” from “declared but failing”. Validation adds two DQV
- * measurements (`manifests-sampled`, `manifests-validated`) so
- * consumers can tell working manifests apart from broken ones.
+ * Detection is *decoupled* from SCHEMA-AP-NDE conformance (issue #314): a
+ * resource counts as IIIF capability if its `schema:encodingFormat` literal is
+ * either the full profile pattern *or* the bare `application/ld+json` media
+ * type — so a working manifest declared without the `;profile=` parameter is
+ * not missed. The profile-conformant manifests are emitted as a nested
+ * `void:subset` keyed on `dcterms:conformsTo <https://docs.nde.nl/schema-profile/>`,
+ * encoding `conformant ⊆ capability`. The declared capability marker is never
+ * removed — it distinguishes “no IIIF” from “declared but failing”. Validation
+ * adds two DQV measurements (`manifests-sampled`, `manifests-validated`),
+ * computed on the capability subset, so consumers can tell working manifests
+ * apart from broken ones.
  *
  * Per-request timeout for the SPARQL query is configured at the
  * {@link Pipeline} level via `PipelineOptions.timeout`; the manifest

--- a/src/iiifValidationExecutor.ts
+++ b/src/iiifValidationExecutor.ts
@@ -19,7 +19,6 @@ const DQV_IS_MEASUREMENT_OF = namedNode(
   'http://www.w3.org/ns/dqv#isMeasurementOf',
 );
 const DQV_VALUE = namedNode('http://www.w3.org/ns/dqv#value');
-const DCTERMS_CONFORMS_TO = namedNode('http://purl.org/dc/terms/conformsTo');
 const PROV_ACTIVITY = namedNode('http://www.w3.org/ns/prov#Activity');
 const PROV_USED = namedNode('http://www.w3.org/ns/prov#used');
 const PROV_WAS_ASSOCIATED_WITH = namedNode(
@@ -122,16 +121,21 @@ export class IiifValidationExecutor implements Executor {
     dataset: Dataset,
   ): AsyncIterable<Quad> {
     const sampledManifests: string[] = [];
+    // The manifest-sample triples are all subjects of the IIIF capability
+    // subset; capture that IRI so the measurements are computed on the subset
+    // they actually describe, not the whole dataset.
+    let iiifSubset: string | undefined;
     for await (const q of quads) {
       if (q.predicate.equals(MANIFEST_SAMPLE)) {
         sampledManifests.push(q.object.value);
+        iiifSubset = q.subject.value;
         continue;
       }
       yield q;
     }
 
     // No IIIF subset detected: emit nothing extra (state 1, “no IIIF”).
-    if (sampledManifests.length === 0) {
+    if (sampledManifests.length === 0 || iiifSubset === undefined) {
       return;
     }
 
@@ -143,38 +147,57 @@ export class IiifValidationExecutor implements Executor {
       verdict => verdict.status === 'fulfilled' && verdict.value.valid,
     ).length;
 
-    yield* this.measurementQuads(dataset, sampledManifests.length, validated);
+    yield* this.measurementQuads(
+      dataset,
+      namedNode(iiifSubset),
+      sampledManifests.length,
+      validated,
+    );
   }
 
   private *measurementQuads(
     dataset: Dataset,
+    iiifSubset: ReturnType<typeof namedNode>,
     sampled: number,
     validated: number,
   ): Generator<Quad> {
-    const subject = namedNode(dataset.iri.toString());
     const activity = blankNode();
     const sampledMeasurement = blankNode();
     const validatedMeasurement = blankNode();
 
     // PROV: the dereferencing activity.
     yield quad(activity, RDF_TYPE, PROV_ACTIVITY);
-    yield quad(activity, PROV_USED, subject);
+    yield quad(activity, PROV_USED, namedNode(dataset.iri.toString()));
     yield quad(activity, PROV_USED, IIIF_PRESENTATION);
     yield quad(activity, PROV_WAS_ASSOCIATED_WITH, this.validatorSoftware);
 
-    yield quad(subject, DQV_HAS_QUALITY_MEASUREMENT, sampledMeasurement);
-    yield quad(subject, DQV_HAS_QUALITY_MEASUREMENT, validatedMeasurement);
+    // The measurements describe the IIIF capability subset, which already
+    // carries `dcterms:conformsTo <iiif-presentation>` — so they hang off the
+    // subset and `dqv:computedOn` it, dropping the per-measurement conformsTo
+    // back-link the dataset-level modelling needed.
+    yield quad(iiifSubset, DQV_HAS_QUALITY_MEASUREMENT, sampledMeasurement);
+    yield quad(iiifSubset, DQV_HAS_QUALITY_MEASUREMENT, validatedMeasurement);
+
+    // Backward compatibility: also link the measurements from the dataset, the
+    // path the shipped dataset-register queries still read
+    // (`?dataset dqv:hasQualityMeasurement …`). The new structure only appears
+    // after the next DKG run, so consumers cannot migrate to
+    // `void:subset/dqv:hasQualityMeasurement` before then. Drop these once
+    // dataset-register has migrated (tracked in dataset-register).
+    const datasetNode = namedNode(dataset.iri.toString());
+    yield quad(datasetNode, DQV_HAS_QUALITY_MEASUREMENT, sampledMeasurement);
+    yield quad(datasetNode, DQV_HAS_QUALITY_MEASUREMENT, validatedMeasurement);
 
     yield* this.integerMeasurement(
       sampledMeasurement,
-      subject,
+      iiifSubset,
       MANIFESTS_SAMPLED_METRIC,
       sampled,
       activity,
     );
     yield* this.integerMeasurement(
       validatedMeasurement,
-      subject,
+      iiifSubset,
       MANIFESTS_VALIDATED_METRIC,
       validated,
       activity,
@@ -183,18 +206,15 @@ export class IiifValidationExecutor implements Executor {
 
   private *integerMeasurement(
     measurement: ReturnType<typeof blankNode>,
-    subject: ReturnType<typeof namedNode>,
+    computedOn: ReturnType<typeof namedNode>,
     metric: ReturnType<typeof namedNode>,
     value: number,
     activity: ReturnType<typeof blankNode>,
   ): Generator<Quad> {
     yield quad(measurement, RDF_TYPE, DQV_QUALITY_MEASUREMENT);
-    yield quad(measurement, DQV_COMPUTED_ON, subject);
+    yield quad(measurement, DQV_COMPUTED_ON, computedOn);
     yield quad(measurement, DQV_IS_MEASUREMENT_OF, metric);
     yield quad(measurement, DQV_VALUE, literal(String(value), XSD_INTEGER));
-    // Carry the IIIF profile so the DQV navigation path reaches what was
-    // validated without leaving DQV (mirrors the conformance measurement).
-    yield quad(measurement, DCTERMS_CONFORMS_TO, IIIF_PRESENTATION);
     yield quad(measurement, PROV_WAS_GENERATED_BY, activity);
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import {createSubjectFilterSelector} from './subjectFilters.js';
 import {buildUriSpacesMap} from './uriSpaces.js';
 import {qualityMeasurementsStage} from './qualityMeasurementsStage.js';
 import {iiifStage} from './iiifStage.js';
+import {mediaStage} from './mediaStage.js';
 import {ConsoleReporter} from '@lde/pipeline-console-reporter';
 import {resolve} from 'node:path';
 import type {DatasetSelector} from '@lde/pipeline';
@@ -88,6 +89,9 @@ const sampleStages = await shaclSampleStages({
 const stages = [
   ...voidStageList,
   ...sampleStages,
+  // mediaStage runs before iiifStage so the media subset its capability subset
+  // nests under is present when the IIIF stage asserts the containment edge.
+  await mediaStage(),
   await iiifStage({manifestSampleSize: IIIF_MANIFEST_SAMPLE_SIZE}),
   qualityMeasurementsStage({
     validator: schemaApValidator,

--- a/src/mediaStage.ts
+++ b/src/mediaStage.ts
@@ -1,0 +1,100 @@
+import {resolve} from 'node:path';
+import {DataFactory} from 'n3';
+import type {Quad} from '@rdfjs/types';
+import type {Dataset, Distribution} from '@lde/dataset';
+import {
+  Stage,
+  SparqlConstructExecutor,
+  readQueryFile,
+  NotSupported,
+  type Executor,
+  type ExecuteOptions,
+} from '@lde/pipeline';
+
+const {namedNode, literal, quad} = DataFactory;
+
+const QUERY_FILE = resolve('queries/analysis/media.rq');
+
+const VOID_ENTITIES = namedNode('http://rdfs.org/ns/void#entities');
+const PROBE_DETECTS = namedNode('https://def.nde.nl/probe#detects');
+const PROBE_MEDIA = namedNode('https://def.nde.nl/probe#media');
+const XSD_INTEGER = namedNode('http://www.w3.org/2001/XMLSchema#integer');
+
+/**
+ * Detect whether a dataset exposes any media and emit a `void:subset` marked
+ * `<https://def.nde.nl/probe#detects> <https://def.nde.nl/probe#media>`, with a
+ * self-describing `void:propertyPartition` per media predicate found. The
+ * subset’s own `void:entities` is the MAX over those partitions — a
+ * double-count-safe lower bound on the number of media objects, since the same
+ * record commonly carries several media predicates (`image` + `thumbnailUrl` +
+ * `contentUrl`) and summing would triple-count it.
+ *
+ * The subset exists iff the dataset has media, so its mere presence is the
+ * `has-media` signal: a media-bearing dataset that offers no IIIF is then
+ * observable as “media, but no IIIF” rather than indistinguishable from “no
+ * media”. IIIF manifests are themselves media, so {@link iiifStage} nests its
+ * capability subset under this one (`iiif ⊆ media`).
+ */
+export function mediaStage(): Promise<Stage> {
+  return readQueryFile(QUERY_FILE).then(query => {
+    // `deduplicate` collapses the constant subset/marker triples, which the
+    // GROUP BY repeats once per media-predicate partition row.
+    const detection = new SparqlConstructExecutor({query, deduplicate: true});
+    return new Stage({
+      name: 'media.rq',
+      executors: new MediaSubsetExecutor(detection),
+    });
+  });
+}
+
+/**
+ * Executor decorator that adds the aggregate `void:entities` to the media
+ * subset. The detection query emits one `void:propertyPartition` per media
+ * predicate with its own count; this passes those through unchanged and, once
+ * the stream is exhausted, appends `void:entities` on the subset set to the MAX
+ * of the partition counts (a lower bound on the media-object count).
+ */
+export class MediaSubsetExecutor implements Executor {
+  constructor(private readonly inner: Executor) {}
+
+  async execute(
+    dataset: Dataset,
+    distribution: Distribution,
+    options?: ExecuteOptions,
+  ): Promise<AsyncIterable<Quad> | NotSupported> {
+    const result = await this.inner.execute(dataset, distribution, options);
+    if (result instanceof NotSupported) {
+      return result;
+    }
+    return this.withAggregate(result);
+  }
+
+  private async *withAggregate(
+    quads: AsyncIterable<Quad>,
+  ): AsyncIterable<Quad> {
+    let mediaSubset: Quad['subject'] | undefined;
+    let maxEntities = 0;
+    for await (const q of quads) {
+      // The media subset is the subject carrying the probe marker.
+      if (q.predicate.equals(PROBE_DETECTS) && q.object.equals(PROBE_MEDIA)) {
+        mediaSubset = q.subject;
+      }
+      // Every void:entities in this stage is a media partition count.
+      if (q.predicate.equals(VOID_ENTITIES)) {
+        maxEntities = Math.max(maxEntities, Number(q.object.value));
+      }
+      yield q;
+    }
+
+    // No media subset: the dataset has no media (state 0); emit nothing extra.
+    if (mediaSubset === undefined) {
+      return;
+    }
+
+    yield quad(
+      mediaSubset,
+      VOID_ENTITIES,
+      literal(String(maxEntities), XSD_INTEGER),
+    );
+  }
+}

--- a/test/iiifStage.test.ts
+++ b/test/iiifStage.test.ts
@@ -470,4 +470,26 @@ describe('iiif.rq detection query', () => {
     // … but nothing dereferenceable is sampled.
     expect(findSampleManifests(quads, subsetIri!)).toEqual([]);
   });
+
+  it('samples a SCHEMA-AP-NDE-conformant manifest as its own encodingFormat-bearing IRI (no contentUrl override)', async () => {
+    // A conformant manifest per IIIFPresentationManifestShape is an IRI bearing
+    // the profile encodingFormat and a license, with NO schema:contentUrl — so
+    // the dereference target must be the manifest IRI itself. The contentUrl
+    // branch only exists for the non-conformant MediaObject-wrapper structure,
+    // and is keyed on the presence of a contentUrl, which a conformant manifest
+    // does not have.
+    const turtle = `
+      <https://example.org/iiif/1/manifest> schema:encodingFormat
+          "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json'" ;
+        schema:license <https://creativecommons.org/publicdomain/zero/1.0/> .
+    `;
+
+    const quads = await runQueryOn(turtle);
+
+    const subsetIri = findSubsetIri(quads);
+    expect(subsetIri).toBeDefined();
+    expect(findSampleManifests(quads, subsetIri!)).toEqual([
+      'https://example.org/iiif/1/manifest',
+    ]);
+  });
 });

--- a/test/iiifStage.test.ts
+++ b/test/iiifStage.test.ts
@@ -15,6 +15,7 @@ const VOID_ENTITIES = namedNode('http://rdfs.org/ns/void#entities');
 const DCTERMS_CONFORMS_TO = namedNode('http://purl.org/dc/terms/conformsTo');
 const IIIF_PRESENTATION = namedNode('http://iiif.io/api/presentation/');
 const MANIFEST_SAMPLE = namedNode('https://def.nde.nl/iiif#manifest-sample');
+const SCHEMA_AP_NDE = namedNode('https://docs.nde.nl/schema-profile/');
 const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
 
 const DATASET_IRI = 'http://example.org/dataset/1';
@@ -22,6 +23,10 @@ const EXPECTED_SUBSET_IRI =
   DATASET_IRI +
   '/.well-known/void#iiif-' +
   createHash('md5').update('http://iiif.io/api/presentation/').digest('hex');
+const EXPECTED_CONFORMANT_SUBSET_IRI =
+  DATASET_IRI +
+  '/.well-known/void#iiif-conformant-' +
+  createHash('md5').update('https://docs.nde.nl/schema-profile/').digest('hex');
 
 const queryPath = resolve(
   new URL('../queries/analysis/iiif.rq', import.meta.url).pathname,
@@ -96,6 +101,16 @@ function findEntitiesCount(quads: Quad[], subset: string): number | undefined {
     q => q.subject.value === subset && q.predicate.equals(VOID_ENTITIES),
   );
   return entities ? Number(entities.object.value) : undefined;
+}
+
+/** The conformant sub-subset nested under the IIIF capability subset. */
+function findConformantSubsetIri(
+  quads: Quad[],
+  iiifSubset: string,
+): string | undefined {
+  return quads.find(
+    q => q.subject.value === iiifSubset && q.predicate.equals(VOID_SUBSET),
+  )?.object.value;
 }
 
 describe('iiifStage', () => {
@@ -339,5 +354,120 @@ describe('iiif.rq detection query', () => {
     const subsetIri = findSubsetIri(quads);
     expect(subsetIri).toBeDefined();
     expect(findEntitiesCount(quads, subsetIri!)).toBe(2);
+  });
+
+  it('detects a manifest declared with the bare application/ld+json media type (issue #314)', async () => {
+    // A functional manifest declared without the `;profile=` parameter — the
+    // Beeldbank Erfgoed ’s-Hertogenbosch case — must still count as IIIF.
+    const turtle = `
+      <http://example.org/manifest/1> schema:encodingFormat "application/ld+json" .
+    `;
+
+    const quads = await runQueryOn(turtle);
+
+    const subsetIri = findSubsetIri(quads);
+    expect(subsetIri).toBe(EXPECTED_SUBSET_IRI);
+    expect(findEntitiesCount(quads, subsetIri!)).toBe(1);
+  });
+
+  it('counts bare ld+json as capability but not as conformance', async () => {
+    const turtle = `
+      <http://example.org/manifest/1> schema:encodingFormat
+        "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json'" .
+      <http://example.org/manifest/2> schema:encodingFormat "application/ld+json" .
+    `;
+
+    const quads = await runQueryOn(turtle);
+
+    const subsetIri = findSubsetIri(quads);
+    expect(subsetIri).toBeDefined();
+    // Capability: both manifests.
+    expect(findEntitiesCount(quads, subsetIri!)).toBe(2);
+
+    // Conformance: nested sub-subset, only the profile-conformant manifest.
+    const conformantIri = findConformantSubsetIri(quads, subsetIri!);
+    expect(conformantIri).toBe(EXPECTED_CONFORMANT_SUBSET_IRI);
+    expect(findEntitiesCount(quads, conformantIri!)).toBe(1);
+    const conformsTo = quads.find(
+      q =>
+        q.subject.value === conformantIri &&
+        q.predicate.equals(DCTERMS_CONFORMS_TO),
+    );
+    expect(conformsTo?.object.equals(SCHEMA_AP_NDE)).toBe(true);
+  });
+
+  it('reports a zero-entity conformant sub-subset when only non-profile manifests exist', async () => {
+    const turtle = `
+      <http://example.org/manifest/1> schema:encodingFormat "application/ld+json" .
+    `;
+
+    const quads = await runQueryOn(turtle);
+
+    const subsetIri = findSubsetIri(quads);
+    const conformantIri = findConformantSubsetIri(quads, subsetIri!);
+    expect(conformantIri).toBeDefined();
+    expect(findEntitiesCount(quads, conformantIri!)).toBe(0);
+  });
+
+  it('nests the IIIF subset under the dataset’s media subset (iiif ⊆ media)', async () => {
+    const turtle = `
+      <http://example.org/manifest/1> schema:encodingFormat
+        "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json'" .
+    `;
+
+    const quads = await runQueryOn(turtle);
+
+    const iiifSubset = findSubsetIri(quads);
+    expect(iiifSubset).toBe(EXPECTED_SUBSET_IRI);
+    // The same deterministic media subset IRI that media.rq emits is the parent.
+    const mediaSubset = DATASET_IRI + '/.well-known/void#media';
+    expect(
+      quads.some(
+        q =>
+          q.subject.value === mediaSubset &&
+          q.predicate.equals(VOID_SUBSET) &&
+          q.object.value === iiifSubset,
+      ),
+    ).toBe(true);
+  });
+
+  it('samples the schema:contentUrl manifest IRI rather than the encodingFormat-bearing node (issue #314 defect #2)', async () => {
+    // The encodingFormat sits on a blank node; the dereferenceable manifest URL
+    // lives in schema:contentUrl. The sample must be the contentUrl, not the
+    // (here, blank) encodingFormat-bearing node.
+    const turtle = `
+      <http://example.org/work/1> schema:associatedMedia [
+        schema:encodingFormat "application/ld+json" ;
+        schema:contentUrl <https://example.org/iiif/1/manifest.json>
+      ] .
+    `;
+
+    const quads = await runQueryOn(turtle);
+
+    const subsetIri = findSubsetIri(quads);
+    expect(subsetIri).toBeDefined();
+    expect(findSampleManifests(quads, subsetIri!)).toEqual([
+      'https://example.org/iiif/1/manifest.json',
+    ]);
+  });
+
+  it('does not sample a blank-node manifest that has no schema:contentUrl (issue #314)', async () => {
+    // encodingFormat on a blank node with no contentUrl: still counted as
+    // capability, but the blank node is not a dereferenceable URL, so it must
+    // not appear in the sample (it would always fail validation otherwise).
+    const turtle = `
+      <http://example.org/work/1> schema:associatedMedia [
+        schema:encodingFormat "application/ld+json"
+      ] .
+    `;
+
+    const quads = await runQueryOn(turtle);
+
+    const subsetIri = findSubsetIri(quads);
+    expect(subsetIri).toBeDefined();
+    // Detected as capability …
+    expect(findEntitiesCount(quads, subsetIri!)).toBe(1);
+    // … but nothing dereferenceable is sampled.
+    expect(findSampleManifests(quads, subsetIri!)).toEqual([]);
   });
 });

--- a/test/iiifValidationExecutor.test.ts
+++ b/test/iiifValidationExecutor.test.ts
@@ -135,7 +135,8 @@ describe('IiifValidationExecutor', () => {
     expect(measurementValue(out, MANIFESTS_SAMPLED_METRIC.value)).toBe(2);
     expect(measurementValue(out, MANIFESTS_VALIDATED_METRIC.value)).toBe(1);
 
-    // Measurements are computed on the dataset and carry the IIIF profile.
+    // Measurements are computed on the IIIF subset (which already carries the
+    // conformsTo marker), not the dataset, and no longer re-link the profile.
     const sampledMeasurement = out.find(
       q =>
         q.predicate.equals(DQV_IS_MEASUREMENT_OF) &&
@@ -147,19 +148,28 @@ describe('IiifValidationExecutor', () => {
         q =>
           q.subject.equals(sampledMeasurement!) &&
           q.predicate.equals(DQV_COMPUTED_ON) &&
-          q.object.equals(namedNode(DATASET_IRI)),
+          q.object.equals(namedNode(SUBSET_IRI)),
       ),
     ).toBe(true);
     expect(
       out.some(
         q =>
           q.subject.equals(sampledMeasurement!) &&
-          q.predicate.equals(DCTERMS_CONFORMS_TO) &&
-          q.object.equals(IIIF_PRESENTATION),
+          q.predicate.equals(DCTERMS_CONFORMS_TO),
       ),
-    ).toBe(true);
+    ).toBe(false);
 
-    // The dataset links to both measurements.
+    // The IIIF subset links to both measurements.
+    expect(
+      out.filter(
+        q =>
+          q.subject.equals(namedNode(SUBSET_IRI)) &&
+          q.predicate.equals(DQV_HAS_QUALITY_MEASUREMENT),
+      ),
+    ).toHaveLength(2);
+
+    // Backward compatibility: the dataset also links to both measurements, so
+    // the shipped `?dataset dqv:hasQualityMeasurement` consumer keeps working.
     expect(
       out.filter(
         q =>

--- a/test/mediaStage.test.ts
+++ b/test/mediaStage.test.ts
@@ -1,0 +1,255 @@
+import {describe, it, expect, beforeAll} from 'vitest';
+import {readFile} from 'node:fs/promises';
+import {resolve} from 'node:path';
+import {DataFactory, Parser, Store} from 'n3';
+import type {Quad} from '@rdfjs/types';
+import {QueryEngine} from '@comunica/query-sparql-rdfjs-lite';
+import {Dataset, Distribution} from '@lde/dataset';
+import {NotSupported, Stage, type Executor} from '@lde/pipeline';
+import {mediaStage, MediaSubsetExecutor} from '../src/mediaStage.js';
+
+const {namedNode, literal, quad} = DataFactory;
+
+const VOID_SUBSET = namedNode('http://rdfs.org/ns/void#subset');
+const VOID_ENTITIES = namedNode('http://rdfs.org/ns/void#entities');
+const VOID_PROPERTY_PARTITION = namedNode(
+  'http://rdfs.org/ns/void#propertyPartition',
+);
+const VOID_PROPERTY = namedNode('http://rdfs.org/ns/void#property');
+const PROBE_DETECTS = namedNode('https://def.nde.nl/probe#detects');
+const PROBE_MEDIA = namedNode('https://def.nde.nl/probe#media');
+const XSD_INTEGER = namedNode('http://www.w3.org/2001/XMLSchema#integer');
+
+const DATASET_IRI = 'http://example.org/dataset/1';
+const MEDIA_SUBSET_IRI = DATASET_IRI + '/.well-known/void#media';
+
+const queryPath = resolve(
+  new URL('../queries/analysis/media.rq', import.meta.url).pathname,
+);
+
+let queryTemplate: string;
+beforeAll(async () => {
+  queryTemplate = (await readFile(queryPath)).toString();
+});
+
+function buildQuery(subjectFilter = ''): string {
+  return queryTemplate
+    .replaceAll('#subjectFilter#', subjectFilter)
+    .replaceAll('?dataset', `<${DATASET_IRI}>`);
+}
+
+async function runQueryOn(turtle: string, subjectFilter = ''): Promise<Quad[]> {
+  const store = new Store();
+  store.addQuads(new Parser().parse(turtle));
+  const engine = new QueryEngine();
+  const stream = await engine.queryQuads(buildQuery(subjectFilter), {
+    sources: [store],
+  });
+  const seen = new Set<string>();
+  const quads: Quad[] = [];
+  for await (const q of stream) {
+    const key = `${q.subject.value}|${q.predicate.value}|${q.object.value}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      quads.push(q);
+    }
+  }
+  return quads;
+}
+
+function propertyPartitionCounts(quads: Quad[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const partition of quads.filter(q =>
+    q.predicate.equals(VOID_PROPERTY_PARTITION),
+  )) {
+    const node = partition.object;
+    const property = quads.find(
+      q => q.subject.equals(node) && q.predicate.equals(VOID_PROPERTY),
+    )?.object.value;
+    const entities = quads.find(
+      q => q.subject.equals(node) && q.predicate.equals(VOID_ENTITIES),
+    )?.object.value;
+    if (property && entities) counts.set(property, Number(entities));
+  }
+  return counts;
+}
+
+describe('mediaStage', () => {
+  it('returns a Stage named media.rq', async () => {
+    const stage = await mediaStage();
+    expect(stage).toBeInstanceOf(Stage);
+    expect(stage.name).toBe('media.rq');
+  });
+});
+
+describe('media.rq detection query', () => {
+  it('emits a marked media subset with one partition per media predicate', async () => {
+    const turtle = `
+      <http://example.org/record/1> <http://schema.org/image> <http://example.org/img/1> .
+      <http://example.org/record/2> <http://schema.org/image> <http://example.org/img/2> .
+      <http://example.org/record/1> <http://schema.org/contentUrl> <http://example.org/cu/1> .
+    `;
+
+    const quads = await runQueryOn(turtle);
+
+    // The dataset points at the deterministic media subset IRI …
+    const subset = quads.find(
+      q => q.subject.value === DATASET_IRI && q.predicate.equals(VOID_SUBSET),
+    );
+    expect(subset?.object.value).toBe(MEDIA_SUBSET_IRI);
+
+    // … which carries the probe marker …
+    expect(
+      quads.some(
+        q =>
+          q.subject.value === MEDIA_SUBSET_IRI &&
+          q.predicate.equals(PROBE_DETECTS) &&
+          q.object.equals(PROBE_MEDIA),
+      ),
+    ).toBe(true);
+
+    // … and a self-describing partition per present predicate.
+    const counts = propertyPartitionCounts(quads);
+    expect(counts.get('http://schema.org/image')).toBe(2);
+    expect(counts.get('http://schema.org/contentUrl')).toBe(1);
+  });
+
+  it('detects media expressed only in EDM (no schema.org media)', async () => {
+    const turtle = `
+      <http://example.org/record/1>
+        <http://www.europeana.eu/schemas/edm/isShownBy> <http://example.org/img/1> .
+    `;
+
+    const quads = await runQueryOn(turtle);
+
+    expect(
+      quads.some(
+        q => q.predicate.equals(PROBE_DETECTS) && q.object.equals(PROBE_MEDIA),
+      ),
+    ).toBe(true);
+    expect(
+      propertyPartitionCounts(quads).get(
+        'http://www.europeana.eu/schemas/edm/isShownBy',
+      ),
+    ).toBe(1);
+  });
+
+  it('counts schema:encodingFormat as media, so every IIIF manifest is also media (iiif ⊆ media)', async () => {
+    const turtle = `
+      <http://example.org/manifest/1> <http://schema.org/encodingFormat> "application/ld+json" .
+    `;
+
+    const quads = await runQueryOn(turtle);
+
+    expect(
+      quads.some(
+        q => q.predicate.equals(PROBE_DETECTS) && q.object.equals(PROBE_MEDIA),
+      ),
+    ).toBe(true);
+    expect(
+      propertyPartitionCounts(quads).get('http://schema.org/encodingFormat'),
+    ).toBe(1);
+  });
+
+  it('emits nothing for a dataset without media', async () => {
+    const turtle = `
+      <http://example.org/record/1> <http://schema.org/name> "A record" .
+      <http://example.org/record/1> <http://schema.org/depicts> <http://example.org/subject/1> .
+    `;
+
+    const quads = await runQueryOn(turtle);
+    expect(quads).toHaveLength(0);
+  });
+});
+
+const dataset = new Dataset({iri: new URL(DATASET_IRI), distributions: []});
+const distribution = Distribution.sparql(new URL('http://example.org/sparql'));
+
+function innerYielding(quads: Quad[]): Executor {
+  return {
+    async execute() {
+      return (async function* () {
+        for (const q of quads) yield q;
+      })();
+    },
+  };
+}
+
+async function collect(
+  result: AsyncIterable<Quad> | NotSupported,
+): Promise<Quad[]> {
+  if (result instanceof NotSupported) throw new Error('unexpected');
+  const quads: Quad[] = [];
+  for await (const q of result) quads.push(q);
+  return quads;
+}
+
+/** A marked media subset with two property partitions of the given counts. */
+function subsetWithPartitions(...counts: number[]): Quad[] {
+  const subset = namedNode(MEDIA_SUBSET_IRI);
+  const quads: Quad[] = [
+    quad(namedNode(DATASET_IRI), VOID_SUBSET, subset),
+    quad(subset, PROBE_DETECTS, PROBE_MEDIA),
+  ];
+  counts.forEach((count, index) => {
+    const partition = namedNode(`http://example.org/partition/${index}`);
+    quads.push(quad(subset, VOID_PROPERTY_PARTITION, partition));
+    quads.push(
+      quad(partition, VOID_ENTITIES, literal(String(count), XSD_INTEGER)),
+    );
+  });
+  return quads;
+}
+
+describe('MediaSubsetExecutor', () => {
+  it('sets the subset void:entities to the MAX over partition counts (not the sum)', async () => {
+    const executor = new MediaSubsetExecutor(
+      innerYielding(subsetWithPartitions(1, 2, 1)),
+    );
+    const out = await collect(await executor.execute(dataset, distribution));
+
+    const entities = out.find(
+      q =>
+        q.subject.value === MEDIA_SUBSET_IRI &&
+        q.predicate.equals(VOID_ENTITIES),
+    );
+    expect(entities).toBeDefined();
+    expect(Number(entities!.object.value)).toBe(2);
+    expect(
+      (entities!.object as {datatype: {value: string}}).datatype.value,
+    ).toBe(XSD_INTEGER.value);
+  });
+
+  it('passes the partition triples through unchanged', async () => {
+    const input = subsetWithPartitions(3);
+    const executor = new MediaSubsetExecutor(innerYielding(input));
+    const out = await collect(await executor.execute(dataset, distribution));
+
+    for (const q of input) {
+      expect(out.some(o => o.equals(q))).toBe(true);
+    }
+  });
+
+  it('emits nothing extra when the dataset has no media subset', async () => {
+    const executor = new MediaSubsetExecutor(
+      innerYielding([
+        quad(namedNode(DATASET_IRI), VOID_SUBSET, namedNode('x')),
+      ]),
+    );
+    const out = await collect(await executor.execute(dataset, distribution));
+    expect(out.some(q => q.predicate.equals(VOID_ENTITIES))).toBe(false);
+  });
+
+  it('passes NotSupported through', async () => {
+    const inner: Executor = {
+      async execute() {
+        return new NotSupported('no distribution');
+      },
+    };
+    const result = await new MediaSubsetExecutor(inner).execute(
+      dataset,
+      distribution,
+    );
+    expect(result).toBeInstanceOf(NotSupported);
+  });
+});


### PR DESCRIPTION
Closes #314.

## What

Decouples IIIF detection from SCHEMA-AP-NDE conformance and adds a media signal, so the gradient *no media → media but no IIIF → IIIF non-conformant → IIIF conformant* is observable. The DKG stays signal-only; consumers (dataset-register) compose the verdict.

### IIIF detection (`iiif.rq`, `iiifValidationExecutor.ts`)
- **Capability ∪ conformance.** A manifest counts as IIIF capability when `schema:encodingFormat` is the profile pattern **or** the bare `application/ld+json` media type — a working manifest declared without `;profile=` is no longer missed (the Beeldbank Erfgoed ’s-Hertogenbosch case).
- **Nested conformance.** The profile-conformant manifests are a nested `void:subset` (`conformsTo <schema-profile/>`), encoding `conformant ⊆ capability`; both independently queryable.
- **Dereferenceable sample (defect #2).** The sample targets the `schema:contentUrl` manifest URL, never a blank node (`FILTER(!isBlank(?manifest))`); the sample sub-select is `OPTIONAL` so detection survives an all-blank sample.

### Media signal (`media.rq`, `mediaStage.ts`)
- A `void:subset` marked `probe#detects probe#media`, with a self-describing `void:propertyPartition` per media predicate (wide curated allowlist across schema.org/EDM/CIDOC/Linked-Art/FOAF/Omeka, minus false friends) and an aggregate `void:entities` = MAX over partitions (double-count-safe lower bound).
- `schema:encodingFormat` is in the allowlist, so every IIIF manifest is also media: `iiif ⊆ media` holds structurally and the capability subset nests under the media subset.

### Modelling
Pure VoID for the structural counts (media, capability, conformance) as a nested subset chain; DQV + PROV only for the live dereference probe (`manifests-sampled`/`-validated`), `dqv:computedOn` the capability subset.

## Backward compatibility
The validation measurements are also linked from the dataset (`?dataset dqv:hasQualityMeasurement …`), the path shipped consumers read, until they migrate via `void:subset` — tracked in **netwerk-digitaal-erfgoed/dataset-register#2048**. The new structure only appears after the next DKG run.

## Follow-ups (out of scope)
- Class-typed media objects (v1 counts via predicates only).
- Deriving the media counts from the void stage’s existing partitions instead of a separate scan.
- The `@lde/iiif-validator` content-type gate (skip downloading non-manifest binaries) lands via ldelements/lde#440; bump the dependency once released.

## Validation
`npm run compile` ✓, `npm run lint` ✓, `vitest` 34 passed (13 new).
