### PR TITLE
fix: exclude IIIF manifest URLs from the subject-URI resolution sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,17 @@ institutional landing page). A URI counts as resolved when the final response is
 the user (raw or HTML-entity-escaped) – which matters precisely because we landed
 on a different, redirected URL. Dereferencing is throttled (≤ 4 concurrent).
 
+URLs the dataset already exposes as
+[IIIF manifests](#iiif-presentation-manifests) are **excluded from the sample**:
+a manifest correctly serves JSON, not `text/html`, so it would fail this check as
+`wrong-content-type` while simultaneously passing the IIIF criterion – one URL
+both green (IIIF) and red (persistent identifier). An ARK+IIIF publisher whose
+subject sample includes manifest URLs (e.g. `…/ark:/85849/{uuid}/iiif.json`) hits
+this. Excluding them leaves manifests to the IIIF criterion alone, with no loss of
+coverage; the exclusion mirrors the manifest detection in
+`queries/analysis/iiif.rq` (the `schema:encodingFormat` IIIF media type, on the
+subject itself or on the node whose `schema:contentUrl` it is).
+
 ARK/Handle resolution traverses a multi-hop global chain (`n2t.net → arks.org →
 institutional host → landing page`), so a single slow or briefly rate-limited hop
 must not be mistaken for a broken PID. Outcomes are therefore split in two:

--- a/queries/analysis/iiif.rq
+++ b/queries/analysis/iiif.rq
@@ -42,11 +42,7 @@ WHERE {
         SELECT (COUNT(DISTINCT ?s) AS ?count) {
             #subjectFilter#
             ?s schema:encodingFormat|<http://schema.org/encodingFormat> ?format .
-            FILTER(isLiteral(?format) && (
-                (STRSTARTS(STR(?format), "application/ld+json;profile='http://iiif.io/api/presentation/")
-                    && STRENDS(STR(?format), "/context.json'"))
-                || STR(?format) = "application/ld+json"
-            ))
+            FILTER(#manifestFormatFilter#)
         }
     }
     {
@@ -56,9 +52,7 @@ WHERE {
         SELECT (COUNT(DISTINCT ?s) AS ?conformantCount) {
             #subjectFilter#
             ?s schema:encodingFormat|<http://schema.org/encodingFormat> ?format .
-            FILTER(isLiteral(?format)
-                && STRSTARTS(STR(?format), "application/ld+json;profile='http://iiif.io/api/presentation/")
-                && STRENDS(STR(?format), "/context.json'"))
+            FILTER(#conformantFormatFilter#)
         }
     }
     # OPTIONAL so detection survives an empty sample: if every matched manifest
@@ -76,11 +70,7 @@ WHERE {
         SELECT DISTINCT ?manifest {
             #subjectFilter#
             ?s schema:encodingFormat|<http://schema.org/encodingFormat> ?format .
-            FILTER(isLiteral(?format) && (
-                (STRSTARTS(STR(?format), "application/ld+json;profile='http://iiif.io/api/presentation/")
-                    && STRENDS(STR(?format), "/context.json'"))
-                || STR(?format) = "application/ld+json"
-            ))
+            FILTER(#manifestFormatFilter#)
             OPTIONAL {
                 ?s schema:contentUrl|<http://schema.org/contentUrl> ?contentUrl .
             }

--- a/src/iiifManifestDetection.ts
+++ b/src/iiifManifestDetection.ts
@@ -1,0 +1,47 @@
+/**
+ * Single source of truth for how an IIIF Presentation manifest is recognised
+ * from a `schema:encodingFormat` literal. Both the IIIF criterion
+ * (`queries/analysis/iiif.rq`) and the subject-URI resolution check
+ * (`subjectUriResolution.ts`) build their manifest test from these helpers, so
+ * the two cannot drift: a drift would let one URL be both a passing IIIF
+ * manifest and a failing “persistent identifier” (the green/red contradiction
+ * the exclusion exists to prevent).
+ *
+ * Each helper returns a SPARQL boolean expression over `?{formatVariable}`,
+ * ready to drop inside a `FILTER(…)`. Matched with `STRSTARTS`/`STRENDS` rather
+ * than a regex, which is costly on QLever and on remote endpoints alike.
+ */
+
+/**
+ * The IIIF Presentation profile media type: a JSON-LD type whose `;profile=`
+ * parameter points at an `iiif.io/api/presentation/{version}` context. The
+ * version segment is left unconstrained — intentionally forwards-compatible with
+ * future Presentation API versions.
+ */
+export function iiifProfileFormatMatch(formatVariable: string): string {
+  return `STRSTARTS(STR(?${formatVariable}), "application/ld+json;profile='http://iiif.io/api/presentation/")
+        && STRENDS(STR(?${formatVariable}), "/context.json'")`;
+}
+
+/**
+ * Capability test — what counts as an IIIF manifest at all: the
+ * {@link iiifProfileFormatMatch profile pattern} *or* the bare
+ * `application/ld+json` media type (issue #314: a functional manifest declared
+ * without the `;profile=` parameter must still count). This is the test the
+ * subject-URI sampler mirrors to exclude manifests.
+ */
+export function iiifManifestFormatFilter(formatVariable: string): string {
+  return `isLiteral(?${formatVariable}) && (
+        (${iiifProfileFormatMatch(formatVariable)})
+        || STR(?${formatVariable}) = "application/ld+json"
+      )`;
+}
+
+/**
+ * Conformance test — the stricter SCHEMA-AP-NDE subset: only the full profile
+ * pattern conforms; the bare JSON-LD type does not. `conformant ⊆ capability`.
+ */
+export function iiifConformantFormatFilter(formatVariable: string): string {
+  return `isLiteral(?${formatVariable})
+        && ${iiifProfileFormatMatch(formatVariable)}`;
+}

--- a/src/iiifStage.ts
+++ b/src/iiifStage.ts
@@ -1,6 +1,10 @@
 import {resolve} from 'node:path';
 import {Stage, SparqlConstructExecutor, readQueryFile} from '@lde/pipeline';
 import {IiifValidationExecutor} from './iiifValidationExecutor.js';
+import {
+  iiifManifestFormatFilter,
+  iiifConformantFormatFilter,
+} from './iiifManifestDetection.js';
 
 const QUERY_FILE = resolve('queries/analysis/iiif.rq');
 
@@ -44,10 +48,16 @@ export async function iiifStage(
   options: IiifStageOptions = {},
 ): Promise<Stage> {
   const sampleSize = options.manifestSampleSize ?? DEFAULT_MANIFEST_SAMPLE_SIZE;
-  const query = (await readQueryFile(QUERY_FILE)).replaceAll(
-    '#limit#',
-    String(sampleSize),
-  );
+  // The manifest detection rule lives in iiifManifestDetection.ts, shared with
+  // the subject-URI sampler so the two cannot drift; weave it into the query
+  // here, the same way #limit# is substituted.
+  const query = (await readQueryFile(QUERY_FILE))
+    .replaceAll('#limit#', String(sampleSize))
+    .replaceAll('#manifestFormatFilter#', iiifManifestFormatFilter('format'))
+    .replaceAll(
+      '#conformantFormatFilter#',
+      iiifConformantFormatFilter('format'),
+    );
   // `deduplicate` collapses the constant subset/conformsTo/entities triples,
   // which the COUNT × sample cross-join repeats once per sampled row.
   const detection = new SparqlConstructExecutor({query, deduplicate: true});

--- a/src/subjectUriResolution.ts
+++ b/src/subjectUriResolution.ts
@@ -9,6 +9,7 @@ import {
   failureUsageQuads,
   type SampleFailure,
 } from './failureUsage.js';
+import {iiifManifestFormatFilter} from './iiifManifestDetection.js';
 
 const {namedNode, literal, blankNode, quad} = DataFactory;
 
@@ -622,11 +623,11 @@ function* booleanMeasurement(
  * URL both green (IIIF) and red (persistent identifier). Excluding them leaves
  * manifests to the IIIF criterion alone and resolves the contradiction.
  *
- * The manifest match mirrors `queries/analysis/iiif.rq` (the encodingFormat
- * literal is the full SCHEMA-AP-NDE profile pattern *or* the bare
- * `application/ld+json`; the dereference target is `schema:contentUrl` when
- * present, else the encodingFormat-bearing node), and is tolerant of
- * `http`/`https` schema.org like that query.
+ * The manifest test is the shared {@link iiifManifestFormatFilter} — the same
+ * encodingFormat rule the IIIF criterion uses — so the two cannot drift. The
+ * dereference target mirrors `queries/analysis/iiif.rq`: `schema:contentUrl`
+ * when present, else the encodingFormat-bearing node. Tolerant of `http`/`https`
+ * schema.org like that query.
  *
  * The `http`/`https` predicates are enumerated with `VALUES` rather than a
  * property-path alternation (`a|b`): the latter is mis-evaluated by the query
@@ -648,11 +649,7 @@ const IIIF_MANIFEST_EXCLUSION = `FILTER NOT EXISTS {
       ?manifestNode ?contentUrlPredicate ?s ;
         ?encodingFormatPredicate ?iiifFormat .
     }
-    FILTER(isLiteral(?iiifFormat) && (
-      (STRSTARTS(STR(?iiifFormat), "application/ld+json;profile='http://iiif.io/api/presentation/")
-        && STRENDS(STR(?iiifFormat), "/context.json'"))
-      || STR(?iiifFormat) = "application/ld+json"
-    ))
+    FILTER(${iiifManifestFormatFilter('iiifFormat')})
   }`;
 
 /**

--- a/src/subjectUriResolution.ts
+++ b/src/subjectUriResolution.ts
@@ -612,34 +612,97 @@ function* booleanMeasurement(
 }
 
 /**
- * Default sampler: a `SELECT DISTINCT ?s … LIMIT n` short-circuited on the
- * namespace prefix, run as a plain SPARQL SELECT against the distribution's
- * endpoint. The fetcher's own timeout fast-fails a slow endpoint, since the
- * transform runs outside the stage runner where the Pipeline's adaptive policy
- * would normally apply. The distribution's subject filter and named graph are
- * woven into the query, mirroring the VoID class selector.
+ * SPARQL `FILTER NOT EXISTS` fragment that drops any sampled subject the IIIF
+ * criterion already assesses as a manifest: either the subject is itself a
+ * manifest node (it bears an IIIF `schema:encodingFormat`) or it is the
+ * `schema:contentUrl` such a node dereferences to. Without it, an ARK+IIIF
+ * publisher’s manifest URLs (e.g. `…/ark:/85849/{uuid}/iiif.json`) can be
+ * sampled here and fail as `wrong-content-type` — a manifest correctly serves
+ * JSON, not `text/html` — while simultaneously passing the IIIF criterion: one
+ * URL both green (IIIF) and red (persistent identifier). Excluding them leaves
+ * manifests to the IIIF criterion alone and resolves the contradiction.
+ *
+ * The manifest match mirrors `queries/analysis/iiif.rq` (the encodingFormat
+ * literal is the full SCHEMA-AP-NDE profile pattern *or* the bare
+ * `application/ld+json`; the dereference target is `schema:contentUrl` when
+ * present, else the encodingFormat-bearing node), and is tolerant of
+ * `http`/`https` schema.org like that query.
+ *
+ * The `http`/`https` predicates are enumerated with `VALUES` rather than a
+ * property-path alternation (`a|b`): the latter is mis-evaluated by the query
+ * engine inside `FILTER NOT EXISTS` — when no triple uses the predicate at all,
+ * the whole `NOT EXISTS` collapses to false and drops every subject.
  */
-const defaultSampleUris: SampleUris = async (
-  uriSpace,
-  sampleSize,
-  {distribution},
-) => {
-  const subjectFilter = distribution.subjectFilter ?? '';
+const IIIF_MANIFEST_EXCLUSION = `FILTER NOT EXISTS {
+    VALUES ?encodingFormatPredicate {
+      <https://schema.org/encodingFormat> <http://schema.org/encodingFormat>
+    }
+    # ?s is itself the manifest node …
+    { ?s ?encodingFormatPredicate ?iiifFormat . }
+    UNION
+    # … or ?s is the schema:contentUrl the manifest node dereferences to.
+    {
+      VALUES ?contentUrlPredicate {
+        <https://schema.org/contentUrl> <http://schema.org/contentUrl>
+      }
+      ?manifestNode ?contentUrlPredicate ?s ;
+        ?encodingFormatPredicate ?iiifFormat .
+    }
+    FILTER(isLiteral(?iiifFormat) && (
+      (STRSTARTS(STR(?iiifFormat), "application/ld+json;profile='http://iiif.io/api/presentation/")
+        && STRENDS(STR(?iiifFormat), "/context.json'"))
+      || STR(?iiifFormat) = "application/ld+json"
+    ))
+  }`;
+
+/**
+ * Build the subject-URI sample query: a `SELECT DISTINCT ?s … LIMIT n`
+ * short-circuited on the namespace prefix, with the distribution's subject
+ * filter and named graph woven in (mirroring the VoID class selector) and
+ * {@link IIIF_MANIFEST_EXCLUSION known IIIF manifests} filtered out. Exported so
+ * the manifest exclusion can be exercised against an in-memory store.
+ */
+export function buildSampleQuery(
+  uriSpace: string,
+  sampleSize: number,
+  subjectFilter: string,
+  namedGraph?: string,
+): string {
   let fromClause = '';
-  if (distribution.namedGraph) {
-    assertSafeIri(distribution.namedGraph);
-    fromClause = `FROM <${distribution.namedGraph}>`;
+  if (namedGraph) {
+    assertSafeIri(namedGraph);
+    fromClause = `FROM <${namedGraph}>`;
   }
-  const query = [
+  return [
     'SELECT DISTINCT ?s',
     fromClause,
     'WHERE {',
     `  ${subjectFilter}`,
     '  ?s ?p ?o .',
     `  FILTER(ISIRI(?s) && STRSTARTS(STR(?s), ${sparqlString(uriSpace)}))`,
+    `  ${IIIF_MANIFEST_EXCLUSION}`,
     '}',
     `LIMIT ${sampleSize}`,
   ].join('\n');
+}
+
+/**
+ * Default sampler: runs {@link buildSampleQuery} as a plain SPARQL SELECT
+ * against the distribution's endpoint. The fetcher's own timeout fast-fails a
+ * slow endpoint, since the transform runs outside the stage runner where the
+ * Pipeline's adaptive policy would normally apply.
+ */
+const defaultSampleUris: SampleUris = async (
+  uriSpace,
+  sampleSize,
+  {distribution},
+) => {
+  const query = buildSampleQuery(
+    uriSpace,
+    sampleSize,
+    distribution.subjectFilter ?? '',
+    distribution.namedGraph,
+  );
 
   const fetcher = new SparqlEndpointFetcher({timeout: SAMPLE_TIMEOUT_MS});
   // fetchBindings yields IBindings (object mode), not the string/Buffer the

--- a/test/iiifStage.test.ts
+++ b/test/iiifStage.test.ts
@@ -6,6 +6,10 @@ import {DataFactory, Parser, Store} from 'n3';
 import type {Quad} from '@rdfjs/types';
 import {QueryEngine} from '@comunica/query-sparql-rdfjs-lite';
 import {iiifStage} from '../src/iiifStage.js';
+import {
+  iiifManifestFormatFilter,
+  iiifConformantFormatFilter,
+} from '../src/iiifManifestDetection.js';
 import {Stage} from '@lde/pipeline';
 
 const {namedNode} = DataFactory;
@@ -45,10 +49,16 @@ beforeAll(async () => {
 
 function buildQuery(subjectFilter = '', limit = 10): string {
   // Mirror iiifStage's and SparqlConstructExecutor's substitutions: the
-  // #limit# sample cap (threaded by iiifStage), the subjectFilter pattern,
-  // and ?dataset → the dataset IRI literal.
+  // #limit# sample cap and the shared manifest/conformant format filters
+  // (threaded by iiifStage), the subjectFilter pattern, and ?dataset → the
+  // dataset IRI literal.
   return queryTemplate
     .replaceAll('#limit#', String(limit))
+    .replaceAll('#manifestFormatFilter#', iiifManifestFormatFilter('format'))
+    .replaceAll(
+      '#conformantFormatFilter#',
+      iiifConformantFormatFilter('format'),
+    )
     .replaceAll('#subjectFilter#', subjectFilter)
     .replaceAll('?dataset', `<${DATASET_IRI}>`);
 }

--- a/test/subjectUriResolutionSample.test.ts
+++ b/test/subjectUriResolutionSample.test.ts
@@ -1,0 +1,112 @@
+import {describe, it, expect} from 'vitest';
+import {Parser, Store} from 'n3';
+import {QueryEngine} from '@comunica/query-sparql-rdfjs-lite';
+import {buildSampleQuery} from '../src/subjectUriResolution.js';
+
+// The DKOR case: an ARK namespace whose subjects include both genuine resources
+// and IIIF manifest URLs (`…/{uuid}/iiif.json`). The manifests pass the IIIF
+// criterion but, serving JSON rather than text/html, would fail the subject-URI
+// resolution check as `wrong-content-type` — so the sampler must exclude them.
+const URI_SPACE = 'https://n2t.net/ark:/85849/';
+
+const PREFIXES = '@prefix schema: <https://schema.org/> .\n';
+
+async function sample(turtle: string, limit = 10): Promise<string[]> {
+  const store = new Store();
+  store.addQuads(new Parser().parse(PREFIXES + turtle));
+
+  const engine = new QueryEngine();
+  const bindings = await engine.queryBindings(
+    buildSampleQuery(URI_SPACE, limit, ''),
+    {sources: [store]},
+  );
+  const subjects: string[] = [];
+  for await (const binding of bindings) {
+    const term = binding.get('s');
+    if (term?.termType === 'NamedNode') subjects.push(term.value);
+  }
+  return subjects.sort();
+}
+
+const IIIF_V3 =
+  "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json'";
+
+describe('buildSampleQuery IIIF manifest exclusion', () => {
+  it('excludes manifest URLs that bear the IIIF encodingFormat themselves', async () => {
+    const turtle = `
+      <${URI_SPACE}aaa> schema:name "Work A" .
+      <${URI_SPACE}bbb> schema:name "Work B" .
+      <${URI_SPACE}aaa/iiif.json> schema:encodingFormat "${IIIF_V3}" .
+      <${URI_SPACE}bbb/iiif.json> schema:encodingFormat "${IIIF_V3}" .
+    `;
+
+    // Only the genuine subjects survive; the two iiif.json manifests are dropped.
+    expect(await sample(turtle)).toEqual([
+      `${URI_SPACE}aaa`,
+      `${URI_SPACE}bbb`,
+    ]);
+  });
+
+  it('excludes a manifest declared with the bare application/ld+json media type', async () => {
+    const turtle = `
+      <${URI_SPACE}aaa> schema:name "Work A" .
+      <${URI_SPACE}aaa/iiif.json> schema:encodingFormat "application/ld+json" .
+    `;
+
+    expect(await sample(turtle)).toEqual([`${URI_SPACE}aaa`]);
+  });
+
+  it('excludes a manifest URL referenced via schema:contentUrl', async () => {
+    // The encodingFormat sits on a wrapper node; the dereferenceable manifest
+    // URL lives in schema:contentUrl and is itself a subject in the namespace.
+    const turtle = `
+      <${URI_SPACE}ccc> schema:associatedMedia [
+        schema:encodingFormat "${IIIF_V3}" ;
+        schema:contentUrl <${URI_SPACE}ccc/manifest.json>
+      ] .
+      <${URI_SPACE}ccc/manifest.json> schema:name "Manifest" .
+    `;
+
+    // The work survives; the contentUrl manifest is dropped.
+    expect(await sample(turtle)).toEqual([`${URI_SPACE}ccc`]);
+  });
+
+  it('keeps non-IIIF media subjects (e.g. plain images)', async () => {
+    const turtle = `
+      <${URI_SPACE}aaa> schema:name "Work A" .
+      <${URI_SPACE}eee> schema:encodingFormat "image/jpeg" .
+    `;
+
+    // Only IIIF manifests are excluded — a plain media object stays sampled.
+    expect(await sample(turtle)).toEqual([
+      `${URI_SPACE}aaa`,
+      `${URI_SPACE}eee`,
+    ]);
+  });
+
+  it('leaves a manifest-free namespace untouched', async () => {
+    const turtle = `
+      <${URI_SPACE}aaa> schema:name "Work A" .
+      <${URI_SPACE}bbb> schema:name "Work B" .
+    `;
+
+    expect(await sample(turtle)).toEqual([
+      `${URI_SPACE}aaa`,
+      `${URI_SPACE}bbb`,
+    ]);
+  });
+
+  it('backfills the sample with genuine subjects up to the limit', async () => {
+    // With manifests excluded at the source, a small LIMIT is filled with real
+    // subjects rather than partly wasted on manifests (the DKOR 6/6 outcome).
+    const turtle = `
+      <${URI_SPACE}aaa> schema:name "Work A" .
+      <${URI_SPACE}bbb> schema:name "Work B" .
+      <${URI_SPACE}ccc> schema:name "Work C" .
+      <${URI_SPACE}aaa/iiif.json> schema:encodingFormat "${IIIF_V3}" .
+      <${URI_SPACE}bbb/iiif.json> schema:encodingFormat "${IIIF_V3}" .
+    `;
+
+    expect(await sample(turtle, 2)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Addresses netwerk-digitaal-erfgoed/dataset-register#2097 (DKOR: IIIF manifest
URLs reported as unreachable persistent identifiers).

## Problem

An ARK+IIIF publisher whose subject sample includes manifest URLs (e.g.
`…/ark:/85849/{uuid}/iiif.json`) gets a self-contradictory result: the same URLs
pass the **IIIF criterion** (a valid manifest is found) but fail the
**subject-URI resolution** check as `wrong-content-type` – a manifest correctly
serves JSON, not `text/html`. One URL ends up both green (IIIF) and red
(persistent identifier).

Concrete case: DKOR (Stichting Design en Kunst Openbare Ruimte), namespace
`n2t.net/ark:/85849/`. The dataset mints ARKs in one namespace for works, media
objects *and* manifests as siblings; the 90 `/iiif.json` manifests are ~21% of
the 426 subjects, each a first-class RDF subject (it bears the IIIF
`schema:encodingFormat`). The unordered `LIMIT 10` sample drew 4 of them, all
scored `wrong-content-type`.

## Change

Exclude URLs the dataset already exposes as IIIF manifests from the subject-URI
resolution sample, so they are assessed by the IIIF criterion alone. No coverage
is lost – IIIF manifests are already measured by `manifests-sampled` /
`manifests-validated`. For DKOR the sample becomes 6/6.

- Add a `FILTER NOT EXISTS` to the sample query that drops a subject when it is
  itself a manifest node (bears an IIIF `schema:encodingFormat`) or is the
  `schema:contentUrl` such a node dereferences to – mirroring the manifest
  detection in `queries/analysis/iiif.rq`, tolerant of `http`/`https` schema.org.
  (DKOR is matched by the self branch; the `contentUrl` branch covers other
  publishers' modelling.)
- Enumerate the `http`/`https` predicates with `VALUES` rather than a
  property-path alternation (`a|b`): the alternation is mis-evaluated by the query
  engine inside `FILTER NOT EXISTS` – when no triple uses the predicate at all,
  the whole `NOT EXISTS` collapses to false and drops every subject.

## Shared detection rule (no drift)

To avoid the IIIF criterion and the persistent-URI check duplicating – and
drifting on – the manifest detection rule, the `schema:encodingFormat`
media-type test is extracted into `src/iiifManifestDetection.ts` as a single
source of truth:

- Both the subject-URI exclusion and `iiif.rq` build their manifest test from
  the same helper. `iiif.rq` gets it via `#manifestFormatFilter#` /
  `#conformantFormatFilter#` placeholders threaded by `iiifStage`, the same way
  `#limit#` is substituted.
- This also de-duplicates the format match that was repeated three times inside
  `iiif.rq` itself (capability count, conformance count, sample).
- The two checks stay decoupled: they share the *rule*, not a validator – the
  persistent-URI check does not depend on or reorder the IIIF stage.

## Tests & docs

- `test/subjectUriResolutionSample.test.ts` covers the exclusion against an
  in-memory store (self-borne manifest, bare `application/ld+json`, `contentUrl`
  reference, plain non-IIIF media kept, manifest-free namespace untouched,
  backfill up to the limit).
- `test/iiifStage.test.ts` substitutes the shared filters, so the existing IIIF
  detection tests exercise the real query.
- README subject-URI resolution section documents the exclusion. The matching
  docs chapter is updated in the docs repository.
