### PR TITLE
ci: open release-please PRs with the nde-bot app token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,17 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Use the nde-bot GitHub App token instead of the default GITHUB_TOKEN, so
+      # the release PR triggers workflows (QA, auto-merge). PRs opened by the
+      # default token are gated behind manual approval and never run CI.
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Why

The standing release-please PR (e.g. #343) is opened by the `github-actions` bot using the default `GITHUB_TOKEN`. GitHub deliberately suppresses workflow runs on PRs created with that token, so QA and the Dependabot auto-merge workflow land in the `action_required` state and never run without a manual “Approve and run”.

## What

Generate a GitHub App token (nde-bot) via `actions/create-github-app-token` and pass it to release-please instead of the default `GITHUB_TOKEN`. PRs opened under the nde-bot identity trigger workflows normally, so the release PR’s QA gate runs without manual approval.

This mirrors the token pattern already used by the spec repos’ reusable release-please workflow. The required `GH_APP_ID` and `GH_APP_PRIVATE_KEY` secrets are already available to this repo at the org level.

## Note

This takes effect on the next push to `main`. The existing #343 was created under the old token and still needs a one-off manual approval; the next release-please run will re-create/update it under nde-bot.
