### PR TITLE
feat: select datasets with TriG RDF distributions

### DIFF
--- a/queries/selection/dataset-with-rdf-distribution.rq
+++ b/queries/selection/dataset-with-rdf-distribution.rq
@@ -34,6 +34,7 @@ CONSTRUCT {
         || ?distribution_mediaType = <https://www.iana.org/assignments/media-types/application/n-quads>
         || ?distribution_mediaType = <https://www.iana.org/assignments/media-types/application/n-triples>
         || ?distribution_mediaType = <https://www.iana.org/assignments/media-types/application/rdf+xml>
+        || ?distribution_mediaType = <https://www.iana.org/assignments/media-types/application/trig>
         || ?distribution_mediaType = <https://www.iana.org/assignments/media-types/text/turtle>
     )
 


### PR DESCRIPTION
## Summary

Add `application/trig` to the media-type FILTER in `queries/selection/dataset-with-rdf-distribution.rq`, so datasets whose only RDF dump is a TriG distribution are no longer filtered out before fetching.

This surfaced with the KB dataset [`rise-alba`](https://datasetregister.netwerkdigitaalerfgoed.nl/en/dataset?uri=http://data.bibliotheken.nl/id/dataset/rise-alba), which is never analyzed because its dump distribution is `application/trig` and the selection query only admitted JSON-LD, N-Quads, N-Triples, RDF/XML, Turtle, or a SPARQL endpoint.

## Note

This is the selection half of the fix (issue item 1). To actually ingest TriG, the companion change lives in ldelements/lde#467 (`@lde/sparql-qlever`): add `application/trig` to the `preprocess` map so it is converted to N-Quads before QLever indexing, since QLever cannot ingest TriG natively. The distribution probe already accepts TriG.

Fix #349