### PR TITLE
fix: retry transient subject-URI resolution failures and exclude them from the ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,8 +503,24 @@ following redirects (ARK and Handle URIs are resolver links that redirect to an
 institutional landing page). A URI counts as resolved when the final response is
 `200`, is `text/html`, and the landing page advertises the original URI back to
 the user (raw or HTML-entity-escaped) – which matters precisely because we landed
-on a different, redirected URL. Dereferencing is throttled (≤ 4 concurrent),
-with no retries: a broken URI is one tick in a ratio.
+on a different, redirected URL. Dereferencing is throttled (≤ 4 concurrent).
+
+ARK/Handle resolution traverses a multi-hop global chain (`n2t.net → arks.org →
+institutional host → landing page`), so a single slow or briefly rate-limited hop
+must not be mistaken for a broken PID. Outcomes are therefore split in two:
+
+- **definitive** – a `4xx` such as `404`/`410`, a non-HTML body, or a `200` page
+  that does not advertise its URI: a genuine, dataset-attributable defect. Counted
+  against the ratio and [enumerated](#failed-samples) with its reason.
+- **transient** – a timeout, network error, or `429`/`5xx` (per-request budget
+  15 s): a blip in the resolver chain, not a property of the dataset. Retried with
+  exponential backoff (2 extra attempts); if still failing the URI is **excluded
+  from the sample entirely** – neither counted as a non-resolution nor persisted.
+  When *every* sampled URI is transiently unreachable, nothing is emitted and the
+  next run retries, rather than reporting a misleading `0/0`.
+
+So a network blip during a crawl can no longer report a healthy dataset as
+partially broken.
 
 The measurements hang off the namespace’s `void:subset` node (not the
 dataset, unlike IIIF), so the whole persistent-identifier story is reachable in
@@ -565,7 +581,7 @@ namespace.
 
 | Metric IRI | Type | Meaning |
 |---|---|---|
-| `…/metric#subject-uris-sampled` | `xsd:integer` | Number of subject URIs dereferenced – the denominator `N`, capped at the sample size (10). |
+| `…/metric#subject-uris-sampled` | `xsd:integer` | The denominator `N`: subject URIs that produced a *definitive* verdict (resolved or definitively broken), capped at the sample size (10). Transiently unreachable URIs are excluded, so `N` may be below the sample size. |
 | `…/metric#subject-uris-resolved` | `xsd:integer` | How many of the sampled URIs `k` resolved to a self-describing landing page. |
 
 Combining the chosen namespace, the optional scheme and org, and the resolved
@@ -706,7 +722,7 @@ The reason is a SKOS concept from the scheme matching the check:
 
 | Check | Scheme | Concepts |
 |---|---|---|
-| Subject-URI resolution | [`subject-resolution-failure`](https://def.nde.nl/subject-resolution-failure) | `timeout`, `network-error`, `http-error`, `wrong-content-type`, `no-self-reference` |
+| Subject-URI resolution | [`subject-resolution-failure`](https://def.nde.nl/subject-resolution-failure) | `http-error`, `wrong-content-type`, `no-self-reference` (the *definitive* reasons; the transient `timeout`, `network-error`, `server-error` are retried then excluded, so they are never persisted) |
 | IIIF manifest validation | [`manifest-validation-failure`](https://def.nde.nl/manifest-validation-failure) | `timeout`, `network-error`, `http-error`, `invalid-json`, `binary-content`, `not-a-manifest`, `does-not-load` |
 
 The `manifest-validation-failure` concept local names mirror the

--- a/README.md
+++ b/README.md
@@ -509,15 +509,20 @@ ARK/Handle resolution traverses a multi-hop global chain (`n2t.net → arks.org 
 institutional host → landing page`), so a single slow or briefly rate-limited hop
 must not be mistaken for a broken PID. Outcomes are therefore split in two:
 
-- **definitive** – a `4xx` such as `404`/`410`, a non-HTML body, or a `200` page
-  that does not advertise its URI: a genuine, dataset-attributable defect. Counted
-  against the ratio and [enumerated](#failed-samples) with its reason.
-- **transient** – a timeout, network error, or `429`/`5xx` (per-request budget
-  15 s): a blip in the resolver chain, not a property of the dataset. Retried with
-  exponential backoff (2 extra attempts); if still failing the URI is **excluded
-  from the sample entirely** – neither counted as a non-resolution nor persisted.
-  When *every* sampled URI is transiently unreachable, nothing is emitted and the
-  next run retries, rather than reporting a misleading `0/0`.
+- **definitive** – a non-retryable `4xx` such as `404`/`410`, a non-HTML body, or
+  a `200` page that does not advertise its URI: a genuine, dataset-attributable
+  defect. Counted against the ratio and [enumerated](#failed-samples) with its
+  reason.
+- **transient** – a timeout, network error, or a retryable HTTP status
+  (`408`/`425`/`429`/`5xx`) (per-request budget 15 s): a blip in the resolver
+  chain, not a property of the dataset. Retried with exponential backoff (2 extra
+  attempts); if still failing the URI is **excluded from the sample entirely** –
+  neither counted as a non-resolution nor persisted. When *every* sampled URI is
+  transiently unreachable, the sampled/resolved ratio is omitted (the next run
+  retries) rather than reporting a misleading `0/0`; the declared PID facts
+  (`dcterms:conformsTo`, `dcterms:publisher`), knowable from the namespace alone,
+  still emit. A whole-sample budget (60 s) caps the retry storm so a flaky
+  resolver cannot stall the run.
 
 So a network blip during a crawl can no longer report a healthy dataset as
 partially broken.

--- a/src/subjectUriResolution.ts
+++ b/src/subjectUriResolution.ts
@@ -57,13 +57,39 @@ const SUBJECT_RESOLUTION_FAILURE_BASE =
  * Why a sampled subject URI did not resolve to a self-describing landing page.
  * Mirrors the `subject-resolution-failure` concept scheme; a `null` outcome
  * (resolved) is represented out-of-band.
+ *
+ * Outcomes split into two classes (see {@link isTransientFailure}):
+ * - **definitive** — `http-error` (a non-retryable `4xx` such as `404`/`410`),
+ *   `wrong-content-type`, `no-self-reference`: a genuine, dataset-attributable
+ *   defect. Counted against the ratio and persisted in the PROV trail.
+ * - **transient** — `timeout`, `network-error`, `server-error` (`429`/`5xx`): a
+ *   blip in the multi-hop PID-resolver chain, not a property of the dataset.
+ *   Retried with backoff; if still failing it is excluded from the sample
+ *   entirely (neither counted nor persisted).
  */
 export type SubjectResolutionFailure =
   | 'timeout'
   | 'network-error'
+  | 'server-error'
   | 'http-error'
   | 'wrong-content-type'
   | 'no-self-reference';
+
+/**
+ * Transient failures: a slow or briefly unavailable hop in the resolver chain,
+ * not a broken PID. Retried, then excluded from the denominator rather than
+ * scored as a non-resolution — so a single network blip during a crawl cannot
+ * report a healthy dataset as partially broken.
+ */
+const TRANSIENT_FAILURES: ReadonlySet<SubjectResolutionFailure> = new Set([
+  'timeout',
+  'network-error',
+  'server-error',
+]);
+
+function isTransientFailure(reason: SubjectResolutionFailure): boolean {
+  return TRANSIENT_FAILURES.has(reason);
+}
 
 /** Map a failure reason to its `subject-resolution-failure#` concept IRI. */
 function subjectResolutionFailureIri(reason: SubjectResolutionFailure) {
@@ -135,8 +161,31 @@ const DEFAULT_CONCURRENCY = 4;
  */
 const SAMPLE_TIMEOUT_MS = 60_000;
 
-/** Per-request budget for dereferencing a sampled URI and the arks.org lookup. */
-const DEREFERENCE_TIMEOUT_MS = 10_000;
+/**
+ * Per-request budget for dereferencing a sampled URI and the arks.org lookup.
+ * Kept generous because ARK/Handle resolution traverses a multi-hop global
+ * chain (`n2t.net → arks.org → institutional host → landing page`); a single
+ * slow or briefly rate-limited hop must not trip a false non-resolution.
+ */
+const DEREFERENCE_TIMEOUT_MS = 15_000;
+
+/**
+ * Extra attempts for a transient dereference failure before giving up. Combined
+ * with {@link retryDelay}, the effective budget for a flaky resolver chain
+ * spans several timeouts, not one.
+ */
+const DEFAULT_RETRIES = 2;
+
+/** Exponential backoff before retry attempt `attempt` (0-based): 500 ms, 1 s, … */
+function retryDelay(attempt: number): number {
+  return 500 * 2 ** attempt;
+}
+
+/** Injectable sleep so tests drive the retry loop without real delays. */
+export type Sleep = (milliseconds: number) => Promise<void>;
+
+const defaultSleep: Sleep = milliseconds =>
+  new Promise(resolve => setTimeout(resolve, milliseconds));
 
 /** Samples up to `sampleSize` distinct subject IRIs from `uriSpace`. */
 export type SampleUris = (
@@ -173,6 +222,10 @@ export interface SubjectUriResolutionOptions {
   sampleUris?: SampleUris;
   /** Resolution check. Injectable for testing; defaults to an HTTP fetch. */
   resolve?: ResolveUri;
+  /** Extra attempts for a transient failure before giving up. @default 2 */
+  retries?: number;
+  /** Backoff between retries. Injectable for testing; defaults to real delays. */
+  sleep?: Sleep;
   /** ARK organisation lookup. Injectable for testing; defaults to arks.org. */
   lookupOrg?: LookupOrg;
   /**
@@ -216,6 +269,8 @@ export function subjectUriResolution(
   const concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
   const sampleUris = options.sampleUris ?? defaultSampleUris;
   const resolve = options.resolve ?? defaultResolve;
+  const retries = options.retries ?? DEFAULT_RETRIES;
+  const sleep = options.sleep ?? defaultSleep;
   const lookupOrg = options.lookupOrg ?? defaultLookupOrg;
   const software = options.software
     ? namedNode(options.software)
@@ -260,29 +315,39 @@ export function subjectUriResolution(
         distribution,
       });
       const limit = pLimit(concurrency);
-      const outcomes = await Promise.allSettled(
-        sampled.map(uri => limit(() => resolve(uri))),
+      const outcomes = await Promise.all(
+        sampled.map(uri =>
+          limit(() => resolveWithRetry(uri, resolve, retries, sleep)),
+        ),
       );
 
-      // Pair each sampled URI with its settled outcome: a `null` classification
-      // counts as resolved, any reason becomes a persisted failure. An
-      // unexpected rejection is mapped defensively to `network-error` so the URI
-      // still surfaces rather than vanishing from both the count and the trail.
+      // Classify each settled outcome. A `null` resolves; a *definitive* reason
+      // is a real defect — counted and persisted. A *transient* reason survived
+      // every retry, so the resolver chain (not the dataset) is at fault: drop
+      // the URI from the sample entirely rather than scoring it as broken.
       let resolved = 0;
+      let measurable = 0;
       const failures: SampleFailure[] = [];
       sampled.forEach((uri, index) => {
-        const outcome = outcomes[index];
-        const reason: SubjectResolutionFailure | null =
-          outcome.status === 'fulfilled' ? outcome.value : 'network-error';
+        const reason = outcomes[index];
         if (reason === null) {
           resolved++;
-        } else {
+          measurable++;
+        } else if (!isTransientFailure(reason)) {
+          measurable++;
           failures.push({
             url: uri,
             reasonIri: subjectResolutionFailureIri(reason),
           });
         }
       });
+
+      // Every sampled URI was transiently unreachable: we could not measure this
+      // namespace this run. Emit nothing extra (the next run retries) rather
+      // than reporting a misleading 0/0 the diagnostic queries would misread.
+      if (measurable === 0) {
+        return;
+      }
 
       const scheme = detectPidScheme(winner.uriSpace);
       const org =
@@ -293,7 +358,7 @@ export function subjectUriResolution(
       measurements = [
         ...measurementQuads(
           namedNode(winner.subset),
-          sampled.length,
+          measurable,
           resolved,
           failures,
           scheme,
@@ -307,6 +372,38 @@ export function subjectUriResolution(
 
     yield* measurements;
   };
+}
+
+/**
+ * Resolve a URI, retrying a {@link isTransientFailure transient} outcome with
+ * exponential backoff up to `retries` times. Returns the final outcome: `null`
+ * (resolved), a definitive failure, or — once retries are exhausted — the last
+ * transient failure. An unexpected rejection from `resolve` is treated as a
+ * transient `network-error`, so a flaky check is retried rather than surfacing a
+ * stray non-resolution.
+ */
+async function resolveWithRetry(
+  uri: string,
+  resolve: ResolveUri,
+  retries: number,
+  sleep: Sleep,
+): Promise<SubjectResolutionFailure | null> {
+  let outcome: SubjectResolutionFailure | null;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      outcome = await resolve(uri);
+    } catch {
+      outcome = 'network-error';
+    }
+    if (
+      outcome === null ||
+      !isTransientFailure(outcome) ||
+      attempt >= retries
+    ) {
+      return outcome;
+    }
+    await sleep(retryDelay(attempt));
+  }
 }
 
 /** Pick the subset with the most entities whose namespace is not a terminology source. */
@@ -542,7 +639,7 @@ const defaultResolve: ResolveUri = async uri => {
   } catch (error) {
     return classifyFetchError(error);
   }
-  if (!response.ok) return 'http-error';
+  if (!response.ok) return classifyHttpStatus(response.status);
   if (!(response.headers.get('content-type') ?? '').includes('text/html')) {
     return 'wrong-content-type';
   }
@@ -568,6 +665,15 @@ function classifyFetchError(error: unknown): SubjectResolutionFailure {
   return name === 'TimeoutError' || name === 'AbortError'
     ? 'timeout'
     : 'network-error';
+}
+
+/**
+ * Split a non-2xx status into a transient `server-error` (`429` Too Many
+ * Requests or any `5xx` — the server says “try later”) and a definitive
+ * `http-error` (a `4xx` such as `404`/`410` — the resource is genuinely gone).
+ */
+function classifyHttpStatus(status: number): SubjectResolutionFailure {
+  return status === 429 || status >= 500 ? 'server-error' : 'http-error';
 }
 
 /**

--- a/src/subjectUriResolution.ts
+++ b/src/subjectUriResolution.ts
@@ -62,8 +62,9 @@ const SUBJECT_RESOLUTION_FAILURE_BASE =
  * - **definitive** — `http-error` (a non-retryable `4xx` such as `404`/`410`),
  *   `wrong-content-type`, `no-self-reference`: a genuine, dataset-attributable
  *   defect. Counted against the ratio and persisted in the PROV trail.
- * - **transient** — `timeout`, `network-error`, `server-error` (`429`/`5xx`): a
- *   blip in the multi-hop PID-resolver chain, not a property of the dataset.
+ * - **transient** — `timeout`, `network-error`, `server-error` (a retryable HTTP
+ *   status: `408`/`425`/`429`/`5xx`): a blip in the multi-hop PID-resolver
+ *   chain, not a property of the dataset.
  *   Retried with backoff; if still failing it is excluded from the sample
  *   entirely (neither counted nor persisted).
  */
@@ -176,6 +177,15 @@ const DEREFERENCE_TIMEOUT_MS = 15_000;
  */
 const DEFAULT_RETRIES = 2;
 
+/**
+ * Overall wall-clock budget for dereferencing the whole sample, independent of
+ * the per-request {@link DEREFERENCE_TIMEOUT_MS}. Caps a flaky namespace’s retry
+ * storm: once it elapses, in-flight fetches abort and no further retries are
+ * scheduled, so the transform — which runs outside the Pipeline’s adaptive
+ * timeout — cannot stall the run for minutes.
+ */
+const DEREFERENCE_PHASE_BUDGET_MS = 60_000;
+
 /** Exponential backoff before retry attempt `attempt` (0-based): 500 ms, 1 s, … */
 function retryDelay(attempt: number): number {
   return 500 * 2 ** attempt;
@@ -198,10 +208,14 @@ export type SampleUris = (
  * Resolves a sampled URI and classifies the outcome: `null` when it lands on a
  * self-describing page (a `200`, `text/html` response whose body advertises the
  * original URI), otherwise the {@link SubjectResolutionFailure} describing why
- * it did not.
+ * it did not. The optional `signal` carries the overall
+ * {@link DEREFERENCE_PHASE_BUDGET_MS phase budget}; honour it on the underlying
+ * request so a flaky chain aborts rather than running its full per-request
+ * timeout once the budget is spent.
  */
 export type ResolveUri = (
   uri: string,
+  signal?: AbortSignal,
 ) => Promise<SubjectResolutionFailure | null>;
 
 /** Looks up the issuing organisation’s name for an ARK NAAN, if available. */
@@ -315,9 +329,14 @@ export function subjectUriResolution(
         distribution,
       });
       const limit = pLimit(concurrency);
+      // One budget shared across every dereference: once it elapses, in-flight
+      // fetches abort and resolveWithRetry stops scheduling retries.
+      const phaseSignal = AbortSignal.timeout(DEREFERENCE_PHASE_BUDGET_MS);
       const outcomes = await Promise.all(
         sampled.map(uri =>
-          limit(() => resolveWithRetry(uri, resolve, retries, sleep)),
+          limit(() =>
+            resolveWithRetry(uri, resolve, retries, sleep, phaseSignal),
+          ),
         ),
       );
 
@@ -326,46 +345,48 @@ export function subjectUriResolution(
       // every retry, so the resolver chain (not the dataset) is at fault: drop
       // the URI from the sample entirely rather than scoring it as broken.
       let resolved = 0;
-      let measurable = 0;
       const failures: SampleFailure[] = [];
       sampled.forEach((uri, index) => {
         const reason = outcomes[index];
         if (reason === null) {
           resolved++;
-          measurable++;
         } else if (!isTransientFailure(reason)) {
-          measurable++;
           failures.push({
             url: uri,
             reasonIri: subjectResolutionFailureIri(reason),
           });
         }
       });
+      // The denominator counts only definitively-judged URIs; transient ones are
+      // excluded from both branches above.
+      const measurable = resolved + failures.length;
 
-      // Every sampled URI was transiently unreachable: we could not measure this
-      // namespace this run. Emit nothing extra (the next run retries) rather
-      // than reporting a misleading 0/0 the diagnostic queries would misread.
-      if (measurable === 0) {
-        return;
-      }
-
+      const subset = namedNode(winner.subset);
       const scheme = detectPidScheme(winner.uriSpace);
       const org =
         scheme === 'ark'
           ? await lookupArkOrg(winner.uriSpace, lookupOrg)
           : undefined;
 
-      measurements = [
-        ...measurementQuads(
-          namedNode(winner.subset),
-          measurable,
-          resolved,
-          failures,
-          scheme,
-          org,
-          software,
-        ),
-      ];
+      // Declared facts (PID scheme, issuing org) are knowable from the namespace
+      // alone, so they are emitted even when nothing was measurable this run —
+      // either an empty sample or every URI transiently unreachable. The
+      // sampled/resolved ratio is appended only when there is something to
+      // report, so the diagnostic queries never see a misleading 0/0.
+      const declared = [...declaredFactQuads(subset, scheme, org)];
+      measurements =
+        measurable === 0
+          ? declared
+          : [
+              ...declared,
+              ...measurementQuads(
+                subset,
+                measurable,
+                resolved,
+                failures,
+                software,
+              ),
+            ];
     } catch {
       return;
     }
@@ -380,25 +401,28 @@ export function subjectUriResolution(
  * (resolved), a definitive failure, or — once retries are exhausted — the last
  * transient failure. An unexpected rejection from `resolve` is treated as a
  * transient `network-error`, so a flaky check is retried rather than surfacing a
- * stray non-resolution.
+ * stray non-resolution. Stops early once `signal` (the overall phase budget)
+ * aborts, so a flaky chain cannot keep retrying past the run’s budget.
  */
 async function resolveWithRetry(
   uri: string,
   resolve: ResolveUri,
   retries: number,
   sleep: Sleep,
+  signal: AbortSignal,
 ): Promise<SubjectResolutionFailure | null> {
   let outcome: SubjectResolutionFailure | null;
   for (let attempt = 0; ; attempt++) {
     try {
-      outcome = await resolve(uri);
+      outcome = await resolve(uri, signal);
     } catch {
       outcome = 'network-error';
     }
     if (
       outcome === null ||
       !isTransientFailure(outcome) ||
-      attempt >= retries
+      attempt >= retries ||
+      signal.aborted
     ) {
       return outcome;
     }
@@ -471,23 +495,33 @@ async function lookupArkOrg(
   }
 }
 
-function* measurementQuads(
+/**
+ * Declared facts about the namespace, knowable from the namespace string alone
+ * and independent of whether the sample resolved: `dcterms:conformsTo` a PID
+ * scheme (only when recognised) and the ARK issuing org as `dcterms:publisher`.
+ * Emitted even when nothing was measurable, so they survive an empty sample or a
+ * fully-unreachable resolver chain.
+ */
+function* declaredFactQuads(
   subset: ReturnType<typeof namedNode>,
-  sampled: number,
-  resolved: number,
-  failures: readonly SampleFailure[],
   scheme: PidScheme | undefined,
   org: string | undefined,
-  software: ReturnType<typeof namedNode>,
 ): Generator<Quad> {
-  // Declared facts — only for a recognised PID scheme.
   if (scheme !== undefined) {
     yield quad(subset, DCTERMS_CONFORMS_TO, PID_SCHEMES[scheme]);
   }
   if (org !== undefined) {
     yield quad(subset, DCTERMS_PUBLISHER, literal(org));
   }
+}
 
+function* measurementQuads(
+  subset: ReturnType<typeof namedNode>,
+  sampled: number,
+  resolved: number,
+  failures: readonly SampleFailure[],
+  software: ReturnType<typeof namedNode>,
+): Generator<Quad> {
   // PROV: the sampling/dereferencing activity, with a qualified usage per
   // failed sample naming the URI and why it did not resolve.
   const activity = blankNode();
@@ -628,13 +662,17 @@ const defaultSampleUris: SampleUris = async (
  * because we landed on a different, redirected URL. Returns `null` on success,
  * otherwise the {@link SubjectResolutionFailure} classifying the breakage.
  */
-const defaultResolve: ResolveUri = async uri => {
+const defaultResolve: ResolveUri = async (uri, signal) => {
+  // The request aborts on whichever fires first: its own per-request timeout or
+  // the overall phase budget carried by `signal`.
+  const timeout = AbortSignal.timeout(DEREFERENCE_TIMEOUT_MS);
+  const abort = signal ? AbortSignal.any([timeout, signal]) : timeout;
   let response: Response;
   try {
     response = await fetch(uri, {
       redirect: 'follow',
       headers: {accept: 'text/html'},
-      signal: AbortSignal.timeout(DEREFERENCE_TIMEOUT_MS),
+      signal: abort,
     });
   } catch (error) {
     return classifyFetchError(error);
@@ -668,12 +706,21 @@ function classifyFetchError(error: unknown): SubjectResolutionFailure {
 }
 
 /**
- * Split a non-2xx status into a transient `server-error` (`429` Too Many
- * Requests or any `5xx` — the server says “try later”) and a definitive
- * `http-error` (a `4xx` such as `404`/`410` — the resource is genuinely gone).
+ * Status codes that signal a temporary condition the resolver chain may recover
+ * from: `408` Request Timeout, `425` Too Early, `429` Too Many Requests, and any
+ * `5xx`. Everything else non-2xx (a `4xx` such as `404`/`410`) is definitive.
+ */
+const TRANSIENT_HTTP_STATUSES: ReadonlySet<number> = new Set([408, 425, 429]);
+
+/**
+ * Split a non-2xx status into a transient `server-error` (the server says “try
+ * later”; see {@link TRANSIENT_HTTP_STATUSES}) and a definitive `http-error`
+ * (the resource is genuinely gone).
  */
 function classifyHttpStatus(status: number): SubjectResolutionFailure {
-  return status === 429 || status >= 500 ? 'server-error' : 'http-error';
+  return TRANSIENT_HTTP_STATUSES.has(status) || status >= 500
+    ? 'server-error'
+    : 'http-error';
 }
 
 /**

--- a/test/subjectUriResolution.test.ts
+++ b/test/subjectUriResolution.test.ts
@@ -425,6 +425,53 @@ describe('subjectUriResolution', () => {
     );
   });
 
+  it('still declares the PID scheme when every sample is transiently unreachable', async () => {
+    // An ARK namespace whose resolver chain is down this run: the declared
+    // conformance fact is knowable from the namespace alone, so it survives even
+    // though no ratio can be measured.
+    const ns = subset('https://n2t.net/ark:/60537/', 312000);
+    const transform = subjectUriResolution({
+      terminologyPrefixes: [],
+      sampleUris: sampleFixed(['https://n2t.net/ark:/60537/a']),
+      resolve: async () => 'timeout',
+      lookupOrg: noOrg,
+      sleep: async () => {},
+    });
+
+    const out = await collect(transform(stream(ns.quads), context));
+
+    expect(
+      out.some(
+        q =>
+          q.predicate.equals(DCTERMS_CONFORMS_TO) &&
+          q.object.equals(ARK_SCHEME),
+      ),
+    ).toBe(true);
+    // ...but no sampled/resolved ratio, which would be a misleading 0/0.
+    expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBeUndefined();
+  });
+
+  it('still declares the PID scheme when the sample is empty', async () => {
+    const ns = subset('https://n2t.net/ark:/60537/', 312000);
+    const transform = subjectUriResolution({
+      terminologyPrefixes: [],
+      sampleUris: sampleFixed([]),
+      resolve: resolveByName,
+      lookupOrg: noOrg,
+    });
+
+    const out = await collect(transform(stream(ns.quads), context));
+
+    expect(
+      out.some(
+        q =>
+          q.predicate.equals(DCTERMS_CONFORMS_TO) &&
+          q.object.equals(ARK_SCHEME),
+      ),
+    ).toBe(true);
+    expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBeUndefined();
+  });
+
   it('keeps the VoID output when sampling fails', async () => {
     const ns = subset('http://example.org/id/', 10);
     const transform = subjectUriResolution({
@@ -710,6 +757,17 @@ describe('subjectUriResolution', () => {
       const ns = subset('http://example.org/id/', 10);
       const out = await runWithFetch(
         async () => new Response('', {status: 503}),
+      );
+      expect(failureReasonFor(out, URI)).toBeUndefined();
+      expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBeUndefined();
+    });
+
+    it('excludes a persistent 408 Request Timeout as a transient blip', async () => {
+      // A 408 is a transient 4xx — a proxy cutting a slow upstream — so it must
+      // be retried and excluded, not scored as a definitive non-resolution.
+      const ns = subset('http://example.org/id/', 10);
+      const out = await runWithFetch(
+        async () => new Response('', {status: 408}),
       );
       expect(failureReasonFor(out, URI)).toBeUndefined();
       expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBeUndefined();

--- a/test/subjectUriResolution.test.ts
+++ b/test/subjectUriResolution.test.ts
@@ -324,7 +324,7 @@ describe('subjectUriResolution', () => {
     expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBe(1);
   });
 
-  it('counts a resolution that throws as unresolved and surfaces it as network-error', async () => {
+  it('excludes a persistently throwing resolution as a transient blip', async () => {
     const ns = subset('http://example.org/id/', 10);
     const transform = subjectUriResolution({
       terminologyPrefixes: [],
@@ -336,15 +336,92 @@ describe('subjectUriResolution', () => {
         if (uri.includes('throws')) throw new Error('boom');
         return null;
       },
+      sleep: async () => {},
     });
 
     const out = await collect(transform(stream(ns.quads), context));
 
-    expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBe(2);
+    // The rejection is treated as a transient network-error: retried, then
+    // dropped from the denominator rather than dragging the ratio down.
+    expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBe(1);
     expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
-    // The rejected URI still surfaces, classified defensively.
-    expect(failureReasonFor(out, 'http://example.org/id/throws')).toBe(
-      `${SUBJECT_RESOLUTION_FAILURE_BASE}network-error`,
+    expect(
+      failureReasonFor(out, 'http://example.org/id/throws'),
+    ).toBeUndefined();
+  });
+
+  it('retries a transient failure and counts the eventual success', async () => {
+    const ns = subset('http://example.org/id/', 10);
+    let attempts = 0;
+    const transform = subjectUriResolution({
+      terminologyPrefixes: [],
+      sampleUris: sampleFixed(['http://example.org/id/flaky']),
+      // Times out once, then resolves — exactly the crawl-time blip the retry
+      // exists to absorb.
+      resolve: async () => (attempts++ === 0 ? 'timeout' : null),
+      sleep: async () => {},
+    });
+
+    const out = await collect(transform(stream(ns.quads), context));
+
+    expect(attempts).toBe(2);
+    expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBe(1);
+    expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
+  });
+
+  it('counts definitive failures while excluding transient ones (Chabot case)', async () => {
+    // A healthy ARK dataset where one sample blips transiently and another is
+    // genuinely broken: the blip is dropped, the broken one is scored.
+    const ns = subset('https://n2t.net/ark:/89268/', 1156);
+    const transform = subjectUriResolution({
+      terminologyPrefixes: [],
+      sampleUris: sampleFixed([
+        'https://n2t.net/ark:/89268/good-1',
+        'https://n2t.net/ark:/89268/good-2',
+        'https://n2t.net/ark:/89268/blip-3',
+        'https://n2t.net/ark:/89268/gone-4',
+      ]),
+      resolve: async uri => {
+        if (uri.includes('good')) return null;
+        if (uri.includes('blip')) return 'timeout'; // transient, survives retries
+        return 'no-self-reference'; // definitive
+      },
+      lookupOrg: noOrg,
+      sleep: async () => {},
+    });
+
+    const out = await collect(transform(stream(ns.quads), context));
+
+    // 3 measurable (2 resolved + 1 definitive failure); the transient blip is
+    // excluded from the denominator entirely.
+    expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBe(3);
+    expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(2);
+    expect(failureReasonFor(out, 'https://n2t.net/ark:/89268/gone-4')).toBe(
+      `${SUBJECT_RESOLUTION_FAILURE_BASE}no-self-reference`,
+    );
+    expect(
+      failureReasonFor(out, 'https://n2t.net/ark:/89268/blip-3'),
+    ).toBeUndefined();
+  });
+
+  it('emits no ratio when every sample is transiently unreachable', async () => {
+    const ns = subset('http://example.org/id/', 10);
+    const transform = subjectUriResolution({
+      terminologyPrefixes: [],
+      sampleUris: sampleFixed([
+        'http://example.org/id/a',
+        'http://example.org/id/b',
+      ]),
+      resolve: async () => 'timeout',
+      sleep: async () => {},
+    });
+
+    const out = await collect(transform(stream(ns.quads), context));
+
+    // Nothing measurable this run: the subsets pass through, no ratio emitted.
+    expect(out).toHaveLength(ns.quads.length);
+    expect(out.some(q => q.predicate.equals(DQV_HAS_QUALITY_MEASUREMENT))).toBe(
+      false,
     );
   });
 
@@ -585,13 +662,17 @@ describe('subjectUriResolution', () => {
 
     const URI = 'http://example.org/id/x';
 
-    /** Drive the default resolve (no injected `resolve`) over a single URI. */
+    /**
+     * Drive the default resolve (no injected `resolve`) over a single URI. A
+     * no-op `sleep` keeps the transient-retry backoff from adding real delays.
+     */
     async function runWithFetch(fetchImpl: typeof fetch): Promise<Quad[]> {
       vi.stubGlobal('fetch', vi.fn(fetchImpl));
       const ns = subset('http://example.org/id/', 10);
       const transform = subjectUriResolution({
         terminologyPrefixes: [],
         sampleUris: sampleFixed([URI]),
+        sleep: async () => {},
       });
       return collect(transform(stream(ns.quads), context));
     }
@@ -603,33 +684,47 @@ describe('subjectUriResolution', () => {
       });
     }
 
-    it('classifies an unreachable host as network-error', async () => {
+    it('excludes a persistently unreachable host as a transient blip', async () => {
+      const ns = subset('http://example.org/id/', 10);
       const out = await runWithFetch(async () => {
         throw new Error('ECONNREFUSED');
       });
-      expect(failureReasonFor(out, URI)).toBe(
-        `${SUBJECT_RESOLUTION_FAILURE_BASE}network-error`,
-      );
+      // A network error is transient: retried, then dropped from the sample
+      // entirely rather than scored as a non-resolution.
+      expect(failureReasonFor(out, URI)).toBeUndefined();
+      expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBeUndefined();
     });
 
-    it('classifies an abort/timeout as timeout', async () => {
+    it('excludes a persistent abort/timeout as a transient blip', async () => {
+      const ns = subset('http://example.org/id/', 10);
       const out = await runWithFetch(async () => {
         const error = new Error('aborted');
         error.name = 'TimeoutError';
         throw error;
       });
-      expect(failureReasonFor(out, URI)).toBe(
-        `${SUBJECT_RESOLUTION_FAILURE_BASE}timeout`,
-      );
+      expect(failureReasonFor(out, URI)).toBeUndefined();
+      expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBeUndefined();
     });
 
-    it('classifies a non-2xx response as http-error', async () => {
+    it('excludes a persistent 5xx as a transient blip', async () => {
+      const ns = subset('http://example.org/id/', 10);
+      const out = await runWithFetch(
+        async () => new Response('', {status: 503}),
+      );
+      expect(failureReasonFor(out, URI)).toBeUndefined();
+      expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBeUndefined();
+    });
+
+    it('classifies a definitive non-2xx response as http-error', async () => {
+      const ns = subset('http://example.org/id/', 10);
       const out = await runWithFetch(
         async () => new Response('', {status: 404}),
       );
+      // A 404 is definitive: counted against the ratio and persisted.
       expect(failureReasonFor(out, URI)).toBe(
         `${SUBJECT_RESOLUTION_FAILURE_BASE}http-error`,
       );
+      expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBe(1);
     });
 
     it('classifies a non-HTML content type as wrong-content-type', async () => {
@@ -654,7 +749,8 @@ describe('subjectUriResolution', () => {
       );
     });
 
-    it('classifies an unreadable body as network-error', async () => {
+    it('excludes an unreadable body as a transient blip', async () => {
+      const ns = subset('http://example.org/id/', 10);
       const out = await runWithFetch(
         async () =>
           ({
@@ -665,9 +761,10 @@ describe('subjectUriResolution', () => {
             },
           }) as unknown as Response,
       );
-      expect(failureReasonFor(out, URI)).toBe(
-        `${SUBJECT_RESOLUTION_FAILURE_BASE}network-error`,
-      );
+      // A `200 text/html` whose body cannot be read is a transport failure
+      // (network-error): retried, then excluded rather than scored.
+      expect(failureReasonFor(out, URI)).toBeUndefined();
+      expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBeUndefined();
     });
 
     it('reports a resolving, self-referencing page as resolved', async () => {


### PR DESCRIPTION
## Problem

The subject-URI resolution check produced **false negatives for ARK datasets** because it counted a transient fetch failure as a non-resolving URI. With no retries, a 10 s per-request timeout and a sample size of 10, a single network blip during a crawl could report a healthy dataset as 60–80% resolving and keep that score until the next run.

ARK/Handle resolution traverses a multi-hop global chain (`n2t.net → arks.org → institutional host → landing page`), so any slow or briefly rate-limited hop tripped the timeout and was scored as a broken PID.

## Changes

- **Classify outcomes** as *definitive* (`http-error` for `404`/`410`/other `4xx`, `wrong-content-type`, `no-self-reference`) or *transient* (`timeout`, `network-error`, and a new `server-error` for `429`/`5xx`).
- **Retry** transient outcomes with exponential backoff (2 extra attempts) before giving up. Unexpected `resolve` rejections fold into a transient `network-error` and are retried too.
- **Exclude** surviving transient failures from the `subject-uris-sampled` denominator and from the PROV failure trail, rather than scoring them as non-resolutions — so the contract "every persisted `failure:reason` is a real defect" still holds. When *every* sample is transiently unreachable, no ratio is emitted (the next run retries) instead of a misleading `0/0`.
- **Raise** the per-request dereference timeout from `10 s` to `15 s` for multi-hop resolver chains.
- Add injectable `retries` and `sleep` options so tests drive the retry loop without real delays.
- Update the README and the docs-repo chapter accordingly.

## Acceptance

- A Chabot-style case (sample with one transient blip + one genuine failure) now reports `subject-uris-sampled == subject-uris-resolved + definitive failures`, with the blip excluded — covered by a new test.
- A genuine `no-self-reference` shortfall (the Haags case) is still counted as a real failure.

Fix #339
