### PR TITLE
fix: exclude the URI space prefix itself from the subject-URI sample

### DIFF
--- a/src/subjectUriResolution.ts
+++ b/src/subjectUriResolution.ts
@@ -668,9 +668,11 @@ const IIIF_MANIFEST_EXCLUSION = `FILTER NOT EXISTS {
 /**
  * Build the subject-URI sample query: a `SELECT DISTINCT ?s … LIMIT n`
  * short-circuited on the namespace prefix, with the distribution's subject
- * filter and named graph woven in (mirroring the VoID class selector) and
- * {@link IIIF_MANIFEST_EXCLUSION known IIIF manifests} filtered out. Exported so
- * the manifest exclusion can be exercised against an in-memory store.
+ * filter and named graph woven in (mirroring the VoID class selector), the
+ * {@link IIIF_MANIFEST_EXCLUSION known IIIF manifests} filtered out, and the
+ * URI space prefix itself excluded (it matches its own `STRSTARTS` but is the
+ * namespace, not a dereferenceable resource). Exported so the exclusions can be
+ * exercised against an in-memory store.
  */
 export function buildSampleQuery(
   uriSpace: string,
@@ -689,7 +691,7 @@ export function buildSampleQuery(
     'WHERE {',
     `  ${subjectFilter}`,
     '  ?s ?p ?o .',
-    `  FILTER(ISIRI(?s) && STRSTARTS(STR(?s), ${sparqlString(uriSpace)}))`,
+    `  FILTER(ISIRI(?s) && STRSTARTS(STR(?s), ${sparqlString(uriSpace)}) && STR(?s) != ${sparqlString(uriSpace)})`,
     `  ${IIIF_MANIFEST_EXCLUSION}`,
     '}',
     `LIMIT ${sampleSize}`,

--- a/test/subjectUriResolutionSample.test.ts
+++ b/test/subjectUriResolutionSample.test.ts
@@ -110,3 +110,22 @@ describe('buildSampleQuery IIIF manifest exclusion', () => {
     expect(await sample(turtle, 2)).toHaveLength(2);
   });
 });
+
+describe('buildSampleQuery URI space prefix exclusion', () => {
+  it('excludes the URI space prefix itself while keeping genuine subjects', async () => {
+    // The prefix appears as a subject in the data (e.g. `…/61567/dataset`
+    // strips to `…/61567/`). STRSTARTS matches it against itself, but the
+    // prefix is the namespace, not a dereferenceable resource, so it must be
+    // dropped.
+    const turtle = `
+      <${URI_SPACE}> schema:name "The ARK namespace" .
+      <${URI_SPACE}aaa> schema:name "Work A" .
+      <${URI_SPACE}bbb> schema:name "Work B" .
+    `;
+
+    expect(await sample(turtle)).toEqual([
+      `${URI_SPACE}aaa`,
+      `${URI_SPACE}bbb`,
+    ]);
+  });
+});


### PR DESCRIPTION
## What

The persistent-URI criterion sampled the URI space prefix itself (e.g. the ARK namespace `https://n2t.net/ark:/61567/`) as a subject URI, then tried to resolve it as a persistent identifier.

## Why

The sample filter in `buildSampleQuery()` selected subjects with `STRSTARTS(STR(?s), <uriSpace>)`. `STRSTARTS` is satisfied by equality, so when the prefix appeared as a subject in the data it matched itself. The prefix is the namespace, not a dereferenceable resource, so resolving it gave a misleading verdict.

## Fix

Add `STR(?s) != <uriSpace>` to the filter, excluding the prefix while keeping genuine subjects. This mirrors the IIIF-manifest exclusion added in #347 – another case of filtering URIs that match the namespace but aren’t real subject resources.

A unit test in `test/subjectUriResolutionSample.test.ts` covers a store where the prefix appears as a subject, asserting it is dropped while genuine subjects are kept.

Fix #360
