### PR TITLE
feat: persist failed sampled subject URIs and IIIF manifests with typed reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,11 @@ _:validation
     prov:wasAssociatedWith <https://www.npmjs.com/package/@lde/iiif-validator> .
 ```
 
+Each sampled manifest that **failed** validation is enumerated on the activity as
+a qualified usage carrying the URL and a typed reason (see
+[Failed samples](#failed-samples)); the `validated` manifests are covered by the
+count alone.
+
 | Metric IRI | Type | Meaning |
 |---|---|---|
 | `…/metric#manifests-sampled` | `xsd:integer` | Number of manifest IRIs dereferenced — the denominator `N`. At most the configured sample size (10). |
@@ -536,6 +541,11 @@ _:sampling
     prov:wasAssociatedWith <https://github.com/netwerk-digitaal-erfgoed/dataset-knowledge-graph> .
 ```
 
+Each sampled URI that **failed** to resolve is enumerated on the sampling
+activity as a qualified usage carrying the URI and a typed reason (see
+[Failed samples](#failed-samples)); the `resolved` URIs are covered by the count
+alone.
+
 #### Persistent identifiers
 
 `dcterms:conformsTo` is attached only when the namespace matches a recognised PID
@@ -652,6 +662,79 @@ SELECT ?dataset WHERE {
         ] .
 }
 ```
+
+### Failed samples
+
+Both sampling checks above – subject-URI resolution and
+[IIIF manifest validation](#iiif-presentation-manifests) – report an aggregate
+ratio (`…-resolved` / `…-sampled`, `manifests-validated` / `manifests-sampled`).
+A low ratio tells you *that* something broke, not *which* sample or *why*. So
+every sampled resource that **failed** is enumerated on the check’s
+`prov:Activity` as a [qualified usage](https://www.w3.org/TR/prov-o/#Usage),
+carrying the exact URI/URL and a typed reason:
+
+```ttl
+@prefix prov:    <http://www.w3.org/ns/prov#> .
+@prefix failure: <https://def.nde.nl/failure#> .
+
+_:sampling
+    a prov:Activity ;
+    prov:used <https://example.org/id/123> ;        # the failed resource
+    prov:qualifiedUsage _:usage ;
+    prov:wasAssociatedWith <https://github.com/netwerk-digitaal-erfgoed/dataset-knowledge-graph> .
+
+_:usage
+    a prov:Usage ;
+    prov:entity <https://example.org/id/123> ;
+    failure:reason <https://def.nde.nl/subject-resolution-failure#no-self-reference> .
+```
+
+Only failures are persisted: the presence of a `failure:reason` is the contract
+for *“this sample failed”*, so a forward query needs no negation. The resolved /
+validated samples are covered by the count alone. The `prov:Usage` is owned by
+the activity (a usage reifies an *activity-uses-entity* relationship, never a
+subset), but consumers still reach failures dataset-first via the measurement the
+activity generated:
+
+```
+void:subset → dqv:hasQualityMeasurement → measurement
+            → prov:wasGeneratedBy → prov:Activity
+            → prov:qualifiedUsage → prov:Usage → prov:entity / failure:reason
+```
+
+The reason is a SKOS concept from the scheme matching the check:
+
+| Check | Scheme | Concepts |
+|---|---|---|
+| Subject-URI resolution | [`subject-resolution-failure`](https://def.nde.nl/subject-resolution-failure) | `timeout`, `network-error`, `http-error`, `wrong-content-type`, `no-self-reference` |
+| IIIF manifest validation | [`manifest-validation-failure`](https://def.nde.nl/manifest-validation-failure) | `timeout`, `network-error`, `http-error`, `invalid-json`, `binary-content`, `not-a-manifest`, `does-not-load` |
+
+The `manifest-validation-failure` concept local names mirror the
+[`@lde/iiif-validator`](https://www.npmjs.com/package/@lde/iiif-validator) reason
+enum 1:1 (its success value excepted); a build-time guard keeps the two in
+lockstep, so a new validator reason cannot silently emit an undefined term. The
+`failure:reason` predicate is defined in the [`failure`](https://def.nde.nl/failure)
+module.
+
+“List every failed subject URI per dataset with its reason”:
+
+```sparql
+PREFIX void: <http://rdfs.org/ns/void#>
+PREFIX dqv: <http://www.w3.org/ns/dqv#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX failure: <https://def.nde.nl/failure#>
+
+SELECT ?dataset ?failedUri ?reason WHERE {
+    ?dataset void:subset/dqv:hasQualityMeasurement ?measurement .
+    ?measurement dqv:isMeasurementOf <https://def.nde.nl/metric#subject-uris-resolved> ;
+        prov:wasGeneratedBy/prov:qualifiedUsage ?usage .
+    ?usage prov:entity ?failedUri ;
+        failure:reason ?reason .
+}
+```
+
+Swap `subject-uris-resolved` for `manifests-validated` to list failed IIIF
+manifests instead.
 
 ### Distributions
 

--- a/src/failureUsage.ts
+++ b/src/failureUsage.ts
@@ -14,6 +14,19 @@ const PROV_ENTITY = namedNode('http://www.w3.org/ns/prov#entity');
 /** Predicate naming why a sampled resource failed; see the `failure` module. */
 const FAILURE_REASON = namedNode('https://def.nde.nl/failure#reason');
 
+/**
+ * Build a failure-reason concept IRI from its scheme base and the reason’s
+ * local name — the `<scheme-base><reason>` convention shared by every failure
+ * concept scheme. Callers keep their own typed base constant and reason union;
+ * the naming convention lives here, next to the shape it labels.
+ */
+export function failureReasonIri(
+  schemeBase: string,
+  reason: string,
+): NamedNode {
+  return namedNode(`${schemeBase}${reason}`);
+}
+
 /** A sampled resource that failed, paired with its typed failure reason. */
 export interface SampleFailure {
   /** The failed resource’s URI/URL. */

--- a/src/failureUsage.ts
+++ b/src/failureUsage.ts
@@ -1,0 +1,60 @@
+import {DataFactory} from 'n3';
+import type {BlankNode, NamedNode, Quad} from '@rdfjs/types';
+
+const {namedNode, quad} = DataFactory;
+
+const RDF_TYPE = namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+const PROV_USED = namedNode('http://www.w3.org/ns/prov#used');
+const PROV_QUALIFIED_USAGE = namedNode(
+  'http://www.w3.org/ns/prov#qualifiedUsage',
+);
+const PROV_USAGE = namedNode('http://www.w3.org/ns/prov#Usage');
+const PROV_ENTITY = namedNode('http://www.w3.org/ns/prov#entity');
+
+/** Predicate naming why a sampled resource failed; see the `failure` module. */
+const FAILURE_REASON = namedNode('https://def.nde.nl/failure#reason');
+
+/** A sampled resource that failed, paired with its typed failure reason. */
+export interface SampleFailure {
+  /** The failed resource’s URI/URL. */
+  url: string;
+  /** SKOS concept naming why it failed (the value of `failure:reason`). */
+  reasonIri: NamedNode;
+}
+
+/**
+ * Emit the PROV qualified-usage shape recording per-sample failures on an
+ * existing sampling/validation `prov:Activity`. For every failed sample the
+ * activity `prov:used` the resource and `prov:qualifiedUsage` a `prov:Usage`
+ * that carries `prov:entity` (the failed URI/URL) and a single
+ * `failure:reason` (a SKOS concept). Successful samples are not enumerated, so
+ * the presence of a `failure:reason` is the contract for “this sample failed”.
+ *
+ * The `prov:Usage` is owned by the activity, never by the VoID subset, because
+ * a usage reifies an activity-uses-entity relationship. Consumers still reach
+ * failures dataset-first via the existing forward path
+ * `subset → dqv:hasQualityMeasurement → measurement → prov:wasGeneratedBy →
+ * activity → prov:qualifiedUsage → usage`.
+ *
+ * Shared by the subject-URI resolution transform and the IIIF validation
+ * executor so the failure shape lives in exactly one place. Emits nothing for
+ * an empty failure list.
+ */
+export function* failureUsageQuads(
+  activity: BlankNode,
+  failures: readonly SampleFailure[],
+): Generator<Quad> {
+  for (const {url, reasonIri} of failures) {
+    const entity = namedNode(url);
+    const usage = DataFactory.blankNode();
+
+    // `prov:used` accompanies each qualified usage, per PROV convention; the
+    // used-set lists only the failed resources, which PROV permits.
+    yield quad(activity, PROV_USED, entity);
+    yield quad(activity, PROV_QUALIFIED_USAGE, usage);
+
+    yield quad(usage, RDF_TYPE, PROV_USAGE);
+    yield quad(usage, PROV_ENTITY, entity);
+    yield quad(usage, FAILURE_REASON, reasonIri);
+  }
+}

--- a/src/iiifValidationExecutor.ts
+++ b/src/iiifValidationExecutor.ts
@@ -3,7 +3,12 @@ import pLimit from 'p-limit';
 import type {Quad} from '@rdfjs/types';
 import type {Dataset, Distribution} from '@lde/dataset';
 import {NotSupported, type Executor, type ExecuteOptions} from '@lde/pipeline';
-import {validateManifest, type ManifestValidation} from '@lde/iiif-validator';
+import {
+  validateManifest,
+  type ManifestValidation,
+  type ManifestValidationReason,
+} from '@lde/iiif-validator';
+import {failureUsageQuads, type SampleFailure} from './failureUsage.js';
 
 const {namedNode, literal, blankNode, quad} = DataFactory;
 
@@ -42,6 +47,48 @@ const MANIFESTS_VALIDATED_METRIC = namedNode(
  * the IRI hard-coded in `queries/analysis/iiif.rq`.
  */
 const MANIFEST_SAMPLE = namedNode('https://def.nde.nl/iiif#manifest-sample');
+
+const MANIFEST_VALIDATION_FAILURE_BASE =
+  'https://def.nde.nl/manifest-validation-failure#';
+
+/**
+ * A non-success {@link ManifestValidationReason} — a manifest failure reason.
+ * Excludes the validator’s `valid-manifest` success value, the one reason with
+ * no failure concept.
+ */
+export type ManifestValidationFailureReason = Exclude<
+  ManifestValidationReason,
+  'valid-manifest'
+>;
+
+/**
+ * Lockstep guard between the `@lde/iiif-validator` reason enum and the
+ * published `manifest-validation-failure` concept scheme. Keying a `Record` on
+ * every failure reason forces an entry per reason, so a new validator reason
+ * fails the TypeScript build here rather than silently emitting a
+ * `manifest-validation-failure#` term the vocabulary never defined. The concept
+ * local names equal the enum strings, so the IRI is a plain concatenation with
+ * no lookup table to drift.
+ */
+export const MANIFEST_VALIDATION_FAILURE_REASONS: Record<
+  ManifestValidationFailureReason,
+  true
+> = {
+  timeout: true,
+  'network-error': true,
+  'http-error': true,
+  'invalid-json': true,
+  'binary-content': true,
+  'not-a-manifest': true,
+  'does-not-load': true,
+};
+
+/** Map a manifest failure reason to its `manifest-validation-failure#` IRI. */
+export function manifestValidationFailureIri(
+  reason: ManifestValidationFailureReason,
+) {
+  return namedNode(`${MANIFEST_VALIDATION_FAILURE_BASE}${reason}`);
+}
 
 const DEFAULT_VALIDATOR_SOFTWARE = namedNode(
   'https://www.npmjs.com/package/@lde/iiif-validator',
@@ -143,15 +190,33 @@ export class IiifValidationExecutor implements Executor {
     const verdicts = await Promise.allSettled(
       sampledManifests.map(url => limit(() => this.validate(url))),
     );
-    const validated = verdicts.filter(
-      verdict => verdict.status === 'fulfilled' && verdict.value.valid,
-    ).length;
+
+    // Pair each sampled manifest with its verdict: a valid manifest counts
+    // towards `validated`, every other outcome becomes a persisted failure
+    // carrying the validator’s reason. A rejected validator (which its contract
+    // says never happens) surfaces defensively as `network-error` so the URL is
+    // not silently dropped.
+    let validated = 0;
+    const failures: SampleFailure[] = [];
+    sampledManifests.forEach((url, index) => {
+      const verdict = verdicts[index];
+      if (verdict.status === 'fulfilled' && verdict.value.valid) {
+        validated++;
+        return;
+      }
+      const reason: ManifestValidationFailureReason =
+        verdict.status === 'fulfilled'
+          ? (verdict.value.reason as ManifestValidationFailureReason)
+          : 'network-error';
+      failures.push({url, reasonIri: manifestValidationFailureIri(reason)});
+    });
 
     yield* this.measurementQuads(
       dataset,
       namedNode(iiifSubset),
       sampledManifests.length,
       validated,
+      failures,
     );
   }
 
@@ -160,16 +225,19 @@ export class IiifValidationExecutor implements Executor {
     iiifSubset: ReturnType<typeof namedNode>,
     sampled: number,
     validated: number,
+    failures: readonly SampleFailure[],
   ): Generator<Quad> {
     const activity = blankNode();
     const sampledMeasurement = blankNode();
     const validatedMeasurement = blankNode();
 
-    // PROV: the dereferencing activity.
+    // PROV: the dereferencing activity, with a qualified usage per failed
+    // manifest naming the URL and why validation failed.
     yield quad(activity, RDF_TYPE, PROV_ACTIVITY);
     yield quad(activity, PROV_USED, namedNode(dataset.iri.toString()));
     yield quad(activity, PROV_USED, IIIF_PRESENTATION);
     yield quad(activity, PROV_WAS_ASSOCIATED_WITH, this.validatorSoftware);
+    yield* failureUsageQuads(activity, failures);
 
     // The measurements describe the IIIF capability subset, which already
     // carries `dcterms:conformsTo <iiif-presentation>` — so they hang off the

--- a/src/iiifValidationExecutor.ts
+++ b/src/iiifValidationExecutor.ts
@@ -8,7 +8,11 @@ import {
   type ManifestValidation,
   type ManifestValidationReason,
 } from '@lde/iiif-validator';
-import {failureUsageQuads, type SampleFailure} from './failureUsage.js';
+import {
+  failureReasonIri,
+  failureUsageQuads,
+  type SampleFailure,
+} from './failureUsage.js';
 
 const {namedNode, literal, blankNode, quad} = DataFactory;
 
@@ -87,7 +91,23 @@ export const MANIFEST_VALIDATION_FAILURE_REASONS: Record<
 export function manifestValidationFailureIri(
   reason: ManifestValidationFailureReason,
 ) {
-  return namedNode(`${MANIFEST_VALIDATION_FAILURE_BASE}${reason}`);
+  return failureReasonIri(MANIFEST_VALIDATION_FAILURE_BASE, reason);
+}
+
+/**
+ * The in-scheme failure reason for a non-valid verdict. A rejected validator
+ * (its contract says this never happens) and the contract-violating
+ * `valid: false` paired with the `valid-manifest` success reason both fall back
+ * to `network-error`, so the emitted `failure:reason` is never an undefined
+ * `manifest-validation-failure#` term. Narrowing out `valid-manifest` lets the
+ * return type check without a cast.
+ */
+function failureReason(
+  verdict: PromiseSettledResult<ManifestValidation>,
+): ManifestValidationFailureReason {
+  if (verdict.status !== 'fulfilled') return 'network-error';
+  const {reason} = verdict.value;
+  return reason === 'valid-manifest' ? 'network-error' : reason;
 }
 
 const DEFAULT_VALIDATOR_SOFTWARE = namedNode(
@@ -193,9 +213,7 @@ export class IiifValidationExecutor implements Executor {
 
     // Pair each sampled manifest with its verdict: a valid manifest counts
     // towards `validated`, every other outcome becomes a persisted failure
-    // carrying the validator’s reason. A rejected validator (which its contract
-    // says never happens) surfaces defensively as `network-error` so the URL is
-    // not silently dropped.
+    // carrying the validator’s reason (see {@link failureReason}).
     let validated = 0;
     const failures: SampleFailure[] = [];
     sampledManifests.forEach((url, index) => {
@@ -204,11 +222,10 @@ export class IiifValidationExecutor implements Executor {
         validated++;
         return;
       }
-      const reason: ManifestValidationFailureReason =
-        verdict.status === 'fulfilled'
-          ? (verdict.value.reason as ManifestValidationFailureReason)
-          : 'network-error';
-      failures.push({url, reasonIri: manifestValidationFailureIri(reason)});
+      failures.push({
+        url,
+        reasonIri: manifestValidationFailureIri(failureReason(verdict)),
+      });
     });
 
     yield* this.measurementQuads(

--- a/src/subjectUriResolution.ts
+++ b/src/subjectUriResolution.ts
@@ -4,7 +4,11 @@ import {SparqlEndpointFetcher, type IBindings} from 'fetch-sparql-endpoint';
 import type {Quad} from '@rdfjs/types';
 import {assertSafeIri, type Dataset, type Distribution} from '@lde/dataset';
 import type {ExecutorContext, QuadTransform} from '@lde/pipeline';
-import {failureUsageQuads, type SampleFailure} from './failureUsage.js';
+import {
+  failureReasonIri,
+  failureUsageQuads,
+  type SampleFailure,
+} from './failureUsage.js';
 
 const {namedNode, literal, blankNode, quad} = DataFactory;
 
@@ -63,7 +67,7 @@ export type SubjectResolutionFailure =
 
 /** Map a failure reason to its `subject-resolution-failure#` concept IRI. */
 function subjectResolutionFailureIri(reason: SubjectResolutionFailure) {
-  return namedNode(`${SUBJECT_RESOLUTION_FAILURE_BASE}${reason}`);
+  return failureReasonIri(SUBJECT_RESOLUTION_FAILURE_BASE, reason);
 }
 
 const PID_SCHEME_BASE = 'https://def.nde.nl/pid-scheme#';

--- a/src/subjectUriResolution.ts
+++ b/src/subjectUriResolution.ts
@@ -4,6 +4,7 @@ import {SparqlEndpointFetcher, type IBindings} from 'fetch-sparql-endpoint';
 import type {Quad} from '@rdfjs/types';
 import {assertSafeIri, type Dataset, type Distribution} from '@lde/dataset';
 import type {ExecutorContext, QuadTransform} from '@lde/pipeline';
+import {failureUsageQuads, type SampleFailure} from './failureUsage.js';
 
 const {namedNode, literal, blankNode, quad} = DataFactory;
 
@@ -44,6 +45,26 @@ const SUBJECT_URIS_RESOLVED_METRIC = namedNode(
 const SUBJECT_NAMESPACE_DURABLE_METRIC = namedNode(
   `${METRIC_BASE}subject-namespace-durable`,
 );
+
+const SUBJECT_RESOLUTION_FAILURE_BASE =
+  'https://def.nde.nl/subject-resolution-failure#';
+
+/**
+ * Why a sampled subject URI did not resolve to a self-describing landing page.
+ * Mirrors the `subject-resolution-failure` concept scheme; a `null` outcome
+ * (resolved) is represented out-of-band.
+ */
+export type SubjectResolutionFailure =
+  | 'timeout'
+  | 'network-error'
+  | 'http-error'
+  | 'wrong-content-type'
+  | 'no-self-reference';
+
+/** Map a failure reason to its `subject-resolution-failure#` concept IRI. */
+function subjectResolutionFailureIri(reason: SubjectResolutionFailure) {
+  return namedNode(`${SUBJECT_RESOLUTION_FAILURE_BASE}${reason}`);
+}
 
 const PID_SCHEME_BASE = 'https://def.nde.nl/pid-scheme#';
 const PID_SCHEMES = {
@@ -121,10 +142,14 @@ export type SampleUris = (
 ) => Promise<string[]>;
 
 /**
- * Resolves a sampled URI and reports whether it lands on a self-describing
- * page: a `200`, `text/html` response whose body advertises the original URI.
+ * Resolves a sampled URI and classifies the outcome: `null` when it lands on a
+ * self-describing page (a `200`, `text/html` response whose body advertises the
+ * original URI), otherwise the {@link SubjectResolutionFailure} describing why
+ * it did not.
  */
-export type ResolveUri = (uri: string) => Promise<boolean>;
+export type ResolveUri = (
+  uri: string,
+) => Promise<SubjectResolutionFailure | null>;
 
 /** Looks up the issuing organisation’s name for an ARK NAAN, if available. */
 export type LookupOrg = (naan: string) => Promise<string | undefined>;
@@ -234,9 +259,26 @@ export function subjectUriResolution(
       const outcomes = await Promise.allSettled(
         sampled.map(uri => limit(() => resolve(uri))),
       );
-      const resolved = outcomes.filter(
-        outcome => outcome.status === 'fulfilled' && outcome.value,
-      ).length;
+
+      // Pair each sampled URI with its settled outcome: a `null` classification
+      // counts as resolved, any reason becomes a persisted failure. An
+      // unexpected rejection is mapped defensively to `network-error` so the URI
+      // still surfaces rather than vanishing from both the count and the trail.
+      let resolved = 0;
+      const failures: SampleFailure[] = [];
+      sampled.forEach((uri, index) => {
+        const outcome = outcomes[index];
+        const reason: SubjectResolutionFailure | null =
+          outcome.status === 'fulfilled' ? outcome.value : 'network-error';
+        if (reason === null) {
+          resolved++;
+        } else {
+          failures.push({
+            url: uri,
+            reasonIri: subjectResolutionFailureIri(reason),
+          });
+        }
+      });
 
       const scheme = detectPidScheme(winner.uriSpace);
       const org =
@@ -249,6 +291,7 @@ export function subjectUriResolution(
           namedNode(winner.subset),
           sampled.length,
           resolved,
+          failures,
           scheme,
           org,
           software,
@@ -331,6 +374,7 @@ function* measurementQuads(
   subset: ReturnType<typeof namedNode>,
   sampled: number,
   resolved: number,
+  failures: readonly SampleFailure[],
   scheme: PidScheme | undefined,
   org: string | undefined,
   software: ReturnType<typeof namedNode>,
@@ -343,9 +387,11 @@ function* measurementQuads(
     yield quad(subset, DCTERMS_PUBLISHER, literal(org));
   }
 
-  // PROV: the sampling/dereferencing activity.
+  // PROV: the sampling/dereferencing activity, with a qualified usage per
+  // failed sample naming the URI and why it did not resolve.
   const activity = blankNode();
   yield* activityQuads(activity, subset, software);
+  yield* failureUsageQuads(activity, failures);
 
   // Validated facts — the sampled/resolved ratio, for any namespace.
   const sampledMeasurement = blankNode();
@@ -478,7 +524,8 @@ const defaultSampleUris: SampleUris = async (
  * Default resolution check: follow redirects to the landing page and require a
  * `200`, `text/html` response that advertises the original sampled URI (raw or
  * HTML-entity-escaped) — the permanent link back to the user, which matters
- * because we landed on a different, redirected URL.
+ * because we landed on a different, redirected URL. Returns `null` on success,
+ * otherwise the {@link SubjectResolutionFailure} classifying the breakage.
  */
 const defaultResolve: ResolveUri = async uri => {
   let response: Response;
@@ -488,21 +535,36 @@ const defaultResolve: ResolveUri = async uri => {
       headers: {accept: 'text/html'},
       signal: AbortSignal.timeout(DEREFERENCE_TIMEOUT_MS),
     });
-  } catch {
-    return false;
+  } catch (error) {
+    return classifyFetchError(error);
   }
-  if (!response.ok) return false;
+  if (!response.ok) return 'http-error';
   if (!(response.headers.get('content-type') ?? '').includes('text/html')) {
-    return false;
+    return 'wrong-content-type';
   }
   let body: string;
   try {
     body = await response.text();
   } catch {
-    return false;
+    // A `200 text/html` whose body cannot be read is a transport failure.
+    return 'network-error';
   }
-  return body.includes(uri) || body.includes(htmlEscape(uri));
+  return body.includes(uri) || body.includes(htmlEscape(uri))
+    ? null
+    : 'no-self-reference';
 };
+
+/**
+ * Split an abort/timeout from a generic transport failure by the caught error’s
+ * name: `AbortSignal.timeout` rejects with a `TimeoutError`, an external abort
+ * with an `AbortError`; anything else is a `network-error`.
+ */
+function classifyFetchError(error: unknown): SubjectResolutionFailure {
+  const name = (error as {name?: unknown} | null)?.name;
+  return name === 'TimeoutError' || name === 'AbortError'
+    ? 'timeout'
+    : 'network-error';
+}
 
 /**
  * Default ARK org lookup: read `properties.who.name` from the arks.org NAAN

--- a/test/failureUsage.test.ts
+++ b/test/failureUsage.test.ts
@@ -1,0 +1,99 @@
+import {describe, it, expect} from 'vitest';
+import {DataFactory} from 'n3';
+import type {Quad} from '@rdfjs/types';
+import {failureUsageQuads} from '../src/failureUsage.js';
+
+const {namedNode, blankNode} = DataFactory;
+
+const RDF_TYPE = namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+const PROV_USED = namedNode('http://www.w3.org/ns/prov#used');
+const PROV_QUALIFIED_USAGE = namedNode(
+  'http://www.w3.org/ns/prov#qualifiedUsage',
+);
+const PROV_USAGE = namedNode('http://www.w3.org/ns/prov#Usage');
+const PROV_ENTITY = namedNode('http://www.w3.org/ns/prov#entity');
+const FAILURE_REASON = namedNode('https://def.nde.nl/failure#reason');
+
+const TIMEOUT = namedNode(
+  'https://def.nde.nl/subject-resolution-failure#timeout',
+);
+const HTTP_ERROR = namedNode(
+  'https://def.nde.nl/subject-resolution-failure#http-error',
+);
+
+function collect(quads: Iterable<Quad>): Quad[] {
+  return [...quads];
+}
+
+describe('failureUsageQuads', () => {
+  it('emits the qualified-usage shape for each failure', () => {
+    const activity = blankNode('activity');
+    const out = collect(
+      failureUsageQuads(activity, [
+        {url: 'http://example.org/id/1', reasonIri: TIMEOUT},
+        {url: 'http://example.org/id/2', reasonIri: HTTP_ERROR},
+      ]),
+    );
+
+    // One prov:used and one prov:qualifiedUsage per failure, on the activity.
+    expect(
+      out.filter(
+        q => q.subject.equals(activity) && q.predicate.equals(PROV_USED),
+      ),
+    ).toHaveLength(2);
+    const usages = out.filter(
+      q =>
+        q.subject.equals(activity) && q.predicate.equals(PROV_QUALIFIED_USAGE),
+    );
+    expect(usages).toHaveLength(2);
+
+    // Each usage carries a type, the failed entity and exactly one reason.
+    for (const url of ['http://example.org/id/1', 'http://example.org/id/2']) {
+      const entity = namedNode(url);
+      const usage = out.find(
+        q => q.predicate.equals(PROV_ENTITY) && q.object.equals(entity),
+      )?.subject;
+      expect(usage).toBeDefined();
+      expect(
+        out.some(
+          q =>
+            q.subject.equals(usage!) &&
+            q.predicate.equals(RDF_TYPE) &&
+            q.object.equals(PROV_USAGE),
+        ),
+      ).toBe(true);
+      expect(
+        out.filter(
+          q => q.subject.equals(usage!) && q.predicate.equals(FAILURE_REASON),
+        ),
+      ).toHaveLength(1);
+      // The activity also prov:used the failed entity directly.
+      expect(
+        out.some(
+          q =>
+            q.subject.equals(activity) &&
+            q.predicate.equals(PROV_USED) &&
+            q.object.equals(entity),
+        ),
+      ).toBe(true);
+    }
+
+    // The reason values match what was passed in.
+    expect(
+      out.some(
+        q => q.predicate.equals(FAILURE_REASON) && q.object.equals(TIMEOUT),
+      ),
+    ).toBe(true);
+    expect(
+      out.some(
+        q => q.predicate.equals(FAILURE_REASON) && q.object.equals(HTTP_ERROR),
+      ),
+    ).toBe(true);
+  });
+
+  it('emits nothing for an empty failure list', () => {
+    expect(collect(failureUsageQuads(blankNode('activity'), []))).toHaveLength(
+      0,
+    );
+  });
+});

--- a/test/failures.ts
+++ b/test/failures.ts
@@ -1,0 +1,26 @@
+import {DataFactory} from 'n3';
+import type {Quad} from '@rdfjs/types';
+
+const {namedNode} = DataFactory;
+
+const PROV_ENTITY = namedNode('http://www.w3.org/ns/prov#entity');
+const FAILURE_REASON = namedNode('https://def.nde.nl/failure#reason');
+
+/**
+ * The `failure:reason` IRI of the qualified usage whose `prov:entity` is `url`,
+ * or `undefined` when no failure usage for `url` was emitted. Inverts
+ * {@link failureUsageQuads}; shared by the subject-resolution and IIIF tests so
+ * the reader of the failure shape stays in one place.
+ */
+export function failureReasonFor(
+  quads: Quad[],
+  url: string,
+): string | undefined {
+  const usage = quads.find(
+    q => q.predicate.equals(PROV_ENTITY) && q.object.equals(namedNode(url)),
+  )?.subject;
+  if (!usage) return undefined;
+  return quads.find(
+    q => q.subject.equals(usage) && q.predicate.equals(FAILURE_REASON),
+  )?.object.value;
+}

--- a/test/iiifValidationExecutor.test.ts
+++ b/test/iiifValidationExecutor.test.ts
@@ -9,6 +9,7 @@ import {
   manifestValidationFailureIri,
   type ValidateManifest,
 } from '../src/iiifValidationExecutor.js';
+import {failureReasonFor} from './failures.js';
 
 const {namedNode, literal, quad} = DataFactory;
 
@@ -39,21 +40,8 @@ const MANIFESTS_VALIDATED_METRIC = namedNode(
 const PROV_QUALIFIED_USAGE = namedNode(
   'http://www.w3.org/ns/prov#qualifiedUsage',
 );
-const PROV_ENTITY = namedNode('http://www.w3.org/ns/prov#entity');
-const FAILURE_REASON = namedNode('https://def.nde.nl/failure#reason');
 const MANIFEST_VALIDATION_FAILURE_BASE =
   'https://def.nde.nl/manifest-validation-failure#';
-
-/** The `failure:reason` IRI of the usage whose `prov:entity` is `url`. */
-function failureReasonFor(quads: Quad[], url: string): string | undefined {
-  const usage = quads.find(
-    q => q.predicate.equals(PROV_ENTITY) && q.object.equals(namedNode(url)),
-  )?.subject;
-  if (!usage) return undefined;
-  return quads.find(
-    q => q.subject.equals(usage) && q.predicate.equals(FAILURE_REASON),
-  )?.object.value;
-}
 
 /** Find the integer value of the measurement of the given metric. */
 function measurementValue(quads: Quad[], metric: string): number | undefined {
@@ -250,6 +238,31 @@ describe('IiifValidationExecutor', () => {
     );
   });
 
+  it('never emits an undefined reason term for a contract-violating verdict', async () => {
+    // `valid` and `reason` are independent fields; guard against the validator
+    // pairing valid:false with the success reason, which would otherwise build
+    // the undefined IRI manifest-validation-failure#valid-manifest.
+    const validateContradictory: ValidateManifest = async () => ({
+      valid: false,
+      reason: 'valid-manifest',
+    });
+    const inner = innerYielding([
+      ...voidQuads(),
+      sampleQuad('http://example.org/bad/1'),
+    ]);
+
+    const executor = new IiifValidationExecutor(inner, {
+      validate: validateContradictory,
+    });
+    const out = await collect(await executor.execute(dataset, distribution));
+
+    expect(measurementValue(out, MANIFESTS_VALIDATED_METRIC.value)).toBe(0);
+    // Falls back to an in-scheme reason rather than #valid-manifest.
+    expect(failureReasonFor(out, 'http://example.org/bad/1')).toBe(
+      `${MANIFEST_VALIDATION_FAILURE_BASE}network-error`,
+    );
+  });
+
   it('counts a manifest that throws during dereferencing as not validated', async () => {
     const validateThrowing: ValidateManifest = async (url: string) => {
       if (url.includes('throws')) throw new Error('boom');
@@ -269,6 +282,10 @@ describe('IiifValidationExecutor', () => {
     // One validator rejection must not fail or drop the others.
     expect(measurementValue(out, MANIFESTS_SAMPLED_METRIC.value)).toBe(2);
     expect(measurementValue(out, MANIFESTS_VALIDATED_METRIC.value)).toBe(1);
+    // The thrown manifest still surfaces, classified defensively.
+    expect(failureReasonFor(out, 'http://example.org/throws/2')).toBe(
+      `${MANIFEST_VALIDATION_FAILURE_BASE}network-error`,
+    );
   });
 
   it('emits no measurements when no IIIF is detected (no sample triples)', async () => {
@@ -304,34 +321,20 @@ describe('IiifValidationExecutor', () => {
 });
 
 describe('manifest-validation-failure lockstep', () => {
-  // The published `manifest-validation-failure` concept scheme; the build must
-  // keep this in lockstep with the validator’s `ManifestValidationReason` enum.
-  // The TypeScript `Record` type in the source enforces it at compile time; this
-  // runtime test documents the expected concepts and the IRI mapping, so a drift
-  // in either direction is visible.
-  const EXPECTED_CONCEPTS = [
-    'timeout',
-    'network-error',
-    'http-error',
-    'invalid-json',
-    'binary-content',
-    'not-a-manifest',
-    'does-not-load',
-  ];
-
-  it('defines a concept for every validator failure reason', () => {
-    expect(Object.keys(MANIFEST_VALIDATION_FAILURE_REASONS).sort()).toEqual(
-      [...EXPECTED_CONCEPTS].sort(),
-    );
-  });
-
-  it('maps each reason to its manifest-validation-failure# IRI', () => {
-    for (const reason of EXPECTED_CONCEPTS) {
-      expect(
-        manifestValidationFailureIri(
-          reason as keyof typeof MANIFEST_VALIDATION_FAILURE_REASONS,
-        ).value,
-      ).toBe(`https://def.nde.nl/manifest-validation-failure#${reason}`);
+  // Lockstep with the validator’s `ManifestValidationReason` enum is enforced at
+  // compile time by the `Record<ManifestValidationFailureReason, true>` type of
+  // `MANIFEST_VALIDATION_FAILURE_REASONS` in the source: a new validator reason
+  // that is not listed fails `tsc`. This test derives its reasons from that same
+  // Record (no second hand-maintained list) and only documents the IRI shape.
+  it('maps each failure reason to its manifest-validation-failure# IRI', () => {
+    const reasons = Object.keys(MANIFEST_VALIDATION_FAILURE_REASONS) as Array<
+      keyof typeof MANIFEST_VALIDATION_FAILURE_REASONS
+    >;
+    expect(reasons.length).toBeGreaterThan(0);
+    for (const reason of reasons) {
+      expect(manifestValidationFailureIri(reason).value).toBe(
+        `https://def.nde.nl/manifest-validation-failure#${reason}`,
+      );
     }
   });
 });

--- a/test/iiifValidationExecutor.test.ts
+++ b/test/iiifValidationExecutor.test.ts
@@ -5,6 +5,8 @@ import {Dataset, Distribution} from '@lde/dataset';
 import {NotSupported, type Executor} from '@lde/pipeline';
 import {
   IiifValidationExecutor,
+  MANIFEST_VALIDATION_FAILURE_REASONS,
+  manifestValidationFailureIri,
   type ValidateManifest,
 } from '../src/iiifValidationExecutor.js';
 
@@ -34,6 +36,24 @@ const MANIFESTS_SAMPLED_METRIC = namedNode(`${METRIC_BASE}manifests-sampled`);
 const MANIFESTS_VALIDATED_METRIC = namedNode(
   `${METRIC_BASE}manifests-validated`,
 );
+const PROV_QUALIFIED_USAGE = namedNode(
+  'http://www.w3.org/ns/prov#qualifiedUsage',
+);
+const PROV_ENTITY = namedNode('http://www.w3.org/ns/prov#entity');
+const FAILURE_REASON = namedNode('https://def.nde.nl/failure#reason');
+const MANIFEST_VALIDATION_FAILURE_BASE =
+  'https://def.nde.nl/manifest-validation-failure#';
+
+/** The `failure:reason` IRI of the usage whose `prov:entity` is `url`. */
+function failureReasonFor(quads: Quad[], url: string): string | undefined {
+  const usage = quads.find(
+    q => q.predicate.equals(PROV_ENTITY) && q.object.equals(namedNode(url)),
+  )?.subject;
+  if (!usage) return undefined;
+  return quads.find(
+    q => q.subject.equals(usage) && q.predicate.equals(FAILURE_REASON),
+  )?.object.value;
+}
 
 /** Find the integer value of the measurement of the given metric. */
 function measurementValue(quads: Quad[], metric: string): number | undefined {
@@ -177,9 +197,25 @@ describe('IiifValidationExecutor', () => {
           q.predicate.equals(DQV_HAS_QUALITY_MEASUREMENT),
       ),
     ).toHaveLength(2);
+
+    // Only the failed manifest is enumerated, as a qualified usage carrying its
+    // reason; the validated one is covered by the count alone.
+    expect(
+      out.filter(q => q.predicate.equals(PROV_QUALIFIED_USAGE)),
+    ).toHaveLength(1);
+    expect(failureReasonFor(out, 'http://example.org/bad/2')).toBe(
+      `${MANIFEST_VALIDATION_FAILURE_BASE}http-error`,
+    );
+    expect(failureReasonFor(out, 'http://example.org/good/1')).toBeUndefined();
   });
 
-  it('records validated = 0 when every sampled manifest fails (k = 0)', async () => {
+  it('records validated = 0 and the validator’s reason per failure (k = 0)', async () => {
+    // Distinct reasons confirm the executor reads the verdict’s reason rather
+    // than hard-coding one.
+    const validateWithReasons: ValidateManifest = async (url: string) =>
+      url.endsWith('/1')
+        ? {valid: false, reason: 'not-a-manifest'}
+        : {valid: false, reason: 'invalid-json'};
     const inner = innerYielding([
       ...voidQuads(),
       sampleQuad('http://example.org/bad/1'),
@@ -187,7 +223,7 @@ describe('IiifValidationExecutor', () => {
     ]);
 
     const executor = new IiifValidationExecutor(inner, {
-      validate: validateByName,
+      validate: validateWithReasons,
     });
     const out = await collect(await executor.execute(dataset, distribution));
 
@@ -201,6 +237,17 @@ describe('IiifValidationExecutor', () => {
     ).toBe(true);
     expect(measurementValue(out, MANIFESTS_SAMPLED_METRIC.value)).toBe(2);
     expect(measurementValue(out, MANIFESTS_VALIDATED_METRIC.value)).toBe(0);
+
+    // Both manifests are enumerated, each with its own typed reason.
+    expect(
+      out.filter(q => q.predicate.equals(PROV_QUALIFIED_USAGE)),
+    ).toHaveLength(2);
+    expect(failureReasonFor(out, 'http://example.org/bad/1')).toBe(
+      `${MANIFEST_VALIDATION_FAILURE_BASE}not-a-manifest`,
+    );
+    expect(failureReasonFor(out, 'http://example.org/bad/2')).toBe(
+      `${MANIFEST_VALIDATION_FAILURE_BASE}invalid-json`,
+    );
   });
 
   it('counts a manifest that throws during dereferencing as not validated', async () => {
@@ -253,5 +300,38 @@ describe('IiifValidationExecutor', () => {
     const result = await executor.execute(dataset, distribution);
 
     expect(result).toBeInstanceOf(NotSupported);
+  });
+});
+
+describe('manifest-validation-failure lockstep', () => {
+  // The published `manifest-validation-failure` concept scheme; the build must
+  // keep this in lockstep with the validator’s `ManifestValidationReason` enum.
+  // The TypeScript `Record` type in the source enforces it at compile time; this
+  // runtime test documents the expected concepts and the IRI mapping, so a drift
+  // in either direction is visible.
+  const EXPECTED_CONCEPTS = [
+    'timeout',
+    'network-error',
+    'http-error',
+    'invalid-json',
+    'binary-content',
+    'not-a-manifest',
+    'does-not-load',
+  ];
+
+  it('defines a concept for every validator failure reason', () => {
+    expect(Object.keys(MANIFEST_VALIDATION_FAILURE_REASONS).sort()).toEqual(
+      [...EXPECTED_CONCEPTS].sort(),
+    );
+  });
+
+  it('maps each reason to its manifest-validation-failure# IRI', () => {
+    for (const reason of EXPECTED_CONCEPTS) {
+      expect(
+        manifestValidationFailureIri(
+          reason as keyof typeof MANIFEST_VALIDATION_FAILURE_REASONS,
+        ).value,
+      ).toBe(`https://def.nde.nl/manifest-validation-failure#${reason}`);
+    }
   });
 });

--- a/test/subjectUriResolution.test.ts
+++ b/test/subjectUriResolution.test.ts
@@ -9,6 +9,7 @@ import {
   type ResolveUri,
   type SampleUris,
 } from '../src/subjectUriResolution.js';
+import {failureReasonFor} from './failures.js';
 
 const {namedNode, literal, quad} = DataFactory;
 
@@ -128,8 +129,6 @@ const SUBJECT_RESOLUTION_FAILURE_BASE =
 const PROV_QUALIFIED_USAGE = namedNode(
   'http://www.w3.org/ns/prov#qualifiedUsage',
 );
-const PROV_ENTITY = namedNode('http://www.w3.org/ns/prov#entity');
-const FAILURE_REASON = namedNode('https://def.nde.nl/failure#reason');
 
 const sampleFixed =
   (uris: string[]): SampleUris =>
@@ -139,17 +138,6 @@ const sampleFixed =
 const resolveByName: ResolveUri = async uri =>
   uri.includes('good') ? null : 'http-error';
 const noOrg: LookupOrg = async () => undefined;
-
-/** The `failure:reason` IRI of the usage whose `prov:entity` is `url`. */
-function failureReasonFor(quads: Quad[], url: string): string | undefined {
-  const usage = quads.find(
-    q => q.predicate.equals(PROV_ENTITY) && q.object.equals(namedNode(url)),
-  )?.subject;
-  if (!usage) return undefined;
-  return quads.find(
-    q => q.subject.equals(usage) && q.predicate.equals(FAILURE_REASON),
-  )?.object.value;
-}
 
 describe('subjectUriResolution', () => {
   it('passes the subsets through and appends sampled/resolved measurements', async () => {

--- a/test/subjectUriResolution.test.ts
+++ b/test/subjectUriResolution.test.ts
@@ -123,12 +123,33 @@ function measurementValueTerm(
   )?.object;
 }
 
+const SUBJECT_RESOLUTION_FAILURE_BASE =
+  'https://def.nde.nl/subject-resolution-failure#';
+const PROV_QUALIFIED_USAGE = namedNode(
+  'http://www.w3.org/ns/prov#qualifiedUsage',
+);
+const PROV_ENTITY = namedNode('http://www.w3.org/ns/prov#entity');
+const FAILURE_REASON = namedNode('https://def.nde.nl/failure#reason');
+
 const sampleFixed =
   (uris: string[]): SampleUris =>
   async () =>
     uris;
-const resolveByName: ResolveUri = async uri => uri.includes('good');
+// `null` means resolved; a non-`good` URI fails with a typed reason.
+const resolveByName: ResolveUri = async uri =>
+  uri.includes('good') ? null : 'http-error';
 const noOrg: LookupOrg = async () => undefined;
+
+/** The `failure:reason` IRI of the usage whose `prov:entity` is `url`. */
+function failureReasonFor(quads: Quad[], url: string): string | undefined {
+  const usage = quads.find(
+    q => q.predicate.equals(PROV_ENTITY) && q.object.equals(namedNode(url)),
+  )?.subject;
+  if (!usage) return undefined;
+  return quads.find(
+    q => q.subject.equals(usage) && q.predicate.equals(FAILURE_REASON),
+  )?.object.value;
+}
 
 describe('subjectUriResolution', () => {
   it('passes the subsets through and appends sampled/resolved measurements', async () => {
@@ -161,6 +182,18 @@ describe('subjectUriResolution', () => {
           q.predicate.equals(DQV_HAS_QUALITY_MEASUREMENT),
       ),
     ).toHaveLength(2);
+
+    // Only the failed sample is enumerated, as a qualified usage carrying its
+    // typed reason; the two resolved samples are covered by the count alone.
+    expect(
+      out.filter(q => q.predicate.equals(PROV_QUALIFIED_USAGE)),
+    ).toHaveLength(1);
+    expect(failureReasonFor(out, 'http://example.org/id/bad-3')).toBe(
+      `${SUBJECT_RESOLUTION_FAILURE_BASE}http-error`,
+    );
+    expect(
+      failureReasonFor(out, 'http://example.org/id/good-1'),
+    ).toBeUndefined();
   });
 
   it('picks the most common non-terminology namespace', async () => {
@@ -303,7 +336,7 @@ describe('subjectUriResolution', () => {
     expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBe(1);
   });
 
-  it('counts a resolution that throws as unresolved', async () => {
+  it('counts a resolution that throws as unresolved and surfaces it as network-error', async () => {
     const ns = subset('http://example.org/id/', 10);
     const transform = subjectUriResolution({
       terminologyPrefixes: [],
@@ -313,7 +346,7 @@ describe('subjectUriResolution', () => {
       ]),
       resolve: async uri => {
         if (uri.includes('throws')) throw new Error('boom');
-        return true;
+        return null;
       },
     });
 
@@ -321,6 +354,10 @@ describe('subjectUriResolution', () => {
 
     expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBe(2);
     expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
+    // The rejected URI still surfaces, classified defensively.
+    expect(failureReasonFor(out, 'http://example.org/id/throws')).toBe(
+      `${SUBJECT_RESOLUTION_FAILURE_BASE}network-error`,
+    );
   });
 
   it('keeps the VoID output when sampling fails', async () => {
@@ -552,6 +589,109 @@ describe('subjectUriResolution', () => {
             q.object.value === 'Gouda Tijdmachine',
         ),
       ).toBe(true);
+    });
+  });
+
+  describe('default resolution classifier', () => {
+    afterEach(() => vi.unstubAllGlobals());
+
+    const URI = 'http://example.org/id/x';
+
+    /** Drive the default resolve (no injected `resolve`) over a single URI. */
+    async function runWithFetch(fetchImpl: typeof fetch): Promise<Quad[]> {
+      vi.stubGlobal('fetch', vi.fn(fetchImpl));
+      const ns = subset('http://example.org/id/', 10);
+      const transform = subjectUriResolution({
+        terminologyPrefixes: [],
+        sampleUris: sampleFixed([URI]),
+      });
+      return collect(transform(stream(ns.quads), context));
+    }
+
+    function htmlResponse(body: string): Response {
+      return new Response(body, {
+        status: 200,
+        headers: {'content-type': 'text/html'},
+      });
+    }
+
+    it('classifies an unreachable host as network-error', async () => {
+      const out = await runWithFetch(async () => {
+        throw new Error('ECONNREFUSED');
+      });
+      expect(failureReasonFor(out, URI)).toBe(
+        `${SUBJECT_RESOLUTION_FAILURE_BASE}network-error`,
+      );
+    });
+
+    it('classifies an abort/timeout as timeout', async () => {
+      const out = await runWithFetch(async () => {
+        const error = new Error('aborted');
+        error.name = 'TimeoutError';
+        throw error;
+      });
+      expect(failureReasonFor(out, URI)).toBe(
+        `${SUBJECT_RESOLUTION_FAILURE_BASE}timeout`,
+      );
+    });
+
+    it('classifies a non-2xx response as http-error', async () => {
+      const out = await runWithFetch(
+        async () => new Response('', {status: 404}),
+      );
+      expect(failureReasonFor(out, URI)).toBe(
+        `${SUBJECT_RESOLUTION_FAILURE_BASE}http-error`,
+      );
+    });
+
+    it('classifies a non-HTML content type as wrong-content-type', async () => {
+      const out = await runWithFetch(
+        async () =>
+          new Response('{}', {
+            status: 200,
+            headers: {'content-type': 'application/json'},
+          }),
+      );
+      expect(failureReasonFor(out, URI)).toBe(
+        `${SUBJECT_RESOLUTION_FAILURE_BASE}wrong-content-type`,
+      );
+    });
+
+    it('classifies HTML without a self-reference as no-self-reference', async () => {
+      const out = await runWithFetch(async () =>
+        htmlResponse('<html>no link here</html>'),
+      );
+      expect(failureReasonFor(out, URI)).toBe(
+        `${SUBJECT_RESOLUTION_FAILURE_BASE}no-self-reference`,
+      );
+    });
+
+    it('classifies an unreadable body as network-error', async () => {
+      const out = await runWithFetch(
+        async () =>
+          ({
+            ok: true,
+            headers: {get: () => 'text/html'},
+            text: async () => {
+              throw new Error('stream closed');
+            },
+          }) as unknown as Response,
+      );
+      expect(failureReasonFor(out, URI)).toBe(
+        `${SUBJECT_RESOLUTION_FAILURE_BASE}network-error`,
+      );
+    });
+
+    it('reports a resolving, self-referencing page as resolved', async () => {
+      const ns = subset('http://example.org/id/', 10);
+      const out = await runWithFetch(async () =>
+        htmlResponse(`<html><a href="${URI}">permalink</a></html>`),
+      );
+      expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
+      expect(failureReasonFor(out, URI)).toBeUndefined();
+      expect(out.some(q => q.predicate.equals(PROV_QUALIFIED_USAGE))).toBe(
+        false,
+      );
     });
   });
 });


### PR DESCRIPTION
Closes #338.

When the DKG samples subject URIs for resolution and IIIF manifests for validation, it recorded only aggregate counts (`subject-uris-sampled`/`subject-uris-resolved`, `manifests-sampled`/`manifests-validated`). The identity of each failed sample – and why it failed – was discarded. This PR persists, for every **failed** sample, the URI/URL together with a typed failure reason, as a PROV qualified usage on the run’s `prov:Activity`.

### RDF shape

```turtle
_:activity a prov:Activity ;
    prov:used <…failed-url> ;
    prov:qualifiedUsage _:usage ;
    prov:wasAssociatedWith <…software> .
_:usage a prov:Usage ;
    prov:entity <…failed-url> ;
    failure:reason <…reason-concept> .
```

Only failures are persisted – the presence of `failure:reason` is the contract for “this sample failed”. Successful samples stay covered by the existing counts. The `prov:Usage` is owned by the activity (never the subset); consumers still reach failures dataset-first via `subset → dqv:hasQualityMeasurement → measurement → prov:wasGeneratedBy → activity → prov:qualifiedUsage → usage`.

### Modules

- **`src/failureUsage.ts`** (new, shared) – emits the qualified-usage shape in one place, called by both the subject-resolution transform and the IIIF executor.
- **`src/subjectUriResolution.ts`** – `ResolveUri` now returns `SubjectResolutionFailure | null`; `defaultResolve` classifies each branch (timeout vs network-error by error name, http-error, wrong-content-type, no-self-reference, unreadable body → network-error). The transform pairs each URI with its settled outcome, counts `null` as resolved, and maps an unexpected `Promise.allSettled` rejection defensively to `network-error`.
- **`src/iiifValidationExecutor.ts`** – reads the validator’s `reason` for non-valid manifests and maps it to `manifest-validation-failure#${reason}`. A `Record<ManifestValidationFailureReason, true>` enforces lockstep with the `@lde/iiif-validator` reason enum at compile time; a runtime guard test documents the expected concepts.

### Tests

New `test/failureUsage.test.ts`; Module A branch classifier tests; failure-trail assertions added to both integration suites; lockstep guard test. **84 tests pass; lint, prettier and `tsc` clean.**

### Cross-repo

The emitted reason IRIs are defined in a companion PR on the **definitions** repo (`failure`, `subject-resolution-failure`, `manifest-validation-failure` modules). Docs updated in the **docs** repo. Surfacing failed samples in the dataset register browser is a separate follow-up (out of scope here).
