### PR TITLE
fix: keep an ARK/Handle PID namespace even when it is a terminology prefix

### DIFF
--- a/src/subjectUriResolution.ts
+++ b/src/subjectUriResolution.ts
@@ -434,7 +434,17 @@ async function sampleUrisWithRetry(
   }
 }
 
-/** Pick the subset with the most entities whose namespace is not a terminology source. */
+/**
+ * Pick the subset with the most entities whose namespace is not a terminology
+ * source — unless that namespace is itself a recognised ARK/Handle PID scheme.
+ *
+ * A NAAN registered as a Network of Terms source can also be the publisher’s own
+ * persistent-identifier namespace: the Gouda Tijdmachine dataset mints its
+ * resources under `https://n2t.net/ark:/60537/`, which the `goudatijdmachine-
+ * straten` terminology source declares as a terms prefix too. Excluding it would
+ * pick a referenced vendor namespace instead and lose the ARK detection, so
+ * PID-ness overrides the terminology exclusion (#373).
+ */
 function pickWinner(
   uriSpaceBySubset: ReadonlyMap<string, string>,
   entitiesBySubset: ReadonlyMap<string, number>,
@@ -442,7 +452,10 @@ function pickWinner(
 ): {subset: string; uriSpace: string} | undefined {
   let best: {subset: string; uriSpace: string; entities: number} | undefined;
   for (const [subset, uriSpace] of uriSpaceBySubset) {
-    if (terminologyPrefixes.some(prefix => uriSpace.startsWith(prefix))) {
+    if (
+      detectPidScheme(uriSpace) === undefined &&
+      terminologyPrefixes.some(prefix => uriSpace.startsWith(prefix))
+    ) {
       continue;
     }
     const entities = entitiesBySubset.get(subset) ?? 0;

--- a/test/subjectUriResolution.test.ts
+++ b/test/subjectUriResolution.test.ts
@@ -206,6 +206,44 @@ describe('subjectUriResolution', () => {
     expect(seen).toEqual(['http://example.org/id/']);
   });
 
+  it('keeps an ARK PID namespace even when it is also a terminology prefix', async () => {
+    // The Gouda Tijdmachine dataset mints its resources under ark:/60537/, a NAAN
+    // the `goudatijdmachine-straten` Network of Terms source declares as a terms
+    // prefix too. The bigger vendor namespace must not be picked over it: PID-ness
+    // overrides the terminology exclusion (#373).
+    const ark = subset('https://n2t.net/ark:/60537/', 1552002);
+    const vendor = subset(
+      'https://www.goudatijdmachine.nl/omeka/api/resources/',
+      1518244,
+    );
+    const seen: string[] = [];
+    const transform = subjectUriResolution({
+      terminologyPrefixes: ['https://n2t.net/ark:/60537/'],
+      sampleUris: async uriSpace => {
+        seen.push(uriSpace);
+        return ['https://n2t.net/ark:/60537/good-1'];
+      },
+      resolve: resolveByName,
+      lookupOrg: noOrg,
+    });
+
+    const out = await collect(
+      transform(stream([...ark.quads, ...vendor.quads]), context),
+    );
+
+    // The ARK namespace is sampled, not the larger vendor one …
+    expect(seen).toEqual(['https://n2t.net/ark:/60537/']);
+    // … and its PID scheme is declared.
+    expect(
+      out.some(
+        q =>
+          q.subject.equals(ark.node) &&
+          q.predicate.equals(DCTERMS_CONFORMS_TO) &&
+          q.object.equals(ARK_SCHEME),
+      ),
+    ).toBe(true);
+  });
+
   it('emits nothing extra when only terminology namespaces survive', async () => {
     const terminology = subset('http://data.rkd.nl/artists/', 900000);
     const transform = subjectUriResolution({


### PR DESCRIPTION
## Problem

Fix #373.

PID detection picked the wrong subject namespace for the [Gouda Tijdmachine dataset](https://datasetregister.netwerkdigitaalerfgoed.nl/dataset?uri=https://n2t.net/ark:/60537/bD64Hu), leaving only `subject-uris-sampling-failed = true`.

GTM mints its resources under `https://n2t.net/ark:/60537/`. That same NAAN is also declared as a `termsPrefixes` entry by the `goudatijdmachine-straten` Network of Terms source (owned by GTM itself). `pickWinner` unconditionally excluded any namespace matching a terminology prefix, so the ranking became:

- `https://n2t.net/ark:/60537/` (1,552,002 entities) → excluded as a terms prefix.
- `https://www.goudatijdmachine.nl/omeka/api/resources/` (1,518,244) → next survivor → winner.

The winner is not an ARK/Handle prefix, so no `pid-scheme#ark` was declared, and sampling against it failed.

## Fix

Run PID detection before the terminology exclusion (option 3 from the issue): a recognised ARK/Handle prefix is a persistent-identifier scheme for the publisher’s own minted resources, so PID-ness overrides the terminology exclusion. One condition in `pickWinner`:

```ts
if (
  detectPidScheme(uriSpace) === undefined &&
  terminologyPrefixes.some(prefix => uriSpace.startsWith(prefix))
) {
  continue;
}
```

The other options were rejected as either too broad (dropping the terminology exclusion entirely reintroduces picking referenced vocabularies) or heavier than warranted (owner-aware exclusion needs publisher-matching plumbing the PID signal already captures).

GTM will be reprocessed automatically: the release-please patch bump rotates `pipelineVersion`.

## Tests

Added a regression test asserting the ARK namespace is sampled over the larger vendor namespace and its `pid-scheme#ark` is declared. Full suite: 129 passing; compile and lint clean.
