### PR TITLE
feat: flag non-durable subject namespaces via a disallow list

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,7 +541,9 @@ _:sampling
 `dcterms:conformsTo` is attached only when the namespace matches a recognised PID
 scheme. The metric names stay neutral (`subject-uris-*`, not `persistent-uris-*`)
 because the resolution ratio applies to any namespace – PID-ness lives only in
-the scheme label.
+the scheme label. Note the two axes: `subject-uris-*` measures the *sampled URIs*
+(how many resolve), while `subject-namespace-durable` (below) is a verdict on the
+*namespace itself* as a durable home, independent of the sample.
 
 | Scheme | Matched on | `dcterms:conformsTo` | Organisation |
 |---|---|---|---|
@@ -566,6 +568,55 @@ count yields five observable states:
 | unrecognised, resolves | absent | > 0 |
 | unrecognised, none resolve | absent | 0 |
 | no surviving namespace | – | nothing emitted |
+
+#### Non-durable namespaces
+
+Resolution measures whether URIs work *today*. It cannot see that a namespace is a
+vendor’s default hosted URL structure – one that resolves now but does not survive
+a contract or CMS change. A disallow list of known non-durable vendor namespaces
+is the counterweight: when the chosen namespace matches it, a
+`subject-namespace-durable` measurement is emitted with value `"false"^^xsd:boolean`.
+
+The flag is `false`-only: not being on a hand-curated list is no evidence of
+durability, so absence stays weaker than a durability claim (mirroring
+`dcterms:conformsTo`, a one-sided positive marker). A boolean – rather than a
+presence-only marker – leaves room to later emit `true` from a justifiable
+positive signal (e.g. a live, registered ARK NAAN).
+
+Unlike the sampled/resolved ratio, durability is knowable from the namespace
+string alone, so the flag is emitted **independently of sampling**: it survives a
+sampling or endpoint failure – a vendor preview domain whose endpoint is slow
+today is exactly what we most want flagged.
+
+| Metric IRI | Type | Meaning |
+|---|---|---|
+| `…/metric#subject-namespace-durable` | `xsd:boolean` | Emitted `false` only when the namespace is on the disallow list of known non-durable vendor namespaces; absent otherwise. |
+
+The list matches in two modes, tolerant of `http`/`https`:
+
+| Mode | Matched on | Example entry | Catches |
+|---|---|---|---|
+| host | host component, exactly or on a dot-boundary subdomain | `adlibhosting.com` | every SaaS subdomain (`cmu.adlibhosting.com`), while rejecting look-alikes (`adlibhosting.com.evil.example`) |
+| path | a slash-bounded substring, any host | `/AtlantisPubliek/` | self-hosted vendor software under an institution’s own domain (`zoeken.geheugenvanzoetermeer.nl/AtlantisPubliek/data/`) |
+
+A 🟠 namespace looks like a fully-resolving one with the extra flag – the two
+measurements coexist on the same subset:
+
+```ttl
+<https://example.org/dataset/.well-known/void#subject-uri-space-…>
+    void:uriSpace "https://collectie.adlibhosting.com/id/" ;
+    dqv:hasQualityMeasurement
+        [ a dqv:QualityMeasurement ;
+          dqv:computedOn <https://example.org/dataset/.well-known/void#subject-uri-space-…> ;
+          dqv:isMeasurementOf <https://def.nde.nl/metric#subject-uris-resolved> ;
+          dqv:value 10 ;
+          prov:wasGeneratedBy _:sampling ] ,
+        [ a dqv:QualityMeasurement ;
+          dqv:computedOn <https://example.org/dataset/.well-known/void#subject-uri-space-…> ;
+          dqv:isMeasurementOf <https://def.nde.nl/metric#subject-namespace-durable> ;
+          dqv:value false ;
+          prov:wasGeneratedBy _:durability ] .
+```
 
 #### Querying
 

--- a/src/subjectUriResolution.ts
+++ b/src/subjectUriResolution.ts
@@ -32,6 +32,7 @@ const PROV_WAS_GENERATED_BY = namedNode(
   'http://www.w3.org/ns/prov#wasGeneratedBy',
 );
 const XSD_INTEGER = namedNode('http://www.w3.org/2001/XMLSchema#integer');
+const XSD_BOOLEAN = namedNode('http://www.w3.org/2001/XMLSchema#boolean');
 
 const METRIC_BASE = 'https://def.nde.nl/metric#';
 const SUBJECT_URIS_SAMPLED_METRIC = namedNode(
@@ -39,6 +40,9 @@ const SUBJECT_URIS_SAMPLED_METRIC = namedNode(
 );
 const SUBJECT_URIS_RESOLVED_METRIC = namedNode(
   `${METRIC_BASE}subject-uris-resolved`,
+);
+const SUBJECT_NAMESPACE_DURABLE_METRIC = namedNode(
+  `${METRIC_BASE}subject-namespace-durable`,
 );
 
 const PID_SCHEME_BASE = 'https://def.nde.nl/pid-scheme#';
@@ -57,6 +61,36 @@ const PID_PREFIXES: ReadonlyArray<{scheme: PidScheme; prefix: string}> = [
   {scheme: 'ark', prefix: 'arks.org/ark:'},
   {scheme: 'handle', prefix: 'hdl.handle.net/'},
   {scheme: 'handle', prefix: 'handle.net/'},
+];
+
+/**
+ * Disallow list of known non-durable subject namespaces: a vendor’s default
+ * hosted URL structure that resolves today but does not survive a contract or
+ * CMS change. Mirrors the {@link PID_PREFIXES} allowlist as auditable governance
+ * data, each entry justified by a `reason`; tolerant of `http`/`https`.
+ *
+ * Two modes capture how vendor software splits by where it is hosted:
+ * - `host` — a SaaS host shared across institutions (Adlib, Spinque, …). Matches
+ *   the host component exactly or on a dot-boundary subdomain, so one entry
+ *   covers every current and future subdomain while rejecting look-alikes.
+ * - `path` — a distinctive software path under the institution’s own domain,
+ *   the only thing that flags *self-hosted* software (e.g. Atlantis under
+ *   `geheugenvanzoetermeer.nl`). Matched as a slash-bounded substring.
+ */
+const NON_DURABLE_NAMESPACES: ReadonlyArray<{
+  mode: 'host' | 'path';
+  value: string;
+  reason: string;
+}> = [
+  {mode: 'host', value: 'adlibhosting.com', reason: 'Axiell Adlib SaaS host'},
+  {mode: 'host', value: 'spinque.com', reason: 'Spinque SaaS host'},
+  {mode: 'host', value: 'kleksi.com', reason: 'Kleksi SaaS host'},
+  {mode: 'host', value: 'xentropics.cloud', reason: 'Xentropics-hosted Omeka'},
+  {
+    mode: 'path',
+    value: '/AtlantisPubliek/',
+    reason: 'Deventit Atlantis software',
+  },
 ];
 
 const DEFAULT_SOFTWARE = namedNode(
@@ -137,6 +171,10 @@ export interface SubjectUriResolutionOptions {
  *   recognised) and `dcterms:publisher` the ARK issuing org (non-fatal);
  * - **validated** facts: `subject-uris-sampled` / `subject-uris-resolved` DQV
  *   measurements plus a PROV activity.
+ * - **durability** facts: a `subject-namespace-durable = false` DQV measurement
+ *   when the chosen namespace matches the {@link NON_DURABLE_NAMESPACES}
+ *   disallow list — emitted independently of sampling, so it survives an
+ *   endpoint failure.
  *
  * The metric names are namespace-neutral because the ratio applies to any
  * namespace; PID-ness lives only in the scheme label. If no non-terminology
@@ -178,6 +216,13 @@ export function subjectUriResolution(
     // No non-terminology namespace survived: emit nothing extra.
     if (winner === undefined) {
       return;
+    }
+
+    // Durability is knowable from the namespace string alone, so flag it before
+    // (and outside) the best-effort sampling block: a vendor preview domain
+    // whose endpoint is slow today is exactly what we most want flagged.
+    if (isNonDurable(winner.uriSpace)) {
+      yield* nonDurableMeasurement(namedNode(winner.subset), software);
     }
 
     // Enrichment is best-effort: a failed sample must not drop the VoID output
@@ -239,11 +284,31 @@ function pickWinner(
   return best && {subset: best.subset, uriSpace: best.uriSpace};
 }
 
+/** Strip a leading `http://`/`https://` once, so host/path matching is scheme-neutral. */
+function stripScheme(uriSpace: string): string {
+  return uriSpace.replace(/^https?:\/\//, '');
+}
+
 /** Classify a namespace as an ARK/Handle PID scheme, tolerant of http/https. */
 function detectPidScheme(uriSpace: string): PidScheme | undefined {
-  const withoutScheme = uriSpace.replace(/^https?:\/\//, '');
+  const withoutScheme = stripScheme(uriSpace);
   return PID_PREFIXES.find(({prefix}) => withoutScheme.startsWith(prefix))
     ?.scheme;
+}
+
+/**
+ * Whether a namespace is on the {@link NON_DURABLE_NAMESPACES} disallow list.
+ * `host` entries match the host component exactly or on a dot-boundary
+ * subdomain; `path` entries match anywhere as a slash-bounded substring.
+ */
+function isNonDurable(uriSpace: string): boolean {
+  const withoutScheme = stripScheme(uriSpace);
+  const host = withoutScheme.split('/')[0];
+  return NON_DURABLE_NAMESPACES.some(({mode, value}) =>
+    mode === 'host'
+      ? host === value || host.endsWith(`.${value}`)
+      : withoutScheme.includes(value),
+  );
 }
 
 /** Extract the NAAN from an ARK namespace, e.g. `…/ark:/60537/` → `60537`. */
@@ -283,9 +348,7 @@ function* measurementQuads(
 
   // PROV: the sampling/dereferencing activity.
   const activity = blankNode();
-  yield quad(activity, RDF_TYPE, PROV_ACTIVITY);
-  yield quad(activity, PROV_USED, subset);
-  yield quad(activity, PROV_WAS_ASSOCIATED_WITH, software);
+  yield* activityQuads(activity, subset, software);
 
   // Validated facts — the sampled/resolved ratio, for any namespace.
   const sampledMeasurement = blankNode();
@@ -309,6 +372,39 @@ function* measurementQuads(
   );
 }
 
+/**
+ * The non-durability marker: `subject-namespace-durable = false`, emitted only
+ * on a disallow-list hit (absence stays weaker than a durability claim). Carries
+ * its own PROV activity so it survives a sampling/endpoint failure.
+ */
+function* nonDurableMeasurement(
+  subset: ReturnType<typeof namedNode>,
+  software: ReturnType<typeof namedNode>,
+): Generator<Quad> {
+  const activity = blankNode();
+  yield* activityQuads(activity, subset, software);
+
+  const measurement = blankNode();
+  yield quad(subset, DQV_HAS_QUALITY_MEASUREMENT, measurement);
+  yield* booleanMeasurement(
+    measurement,
+    subset,
+    SUBJECT_NAMESPACE_DURABLE_METRIC,
+    false,
+    activity,
+  );
+}
+
+function* activityQuads(
+  activity: ReturnType<typeof blankNode>,
+  used: ReturnType<typeof namedNode>,
+  software: ReturnType<typeof namedNode>,
+): Generator<Quad> {
+  yield quad(activity, RDF_TYPE, PROV_ACTIVITY);
+  yield quad(activity, PROV_USED, used);
+  yield quad(activity, PROV_WAS_ASSOCIATED_WITH, software);
+}
+
 function* integerMeasurement(
   measurement: ReturnType<typeof blankNode>,
   computedOn: ReturnType<typeof namedNode>,
@@ -320,6 +416,20 @@ function* integerMeasurement(
   yield quad(measurement, DQV_COMPUTED_ON, computedOn);
   yield quad(measurement, DQV_IS_MEASUREMENT_OF, metric);
   yield quad(measurement, DQV_VALUE, literal(String(value), XSD_INTEGER));
+  yield quad(measurement, PROV_WAS_GENERATED_BY, activity);
+}
+
+function* booleanMeasurement(
+  measurement: ReturnType<typeof blankNode>,
+  computedOn: ReturnType<typeof namedNode>,
+  metric: ReturnType<typeof namedNode>,
+  value: boolean,
+  activity: ReturnType<typeof blankNode>,
+): Generator<Quad> {
+  yield quad(measurement, RDF_TYPE, DQV_QUALITY_MEASUREMENT);
+  yield quad(measurement, DQV_COMPUTED_ON, computedOn);
+  yield quad(measurement, DQV_IS_MEASUREMENT_OF, metric);
+  yield quad(measurement, DQV_VALUE, literal(String(value), XSD_BOOLEAN));
   yield quad(measurement, PROV_WAS_GENERATED_BY, activity);
 }
 

--- a/src/subjectUriResolution.ts
+++ b/src/subjectUriResolution.ts
@@ -67,7 +67,8 @@ const PID_PREFIXES: ReadonlyArray<{scheme: PidScheme; prefix: string}> = [
  * Disallow list of known non-durable subject namespaces: a vendor’s default
  * hosted URL structure that resolves today but does not survive a contract or
  * CMS change. Mirrors the {@link PID_PREFIXES} allowlist as auditable governance
- * data, each entry justified by a `reason`; tolerant of `http`/`https`.
+ * data, each entry tagged with the `reason` it is non-durable; tolerant of
+ * `http`/`https`.
  *
  * Two modes capture how vendor software splits by where it is hosted:
  * - `host` — a SaaS host shared across institutions (Adlib, Spinque, …). Matches
@@ -82,15 +83,11 @@ const NON_DURABLE_NAMESPACES: ReadonlyArray<{
   value: string;
   reason: string;
 }> = [
-  {mode: 'host', value: 'adlibhosting.com', reason: 'Axiell Adlib SaaS host'},
-  {mode: 'host', value: 'spinque.com', reason: 'Spinque SaaS host'},
-  {mode: 'host', value: 'kleksi.com', reason: 'Kleksi SaaS host'},
-  {mode: 'host', value: 'xentropics.cloud', reason: 'Xentropics-hosted Omeka'},
-  {
-    mode: 'path',
-    value: '/AtlantisPubliek/',
-    reason: 'Deventit Atlantis software',
-  },
+  {mode: 'host', value: 'adlibhosting.com', reason: 'vendor'},
+  {mode: 'host', value: 'spinque.com', reason: 'vendor'},
+  {mode: 'host', value: 'kleksi.com', reason: 'vendor'},
+  {mode: 'host', value: 'xentropics.cloud', reason: 'vendor'},
+  {mode: 'path', value: '/AtlantisPubliek/', reason: 'vendor'},
 ];
 
 const DEFAULT_SOFTWARE = namedNode(

--- a/test/subjectUriResolution.test.ts
+++ b/test/subjectUriResolution.test.ts
@@ -30,10 +30,12 @@ const DQV_IS_MEASUREMENT_OF = namedNode(
 );
 const DQV_VALUE = namedNode('http://www.w3.org/ns/dqv#value');
 const XSD_INTEGER = namedNode('http://www.w3.org/2001/XMLSchema#integer');
+const XSD_BOOLEAN = namedNode('http://www.w3.org/2001/XMLSchema#boolean');
 
 const METRIC_BASE = 'https://def.nde.nl/metric#';
 const SAMPLED_METRIC = `${METRIC_BASE}subject-uris-sampled`;
 const RESOLVED_METRIC = `${METRIC_BASE}subject-uris-resolved`;
+const DURABLE_METRIC = `${METRIC_BASE}subject-namespace-durable`;
 const ARK_SCHEME = namedNode('https://def.nde.nl/pid-scheme#ark');
 const HANDLE_SCHEME = namedNode('https://def.nde.nl/pid-scheme#handle');
 
@@ -97,6 +99,28 @@ function measurementValue(
     q => q.subject.equals(measurement) && q.predicate.equals(DQV_VALUE),
   );
   return value ? Number(value.object.value) : undefined;
+}
+
+/** Find the `dqv:value` term of the measurement of `metric`, computed on `node`. */
+function measurementValueTerm(
+  quads: Quad[],
+  metric: string,
+  node: NamedNode,
+): Quad['object'] | undefined {
+  const measurement = quads.find(
+    q => q.predicate.equals(DQV_IS_MEASUREMENT_OF) && q.object.value === metric,
+  )?.subject;
+  if (!measurement) return undefined;
+  const onNode = quads.some(
+    q =>
+      q.subject.equals(measurement) &&
+      q.predicate.equals(DQV_COMPUTED_ON) &&
+      q.object.equals(node),
+  );
+  if (!onNode) return undefined;
+  return quads.find(
+    q => q.subject.equals(measurement) && q.predicate.equals(DQV_VALUE),
+  )?.object;
 }
 
 const sampleFixed =
@@ -316,6 +340,176 @@ describe('subjectUriResolution', () => {
     expect(out.some(q => q.predicate.equals(DQV_HAS_QUALITY_MEASUREMENT))).toBe(
       false,
     );
+  });
+
+  describe('non-durable subject namespaces', () => {
+    it('flags a SaaS host hit with subject-namespace-durable = false', async () => {
+      const ns = subset('https://collectie.adlibhosting.com/id/', 5000);
+      const transform = subjectUriResolution({
+        terminologyPrefixes: [],
+        sampleUris: sampleFixed(['https://collectie.adlibhosting.com/id/good']),
+        resolve: resolveByName,
+      });
+
+      const out = await collect(transform(stream(ns.quads), context));
+
+      expect(measurementValueTerm(out, DURABLE_METRIC, ns.node)?.value).toBe(
+        'false',
+      );
+    });
+
+    it('matches a subdomain of a disallowed host', async () => {
+      const ns = subset('https://cmu.adlibhosting.com/id/', 5000);
+      const transform = subjectUriResolution({
+        terminologyPrefixes: [],
+        sampleUris: sampleFixed(['https://cmu.adlibhosting.com/id/good']),
+        resolve: resolveByName,
+      });
+
+      const out = await collect(transform(stream(ns.quads), context));
+
+      expect(measurementValueTerm(out, DURABLE_METRIC, ns.node)?.value).toBe(
+        'false',
+      );
+    });
+
+    it('does not flag a look-alike host', async () => {
+      const ns = subset('https://adlibhosting.com.evil.example/id/', 5000);
+      const transform = subjectUriResolution({
+        terminologyPrefixes: [],
+        sampleUris: sampleFixed([
+          'https://adlibhosting.com.evil.example/id/good',
+        ]),
+        resolve: resolveByName,
+      });
+
+      const out = await collect(transform(stream(ns.quads), context));
+
+      expect(
+        measurementValueTerm(out, DURABLE_METRIC, ns.node),
+      ).toBeUndefined();
+    });
+
+    it('flags a self-hosted software path fragment', async () => {
+      const ns = subset(
+        'https://zoeken.geheugenvanzoetermeer.nl/AtlantisPubliek/data/',
+        5000,
+      );
+      const transform = subjectUriResolution({
+        terminologyPrefixes: [],
+        sampleUris: sampleFixed([
+          'https://zoeken.geheugenvanzoetermeer.nl/AtlantisPubliek/data/good',
+        ]),
+        resolve: resolveByName,
+      });
+
+      const out = await collect(transform(stream(ns.quads), context));
+
+      expect(measurementValueTerm(out, DURABLE_METRIC, ns.node)?.value).toBe(
+        'false',
+      );
+    });
+
+    it('respects the slash boundary of a path fragment', async () => {
+      const ns = subset('https://example.org/AtlantisPubliekX/data/', 5000);
+      const transform = subjectUriResolution({
+        terminologyPrefixes: [],
+        sampleUris: sampleFixed([
+          'https://example.org/AtlantisPubliekX/data/good',
+        ]),
+        resolve: resolveByName,
+      });
+
+      const out = await collect(transform(stream(ns.quads), context));
+
+      expect(
+        measurementValueTerm(out, DURABLE_METRIC, ns.node),
+      ).toBeUndefined();
+    });
+
+    it('flags the namespace even when sampling fails', async () => {
+      const ns = subset('https://collectie.adlibhosting.com/id/', 5000);
+      const transform = subjectUriResolution({
+        terminologyPrefixes: [],
+        sampleUris: async () => {
+          throw new Error('endpoint timeout');
+        },
+        resolve: resolveByName,
+      });
+
+      const out = await collect(transform(stream(ns.quads), context));
+
+      // The durability marker survives a sampling failure...
+      expect(measurementValueTerm(out, DURABLE_METRIC, ns.node)?.value).toBe(
+        'false',
+      );
+      // ...while the sampled/resolved measurements are dropped.
+      expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBeUndefined();
+    });
+
+    it('emits no durable measurement for an unflagged namespace', async () => {
+      const ns = subset('http://example.org/id/', 5000);
+      const transform = subjectUriResolution({
+        terminologyPrefixes: [],
+        sampleUris: sampleFixed(['http://example.org/id/good']),
+        resolve: resolveByName,
+      });
+
+      const out = await collect(transform(stream(ns.quads), context));
+
+      expect(
+        measurementValueTerm(out, DURABLE_METRIC, ns.node),
+      ).toBeUndefined();
+    });
+
+    it('types the durable value as xsd:boolean', async () => {
+      const ns = subset('https://collectie.adlibhosting.com/id/', 5000);
+      const transform = subjectUriResolution({
+        terminologyPrefixes: [],
+        sampleUris: sampleFixed(['https://collectie.adlibhosting.com/id/good']),
+        resolve: resolveByName,
+      });
+
+      const out = await collect(transform(stream(ns.quads), context));
+
+      const value = measurementValueTerm(out, DURABLE_METRIC, ns.node);
+      expect(value?.termType).toBe('Literal');
+      expect(
+        (value as {datatype?: NamedNode} | undefined)?.datatype?.equals(
+          XSD_BOOLEAN,
+        ),
+      ).toBe(true);
+    });
+
+    it('co-emits the durable flag alongside a full resolution', async () => {
+      // The actual 🟠 scenario: the sample fully resolves, yet the namespace is
+      // a known throwaway — both measurements coexist on the subset.
+      const ns = subset('https://collectie.adlibhosting.com/id/', 5000);
+      const transform = subjectUriResolution({
+        terminologyPrefixes: [],
+        sampleUris: sampleFixed([
+          'https://collectie.adlibhosting.com/id/good-1',
+          'https://collectie.adlibhosting.com/id/good-2',
+        ]),
+        resolve: resolveByName,
+      });
+
+      const out = await collect(transform(stream(ns.quads), context));
+
+      expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBe(2);
+      expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(2);
+      expect(measurementValueTerm(out, DURABLE_METRIC, ns.node)?.value).toBe(
+        'false',
+      );
+      // The subset carries all three measurements.
+      expect(
+        out.filter(
+          q =>
+            q.subject.equals(ns.node) &&
+            q.predicate.equals(DQV_HAS_QUALITY_MEASUREMENT),
+        ),
+      ).toHaveLength(3);
+    });
   });
 
   describe('default ARK organisation lookup', () => {


### PR DESCRIPTION
## Summary

Adds a **disallow list of known non-durable subject namespaces** to the
subject-URI resolution stage, and emits a `subject-namespace-durable` boolean
measurement (value `false`) when the chosen namespace matches it. This lets the
Dataset Register demote an otherwise-green "persistent URIs" criterion to a 🟠
warning for a namespace that resolves **today** but is not a durable home for the
identifiers (a vendor CMS/preview domain that does not survive a contract or CMS
change).

Implements #330 (design resolved in the issue's comment).

## What it does (`src/subjectUriResolution.ts`)

- **Disallow list** `NON_DURABLE_NAMESPACES` – auditable governance data, each
  entry justified by a `reason`, tolerant of `http`/`https`. Two modes:
  - `host` – matches the host component exactly or on a dot-boundary subdomain.
    One entry covers every current/future subdomain of a shared SaaS host (Adlib,
    Spinque, Kleksi, Xentropics) while rejecting look-alikes
    (`adlibhosting.com.evil.example`).
  - `path` – a slash-bounded substring (`/AtlantisPubliek/`), the only thing that
    flags *self-hosted* vendor software under an institution's own domain.
- **`subject-namespace-durable` measurement** – a DQV `QualityMeasurement` with
  `dqv:value "false"^^xsd:boolean`, its own PROV activity, emitted **only** on a
  disallow-list hit (absence stays weaker than a durability claim). Boolean rather
  than presence-only, so a justifiable positive signal (a live, registered ARK
  NAAN) can later emit `true` without minting a new term.
- **Emitted outside the best-effort sampling block**, so the flag survives a
  sampling/endpoint failure – a vendor preview domain whose endpoint is slow today
  is exactly what we most want flagged, and durability is knowable from the
  namespace string alone.

## Naming

Named `subject-namespace-durable` (not the originally-proposed
`subject-uris-persistent`): the verdict is about the *namespace as a durable home*,
not the per-URI sample, so it is namespace-scoped and orthogonal to the
`subject-uris-*` resolution axis.

## Pairing

This is the producer half of a pair:

- DKG (this PR): emits the flag.
- Register: netwerk-digitaal-erfgoed/dataset-register#2072 reads it (kept in an
  `OPTIONAL` block, so it is inert until this ships).

## Testing

- 9 new cases: host hit, subdomain coverage, look-alike rejection, path hit, path
  boundary, survives-sampling-failure, non-hit absence, `xsd:boolean` typing, and
  the resolves-and-flagged 🟠 co-occurrence.
- Full suite green (73 tests); eslint/prettier clean.

## Docs

README: new metric row, a "Non-durable namespaces" subsection with the two-mode
table and a 🟠 worked example, and a note reconciling the per-URI `subject-uris-*`
axis with the namespace-scoped durability axis.

Closes #330.
