### PR TITLE
refactor: extract shared DQV/PROV measurement helpers

### DIFF
--- a/src/iiifValidationExecutor.ts
+++ b/src/iiifValidationExecutor.ts
@@ -8,15 +8,16 @@ import {
   type ManifestValidation,
   type ManifestValidationReason,
 } from '@lde/iiif-validator';
-import {dqv, prov, rdf, xsd} from '@tpluscode/rdf-ns-builders';
+import {dqv} from '@tpluscode/rdf-ns-builders';
 import {
   failureReasonIri,
   failureUsageQuads,
   type SampleFailure,
 } from './failureUsage.js';
 import {metric} from './namespaces.js';
+import {integerMeasurement, provActivity} from './measurements.js';
 
-const {namedNode, literal, quad} = DataFactory;
+const {namedNode, quad} = DataFactory;
 
 const IIIF_PRESENTATION = namedNode('http://iiif.io/api/presentation/');
 
@@ -234,10 +235,11 @@ export class IiifValidationExecutor implements Executor {
 
     // PROV: the dereferencing activity, with a qualified usage per failed
     // manifest naming the URL and why validation failed.
-    yield quad(activity, rdf.type, prov.Activity);
-    yield quad(activity, prov.used, namedNode(dataset.iri.toString()));
-    yield quad(activity, prov.used, IIIF_PRESENTATION);
-    yield quad(activity, prov.wasAssociatedWith, this.validatorSoftware);
+    yield* provActivity(
+      activity,
+      [namedNode(dataset.iri.toString()), IIIF_PRESENTATION],
+      this.validatorSoftware,
+    );
     yield* failureUsageQuads(activity, failures);
 
     // The measurements describe the IIIF capability subset, which already
@@ -257,33 +259,19 @@ export class IiifValidationExecutor implements Executor {
     yield quad(datasetNode, dqv.hasQualityMeasurement, sampledMeasurement);
     yield quad(datasetNode, dqv.hasQualityMeasurement, validatedMeasurement);
 
-    yield* this.integerMeasurement(
+    yield* integerMeasurement(
       sampledMeasurement,
       iiifSubset,
       metric['manifests-sampled'],
       sampled,
       activity,
     );
-    yield* this.integerMeasurement(
+    yield* integerMeasurement(
       validatedMeasurement,
       iiifSubset,
       metric['manifests-validated'],
       validated,
       activity,
     );
-  }
-
-  private *integerMeasurement(
-    measurement: NamedNode,
-    computedOn: NamedNode,
-    metricNode: NamedNode,
-    value: number,
-    activity: NamedNode,
-  ): Generator<Quad> {
-    yield quad(measurement, rdf.type, dqv.QualityMeasurement);
-    yield quad(measurement, dqv.computedOn, computedOn);
-    yield quad(measurement, dqv.isMeasurementOf, metricNode);
-    yield quad(measurement, dqv.value, literal(String(value), xsd.integer));
-    yield quad(measurement, prov.wasGeneratedBy, activity);
   }
 }

--- a/src/measurements.ts
+++ b/src/measurements.ts
@@ -1,0 +1,86 @@
+import {DataFactory} from 'n3';
+import type {BlankNode, Literal, NamedNode, Quad} from '@rdfjs/types';
+import {dqv, prov, rdf, xsd} from '@tpluscode/rdf-ns-builders';
+
+const {literal, quad} = DataFactory;
+
+/**
+ * A structural node a stage mints for its activity or measurement: a skolem
+ * `NamedNode` (so it survives a merge into the dataset graph) or a `BlankNode`
+ * (for dataset-scoped nodes that never leave their graph).
+ */
+type StructuralNode = NamedNode | BlankNode;
+
+/**
+ * The shared PROV activity shape the analysis stages emit before deriving a
+ * measurement from it: a `prov:Activity` that `prov:used` one or more inputs
+ * and `prov:wasAssociatedWith` the `software` that carried it out. Pass an array
+ * to record several inputs (e.g. the dataset and the profile it was validated
+ * against), in order. Measurements then back-link the activity with
+ * `prov:wasGeneratedBy`.
+ */
+export function* provActivity(
+  activity: StructuralNode,
+  used: NamedNode | readonly NamedNode[],
+  software: NamedNode,
+): Generator<Quad> {
+  yield quad(activity, rdf.type, prov.Activity);
+  for (const input of Array.isArray(used) ? used : [used]) {
+    yield quad(activity, prov.used, input);
+  }
+  yield quad(activity, prov.wasAssociatedWith, software);
+}
+
+/**
+ * A DQV quality measurement carrying an `xsd:integer` value: typed
+ * `dqv:QualityMeasurement`, `dqv:computedOn` its subject, `dqv:isMeasurementOf`
+ * the metric, the `dqv:value`, and `prov:wasGeneratedBy` the {@link provActivity}
+ * that produced it.
+ */
+export function* integerMeasurement(
+  measurement: StructuralNode,
+  computedOn: StructuralNode,
+  metricNode: NamedNode,
+  value: number,
+  activity: StructuralNode,
+): Generator<Quad> {
+  yield* typedMeasurement(
+    measurement,
+    computedOn,
+    metricNode,
+    literal(String(value), xsd.integer),
+    activity,
+  );
+}
+
+/** A {@link integerMeasurement} variant carrying an `xsd:boolean` value. */
+export function* booleanMeasurement(
+  measurement: StructuralNode,
+  computedOn: StructuralNode,
+  metricNode: NamedNode,
+  value: boolean,
+  activity: StructuralNode,
+): Generator<Quad> {
+  yield* typedMeasurement(
+    measurement,
+    computedOn,
+    metricNode,
+    literal(String(value), xsd.boolean),
+    activity,
+  );
+}
+
+/** The DQV quality-measurement shape shared by every typed-value variant. */
+function* typedMeasurement(
+  measurement: StructuralNode,
+  computedOn: StructuralNode,
+  metricNode: NamedNode,
+  value: Literal,
+  activity: StructuralNode,
+): Generator<Quad> {
+  yield quad(measurement, rdf.type, dqv.QualityMeasurement);
+  yield quad(measurement, dqv.computedOn, computedOn);
+  yield quad(measurement, dqv.isMeasurementOf, metricNode);
+  yield quad(measurement, dqv.value, value);
+  yield quad(measurement, prov.wasGeneratedBy, activity);
+}

--- a/src/qualityMeasurementsStage.ts
+++ b/src/qualityMeasurementsStage.ts
@@ -4,6 +4,7 @@ import {dcterms, dqv, prov, rdf, xsd} from '@tpluscode/rdf-ns-builders';
 import type {Dataset} from '@lde/dataset';
 import {Stage, type Executor, type Validator} from '@lde/pipeline';
 import {metric} from './namespaces.js';
+import {integerMeasurement, provActivity} from './measurements.js';
 
 const {namedNode, literal, blankNode, quad} = DataFactory;
 
@@ -57,10 +58,7 @@ export function qualityMeasurementsStage(
 
       const quads: Quad[] = [
         // PROV: validation activity.
-        quad(activity, rdf.type, prov.Activity),
-        quad(activity, prov.used, subject),
-        quad(activity, prov.used, profile),
-        quad(activity, prov.wasAssociatedWith, validatorSoftware),
+        ...provActivity(activity, [subject, profile], validatorSoftware),
 
         // Dataset → measurements.
         quad(subject, dqv.hasQualityMeasurement, conformanceMeasurement),
@@ -85,34 +83,22 @@ export function qualityMeasurementsStage(
         quad(conformanceMeasurement, prov.wasGeneratedBy, activity),
 
         // Coverage: number of quads the validator inspected.
-        quad(quadsValidatedMeasurement, rdf.type, dqv.QualityMeasurement),
-        quad(quadsValidatedMeasurement, dqv.computedOn, subject),
-        quad(
+        ...integerMeasurement(
           quadsValidatedMeasurement,
-          dqv.isMeasurementOf,
+          subject,
           metric['quads-validated'],
+          report.quadsValidated,
+          activity,
         ),
-        quad(
-          quadsValidatedMeasurement,
-          dqv.value,
-          literal(String(report.quadsValidated), xsd.integer),
-        ),
-        quad(quadsValidatedMeasurement, prov.wasGeneratedBy, activity),
 
         // Coverage: configured sample cap per target class.
-        quad(samplesPerClassMeasurement, rdf.type, dqv.QualityMeasurement),
-        quad(samplesPerClassMeasurement, dqv.computedOn, subject),
-        quad(
+        ...integerMeasurement(
           samplesPerClassMeasurement,
-          dqv.isMeasurementOf,
+          subject,
           metric['samples-per-class'],
+          options.samplesPerClass,
+          activity,
         ),
-        quad(
-          samplesPerClassMeasurement,
-          dqv.value,
-          literal(String(options.samplesPerClass), xsd.integer),
-        ),
-        quad(samplesPerClassMeasurement, prov.wasGeneratedBy, activity),
       ];
 
       return (async function* () {

--- a/src/subjectUriResolution.ts
+++ b/src/subjectUriResolution.ts
@@ -2,7 +2,7 @@ import {DataFactory} from 'n3';
 import pLimit from 'p-limit';
 import {SparqlEndpointFetcher, type IBindings} from 'fetch-sparql-endpoint';
 import type {NamedNode, Quad} from '@rdfjs/types';
-import {_void, dcterms, dqv, prov, rdf, xsd} from '@tpluscode/rdf-ns-builders';
+import {_void, dcterms, dqv} from '@tpluscode/rdf-ns-builders';
 import {
   assertSafeIri,
   skolemIri,
@@ -16,6 +16,11 @@ import {
   type SampleFailure,
 } from './failureUsage.js';
 import {metric} from './namespaces.js';
+import {
+  booleanMeasurement,
+  integerMeasurement,
+  provActivity,
+} from './measurements.js';
 import {iiifManifestFormatFilter} from './iiifManifestDetection.js';
 
 const {namedNode, literal, quad} = DataFactory;
@@ -497,7 +502,7 @@ function* measurementQuads(
   // node is a skolem IRI derived from the (unique) subset, not a blank node, so
   // it cannot collide with another stage’s nodes in the dataset graph (#352).
   const activity = namedNode(skolemIri(subset.value, 'resolution-activity'));
-  yield* activityQuads(activity, subset, software);
+  yield* provActivity(activity, subset, software);
   yield* failureUsageQuads(activity, failures);
 
   // Validated facts — the sampled/resolved ratio, for any namespace.
@@ -536,7 +541,7 @@ function* nonDurableMeasurement(
   software: NamedNode,
 ): Generator<Quad> {
   const activity = namedNode(skolemIri(subset.value, 'durability-activity'));
-  yield* activityQuads(activity, subset, software);
+  yield* provActivity(activity, subset, software);
 
   const measurement = namedNode(
     skolemIri(subset.value, 'measurement', 'subject-namespace-durable'),
@@ -549,44 +554,6 @@ function* nonDurableMeasurement(
     false,
     activity,
   );
-}
-
-function* activityQuads(
-  activity: NamedNode,
-  used: NamedNode,
-  software: NamedNode,
-): Generator<Quad> {
-  yield quad(activity, rdf.type, prov.Activity);
-  yield quad(activity, prov.used, used);
-  yield quad(activity, prov.wasAssociatedWith, software);
-}
-
-function* integerMeasurement(
-  measurement: NamedNode,
-  computedOn: NamedNode,
-  metricNode: NamedNode,
-  value: number,
-  activity: NamedNode,
-): Generator<Quad> {
-  yield quad(measurement, rdf.type, dqv.QualityMeasurement);
-  yield quad(measurement, dqv.computedOn, computedOn);
-  yield quad(measurement, dqv.isMeasurementOf, metricNode);
-  yield quad(measurement, dqv.value, literal(String(value), xsd.integer));
-  yield quad(measurement, prov.wasGeneratedBy, activity);
-}
-
-function* booleanMeasurement(
-  measurement: NamedNode,
-  computedOn: NamedNode,
-  metricNode: NamedNode,
-  value: boolean,
-  activity: NamedNode,
-): Generator<Quad> {
-  yield quad(measurement, rdf.type, dqv.QualityMeasurement);
-  yield quad(measurement, dqv.computedOn, computedOn);
-  yield quad(measurement, dqv.isMeasurementOf, metricNode);
-  yield quad(measurement, dqv.value, literal(String(value), xsd.boolean));
-  yield quad(measurement, prov.wasGeneratedBy, activity);
 }
 
 /**

--- a/test/measurements.test.ts
+++ b/test/measurements.test.ts
@@ -1,0 +1,165 @@
+import {describe, it, expect} from 'vitest';
+import {DataFactory} from 'n3';
+import type {Quad} from '@rdfjs/types';
+import {
+  booleanMeasurement,
+  integerMeasurement,
+  provActivity,
+} from '../src/measurements.js';
+
+const {namedNode, blankNode} = DataFactory;
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const PROV_ACTIVITY = 'http://www.w3.org/ns/prov#Activity';
+const PROV_USED = 'http://www.w3.org/ns/prov#used';
+const PROV_WAS_ASSOCIATED_WITH = 'http://www.w3.org/ns/prov#wasAssociatedWith';
+const PROV_WAS_GENERATED_BY = 'http://www.w3.org/ns/prov#wasGeneratedBy';
+const DQV_QUALITY_MEASUREMENT = 'http://www.w3.org/ns/dqv#QualityMeasurement';
+const DQV_COMPUTED_ON = 'http://www.w3.org/ns/dqv#computedOn';
+const DQV_IS_MEASUREMENT_OF = 'http://www.w3.org/ns/dqv#isMeasurementOf';
+const DQV_VALUE = 'http://www.w3.org/ns/dqv#value';
+const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
+const XSD_BOOLEAN = 'http://www.w3.org/2001/XMLSchema#boolean';
+
+/**
+ * Normalise a quad to a `subject predicate object` tuple of IRI strings,
+ * tagging a literal object with its datatype. Factory-agnostic, so terms minted
+ * by `n3` and by `@tpluscode/rdf-ns-builders` compare equal.
+ */
+function triple(quad: Quad): string[] {
+  const object =
+    quad.object.termType === 'Literal'
+      ? `${quad.object.value}^^${quad.object.datatype.value}`
+      : quad.object.value;
+  return [quad.subject.value, quad.predicate.value, object];
+}
+
+function triples(quads: Iterable<Quad>): string[][] {
+  return [...quads].map(triple);
+}
+
+describe('provActivity', () => {
+  it('emits the activity shape with a single prov:used', () => {
+    const out = triples(
+      provActivity(
+        namedNode('http://example.org/activity'),
+        namedNode('http://example.org/dataset'),
+        namedNode('http://example.org/software'),
+      ),
+    );
+
+    expect(out).toEqual([
+      ['http://example.org/activity', RDF_TYPE, PROV_ACTIVITY],
+      ['http://example.org/activity', PROV_USED, 'http://example.org/dataset'],
+      [
+        'http://example.org/activity',
+        PROV_WAS_ASSOCIATED_WITH,
+        'http://example.org/software',
+      ],
+    ]);
+  });
+
+  it('emits one prov:used per input, in order, for an array', () => {
+    const out = triples(
+      provActivity(
+        namedNode('http://example.org/activity'),
+        [
+          namedNode('http://example.org/dataset'),
+          namedNode('http://example.org/profile'),
+        ],
+        namedNode('http://example.org/software'),
+      ),
+    );
+
+    expect(out).toEqual([
+      ['http://example.org/activity', RDF_TYPE, PROV_ACTIVITY],
+      ['http://example.org/activity', PROV_USED, 'http://example.org/dataset'],
+      ['http://example.org/activity', PROV_USED, 'http://example.org/profile'],
+      [
+        'http://example.org/activity',
+        PROV_WAS_ASSOCIATED_WITH,
+        'http://example.org/software',
+      ],
+    ]);
+  });
+
+  it('accepts a blank node as the activity', () => {
+    const activity = blankNode();
+    const [first] = [
+      ...provActivity(
+        activity,
+        namedNode('http://example.org/dataset'),
+        namedNode('http://example.org/software'),
+      ),
+    ];
+    expect(first.subject.equals(activity)).toBe(true);
+  });
+});
+
+describe('integerMeasurement', () => {
+  it('emits the DQV measurement shape with an xsd:integer value', () => {
+    const out = triples(
+      integerMeasurement(
+        namedNode('http://example.org/measurement'),
+        namedNode('http://example.org/subset'),
+        namedNode('https://def.nde.nl/metric#subject-uris-sampled'),
+        10,
+        namedNode('http://example.org/activity'),
+      ),
+    );
+
+    expect(out).toEqual([
+      ['http://example.org/measurement', RDF_TYPE, DQV_QUALITY_MEASUREMENT],
+      [
+        'http://example.org/measurement',
+        DQV_COMPUTED_ON,
+        'http://example.org/subset',
+      ],
+      [
+        'http://example.org/measurement',
+        DQV_IS_MEASUREMENT_OF,
+        'https://def.nde.nl/metric#subject-uris-sampled',
+      ],
+      ['http://example.org/measurement', DQV_VALUE, `10^^${XSD_INTEGER}`],
+      [
+        'http://example.org/measurement',
+        PROV_WAS_GENERATED_BY,
+        'http://example.org/activity',
+      ],
+    ]);
+  });
+});
+
+describe('booleanMeasurement', () => {
+  it('emits the DQV measurement shape with an xsd:boolean value', () => {
+    const out = triples(
+      booleanMeasurement(
+        namedNode('http://example.org/measurement'),
+        namedNode('http://example.org/subset'),
+        namedNode('https://def.nde.nl/metric#subject-namespace-durable'),
+        false,
+        namedNode('http://example.org/activity'),
+      ),
+    );
+
+    expect(out).toEqual([
+      ['http://example.org/measurement', RDF_TYPE, DQV_QUALITY_MEASUREMENT],
+      [
+        'http://example.org/measurement',
+        DQV_COMPUTED_ON,
+        'http://example.org/subset',
+      ],
+      [
+        'http://example.org/measurement',
+        DQV_IS_MEASUREMENT_OF,
+        'https://def.nde.nl/metric#subject-namespace-durable',
+      ],
+      ['http://example.org/measurement', DQV_VALUE, `false^^${XSD_BOOLEAN}`],
+      [
+        'http://example.org/measurement',
+        PROV_WAS_GENERATED_BY,
+        'http://example.org/activity',
+      ],
+    ]);
+  });
+});


### PR DESCRIPTION
## What

Extracts the DQV/PROV measurement helpers that were duplicated across the analysis stages into a single shared module, completing the second half of #319 (the first half – consolidating the namespace-IRI constants via `src/namespaces.ts` + `@tpluscode/rdf-ns-builders` – landed in #362).

## How

- **`src/measurements.ts`** exports `provActivity`, `integerMeasurement`, and `booleanMeasurement` – the `prov:Activity` shape and the typed `dqv:QualityMeasurement` shape the stages emit. `provActivity` takes a single input or an array (one `prov:used` per input, in order); the integer/boolean variants share a private `typedMeasurement`. Node parameters accept a skolem `NamedNode` or a `BlankNode`, covering both the skolemized stages and the blank-node-based `qualityMeasurementsStage`.
- **`iiifValidationExecutor.ts`**, **`qualityMeasurementsStage.ts`**, and **`subjectUriResolution.ts`** now import these helpers and drop their per-stage copies (`integerMeasurement` was declared independently in two of them; the PROV-activity boilerplate was inlined in all three).
- The emitted quads are unchanged: the existing per-stage tests assert exact IRIs and pass unmodified. New unit tests cover the shared helpers directly as a drift guard.

Fix #319
