### PR TITLE
build(deps): bump @lde/iiif-validator to 0.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6653,9 +6653,9 @@
       }
     },
     "node_modules/@lde/iiif-validator": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@lde/iiif-validator/-/iiif-validator-0.1.2.tgz",
-      "integrity": "sha512-08NKxFVLgYG0WmIEdoNIpWD4IjbQ+DBZVX+ChFC2+6zHVED0VfCdTmzmdM9EDBP1Nf4x6/DNlvkPUc4K4as53Q==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@lde/iiif-validator/-/iiif-validator-0.1.3.tgz",
+      "integrity": "sha512-g9RiWvAYYBmOocaF5uWa8PqkbcoE+A1z2gq1eEpSf4KkHfE6ElhXz3GMIG5GOupAUoXNBl01Hr3hP+ZbCJDAHQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"


### PR DESCRIPTION
Bumps `@lde/iiif-validator` from 0.1.2 to 0.1.3, picking up [ldelements/lde#443](https://github.com/ldelements/lde/pull/443).

## Why

The validator now requests manifests with `Accept: */*` instead of a JSON-specific `Accept` header. This fixes false **failed** verdicts for IIIF manifests on hosts with backwards content negotiation – serving the manifest to `*/*` while returning a 404 for a JSON-specific request (e.g. `www.ldmax.nl` behind the `n2t.net` ARK redirects, used by the Noord-Brabants Museum dataset).

Lockfile-only change; the `^0.1.2` range already admits `0.1.3`.

## Follow-up

After merge, re-run the DKG pipeline for the affected dataset(s) so they re-sample and re-validate their manifests, writing fresh `manifests-validated` metrics. Only then does the Dataset Register flip the IIIF check from failed to met.
