### PR TITLE
feat: keep invalid datasets, exclude only gone ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -1028,23 +1028,28 @@ crash mid-run leaves the already-processed files intact for the next rebuild.
 
 The writer only rewrites the files of the datasets selected in this run, so a
 dataset that has since been **removed from the register** or whose registration
-has **expired** (`schema:validUntil`) is no longer selected — and its file
-lingers as a stale “ghost”, surfacing in downstream consumers such as the
+source is **gone** (`schema:additionalType` `registry/gone`, the registration
+URL itself became unreachable) is no longer selected — and its file lingers as a
+stale “ghost”, surfacing in downstream consumers such as the
 [data stories](https://datastories.demo.netwerkdigitaalerfgoed.nl/dataset-knowledge-graph/)
 once the index is rebuilt.
 
 After writing, the pipeline reconciles the cache against the register: it asks
-the register for the set of dataset URIs that currently exist and are valid (the
-keep-set, see [`queries/selection/registered-dataset.rq`](queries/selection/registered-dataset.rq)),
+the register for the set of dataset URIs that currently exist and are not gone
+(the keep-set, see [`queries/selection/registered-dataset.rq`](queries/selection/registered-dataset.rq)),
 then deletes every `.nq` file whose dataset is not in that set (both its summary
 and validation file).
 
 The keep-set deliberately applies only the register’s identity and validity
-checks (`validUntil` + catalog freshness), **not** the distribution-type or
-endpoint filters of the selection query: a dataset that is registered and valid
-but merely skipped this run (no RDF distribution, an unreliable or timed-out
-endpoint) stays in the keep-set, so its last-good file is preserved rather than
-deleted. If the register returns an empty keep-set (e.g. an outage), the step
+checks (not-gone + catalog freshness), **not** the distribution-type or
+endpoint filters of the selection query: a dataset that is registered and not
+gone but merely skipped this run (no RDF distribution, an unreliable or timed-out
+endpoint, or a description that failed validation) stays in the keep-set, so its
+last-good file is preserved rather than deleted. Datasets that the register marks
+**invalid** (`registry/invalid`) — their description failed validation but the
+registration source is still reachable — remain selected: their data
+distributions may still be sound, and each distribution is validated at fetch
+time regardless. If the register returns an empty keep-set (e.g. an outage), the step
 fails closed and prunes nothing rather than emptying the cache. Reconciliation
 failures are logged, not fatal: the files for this run are already written, and
 the next run reconciles whatever is left.

--- a/queries/selection/dataset-with-rdf-distribution.rq
+++ b/queries/selection/dataset-with-rdf-distribution.rq
@@ -38,9 +38,14 @@ CONSTRUCT {
         || ?distribution_mediaType = <https://www.iana.org/assignments/media-types/text/turtle>
     )
 
-    # Exclude dataset descriptions that are no longer valid.
+    # Exclude datasets whose registration source is gone (the registration URL
+    # itself became unreachable). Datasets that merely failed description
+    # validation (registry/invalid) are kept: their data distributions may still
+    # be sound, and each distribution is validated at fetch time anyway. The
+    # register marks both cases with schema:validUntil, so filter on the more
+    # specific schema:additionalType to keep the invalid ones.
     FILTER(NOT EXISTS {
-        ?registrationUrl schema:validUntil [] .
+        ?registrationUrl schema:additionalType <https://data.netwerkdigitaalerfgoed.nl/registry/gone> .
     })
 
     # In case of a catalog, exclude datasets that are no longer part of the catalog.

--- a/queries/selection/registered-dataset.rq
+++ b/queries/selection/registered-dataset.rq
@@ -1,14 +1,15 @@
 # The keep-set for store reconciliation: every dataset URI that currently exists
-# in the Dataset Register and is still valid. Any DKG graph whose dataset URI is
-# NOT returned here is an orphan (the dataset was removed from the register or
-# its registration expired) and gets pruned.
+# in the Dataset Register and whose registration source is not gone. Any DKG
+# graph whose dataset URI is NOT returned here is an orphan (the dataset was
+# removed from the register or its registration source became unreachable) and
+# gets pruned.
 #
 # This deliberately mirrors only the identity and validity checks of
-# dataset-with-rdf-distribution.rq (validUntil + catalog freshness), and OMITS
-# its distribution-type and endpoint filters. A dataset that is registered and
-# valid but merely skipped this run (no RDF distribution, an unreliable or
-# timed-out endpoint) must stay in the keep-set so its last-good summary is
-# preserved rather than deleted.
+# dataset-with-rdf-distribution.rq (not-gone + catalog freshness), and OMITS its
+# distribution-type and endpoint filters. A dataset that is registered and not
+# gone but merely skipped this run (no RDF distribution, an unreliable or
+# timed-out endpoint, or a description that failed validation) must stay in the
+# keep-set so its last-good summary is preserved rather than deleted.
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX schema: <https://schema.org/>
 
@@ -16,9 +17,11 @@ SELECT DISTINCT ?dataset WHERE {
     ?dataset a dcat:Dataset ;
         schema:subjectOf ?registrationUrl .
 
-    # Exclude dataset descriptions that are no longer valid.
+    # Exclude datasets whose registration source is gone (the registration URL
+    # itself became unreachable). Datasets that merely failed description
+    # validation (registry/invalid) are kept, mirroring the selection query.
     FILTER(NOT EXISTS {
-        ?registrationUrl schema:validUntil [] .
+        ?registrationUrl schema:additionalType <https://data.netwerkdigitaalerfgoed.nl/registry/gone> .
     })
 
     # In case of a catalog, exclude datasets that are no longer part of the catalog.


### PR DESCRIPTION
## What

Select datasets the register marks **invalid** (`registry/invalid`) instead of dropping them alongside **gone** datasets (`registry/gone`).

## Why

Both the selection query and the reconciliation keep-set excluded any dataset whose registration carried `schema:validUntil`. The Dataset Register sets `validUntil` for two distinct situations:

- **gone** (`registry/gone`) – the registration source itself became unreachable;
- **invalid** (`registry/invalid`) – the dataset is still present in its catalog, but its description failed validation.

Treating them identically dropped invalid-but-reachable datasets even when their data distributions were perfectly sound. Example: `https://omeka.nd.xentropics.cloud/api/items/2449` (“Nederlandse Dansdagen Archief”) is still in its catalog and ships a valid 2 MB Turtle dump, yet was never processed.

## How

Filter on the more specific `schema:additionalType` `registry/gone` rather than the presence of `schema:validUntil`, in both:

- `queries/selection/dataset-with-rdf-distribution.rq` (selection)
- `queries/selection/registered-dataset.rq` (keep-set – must match, or newly-selected invalid datasets would be pruned immediately)

Faulty distributions are not a concern here: the register records no distribution-level health, and each distribution is already validated at fetch time, so an invalid dataset whose distributions are broken simply yields no summary.

## Impact

Against the live register today this admits **+19 datasets** (the `registry/invalid`, still-reachable ones). The 42 `registry/gone` datasets remain excluded.

## Docs

The corresponding chapter in the `docs` repo (`services/dataset-knowledge-graph/index.md`) is updated in a separate change.
