### PR TITLE
feat(subject-uri-resolution): accept RDF responses, promote HTML landing pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "fetch-sparql-endpoint": "^7.1.1",
         "n3": "^2.0.4",
         "p-limit": "^7.3.0",
-        "rdf-dereference": "^5.0.0"
+        "rdf-dereference": "^5.0.0",
+        "rdf-parse": "^5.0.0"
       },
       "devDependencies": {
         "@comunica/query-sparql-rdfjs-lite": "^5.2.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "fetch-sparql-endpoint": "^7.1.1",
     "n3": "^2.0.4",
     "p-limit": "^7.3.0",
-    "rdf-dereference": "^5.0.0"
+    "rdf-dereference": "^5.0.0",
+    "rdf-parse": "^5.0.0"
   },
   "devDependencies": {
     "@comunica/query-sparql-rdfjs-lite": "^5.2.3",

--- a/src/subjectUriResolution.ts
+++ b/src/subjectUriResolution.ts
@@ -784,11 +784,12 @@ const RESOLVE_ACCEPT =
   'application/trig;q=0.8,application/n-quads;q=0.8';
 
 /**
- * Cap on the bytes handed to the RDF parser, so parsing a large body cannot turn
- * a sample check into a CPU sink. Generous: a few sampled resources, parsed at
- * most once each.
+ * Cap on how many bytes of a response body we read, so a single sampled URI that
+ * returns a huge body (a misconfigured multi-GB dump, an unbounded stream) cannot
+ * turn a sample check into a memory or CPU sink. Generous: enough to hold any
+ * real landing page or to parse a sampled resource's RDF.
  */
-const MAX_PARSE_BYTES = 2_000_000;
+export const MAX_BODY_BYTES = 2_000_000;
 
 /** The media type of a response, lower-cased with any parameters stripped. */
 function mediaTypeOf(response: Response): string {
@@ -796,6 +797,44 @@ function mediaTypeOf(response: Response): string {
     .split(';')[0]
     .trim()
     .toLowerCase();
+}
+
+/**
+ * Read at most {@link MAX_BODY_BYTES} bytes of the response body as UTF-8 text,
+ * then cancel the rest of the stream (releasing the connection). Bounds memory
+ * for the self-reference scan and the RDF parse regardless of the body's size or
+ * a missing Content-Length. Falls back to `response.text()` when the body is not
+ * a readable stream (e.g. a stubbed Response in tests). Rejects on a transport
+ * error, which the caller treats as a transient `network-error`.
+ */
+async function readBoundedText(response: Response): Promise<string> {
+  const body = response.body;
+  if (!body) {
+    return response.text();
+  }
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let text = '';
+  let bytesRead = 0;
+  try {
+    for (;;) {
+      const {done, value} = await reader.read();
+      if (done) break;
+      // Take only up to the remaining budget from this chunk, so a body that
+      // arrives in one large chunk is still bounded, not appended whole.
+      const remaining = MAX_BODY_BYTES - bytesRead;
+      const chunk =
+        value.byteLength > remaining ? value.subarray(0, remaining) : value;
+      // stream: true so a multi-byte character split across chunks decodes correctly.
+      text += decoder.decode(chunk, {stream: true});
+      bytesRead += chunk.byteLength;
+      if (bytesRead >= MAX_BODY_BYTES) break;
+    }
+  } finally {
+    // Stop downloading the remainder and free the socket for reuse.
+    await reader.cancel().catch(() => {});
+  }
+  return text + decoder.decode();
 }
 
 /**
@@ -842,12 +881,12 @@ function rdfParseContentType(mediaType: string): string | null {
 }
 
 /**
- * Whether `body` parses as at least one RDF quad under `contentType`, capped at
- * {@link MAX_PARSE_BYTES}. Uses rdf-parse — the parser behind the project's
- * `rdf-dereference` — so every serialisation it supports (the Turtle family,
- * JSON-LD, RDF/XML) is recognised, not just the Turtle family. `baseIri`
- * resolves relative IRIs (the response's final, redirected URL). A parser error,
- * or zero quads, means “not RDF”.
+ * Whether `body` parses as at least one RDF quad under `contentType`. Uses
+ * rdf-parse — the parser behind the project's `rdf-dereference` — so every
+ * serialisation it supports (the Turtle family, JSON-LD, RDF/XML) is recognised,
+ * not just the Turtle family. `body` is already bounded by {@link readBoundedText}.
+ * `baseIri` resolves relative IRIs (the response's final, redirected URL). A
+ * parser error, or zero quads, means “not RDF”.
  */
 function bodyParsesAsRdf(
   body: string,
@@ -857,13 +896,10 @@ function bodyParsesAsRdf(
   return new Promise(resolve => {
     let parsed: Readable;
     try {
-      parsed = rdfParser.parse(
-        Readable.from([body.slice(0, MAX_PARSE_BYTES)]),
-        {
-          contentType,
-          baseIRI: baseIri,
-        },
-      ) as unknown as Readable;
+      parsed = rdfParser.parse(Readable.from([body]), {
+        contentType,
+        baseIRI: baseIri,
+      }) as unknown as Readable;
     } catch {
       resolve(false);
       return;
@@ -911,7 +947,7 @@ const defaultResolve: ResolveUri = async (uri, signal) => {
   if (mediaType === 'text/html') {
     let body: string;
     try {
-      body = await response.text();
+      body = await readBoundedText(response);
     } catch {
       // A `200 text/html` whose body cannot be read is a transport failure.
       return {kind: 'failed', reason: 'network-error'};
@@ -933,7 +969,7 @@ const defaultResolve: ResolveUri = async (uri, signal) => {
   }
   let body: string;
   try {
-    body = await response.text();
+    body = await readBoundedText(response);
   } catch {
     return {kind: 'failed', reason: 'network-error'};
   }

--- a/src/subjectUriResolution.ts
+++ b/src/subjectUriResolution.ts
@@ -1,4 +1,6 @@
-import {DataFactory, Parser} from 'n3';
+import {Readable} from 'node:stream';
+import {DataFactory} from 'n3';
+import {rdfParser} from 'rdf-parse';
 import pLimit from 'p-limit';
 import {SparqlEndpointFetcher, type IBindings} from 'fetch-sparql-endpoint';
 import type {NamedNode, Quad} from '@rdfjs/types';
@@ -782,38 +784,9 @@ const RESOLVE_ACCEPT =
   'application/trig;q=0.8,application/n-quads;q=0.8';
 
 /**
- * Content types that mark a response as RDF on their own, so it resolves without
- * parsing the body. Matched on the media type alone (parameters stripped).
- */
-const RDF_MEDIA_TYPES: ReadonlySet<string> = new Set([
-  'text/turtle',
-  'application/trig',
-  'application/n-triples',
-  'application/n-quads',
-  'application/ld+json',
-  'application/rdf+xml',
-  'text/n3',
-  'application/n3',
-]);
-
-/**
- * Content types too generic to trust either way — a misconfigured server may
- * serve Turtle as `text/plain` or send no type at all. These get a best-effort
- * RDF parse of the body (see {@link parsesAsRdf}) rather than being rejected on
- * the header alone. Anything outside this set that is neither HTML nor a
- * {@link RDF_MEDIA_TYPES known RDF type} (e.g. `image/png`) is not RDF, so it is
- * rejected without the cost of a parse.
- */
-const AMBIGUOUS_MEDIA_TYPES: ReadonlySet<string> = new Set([
-  '',
-  'text/plain',
-  'application/octet-stream',
-]);
-
-/**
- * Cap on the body we attempt to parse as RDF, so a large `application/octet-stream`
- * cannot turn a sample check into a memory or CPU sink. Generous: a few sampled
- * resources, parsed at most once each.
+ * Cap on the bytes handed to the RDF parser, so parsing a large body cannot turn
+ * a sample check into a CPU sink. Generous: a few sampled resources, parsed at
+ * most once each.
  */
 const MAX_PARSE_BYTES = 2_000_000;
 
@@ -826,18 +799,84 @@ function mediaTypeOf(response: Response): string {
 }
 
 /**
- * Whether `body` parses as RDF. Uses the N3 parser, which covers the Turtle
- * family (Turtle, TriG, N-Triples, N-Quads, N3) — the serialisations a server is
- * apt to mislabel as plain text or octet-stream. JSON-LD and RDF/XML are
- * recognised by their {@link RDF_MEDIA_TYPES content type} instead, so they need
- * no parse here. A single quad is enough; a syntax error means “not RDF”.
+ * Map a response media type to a content type rdf-parse understands, or `null`
+ * when the response is plainly non-RDF binary (so a doomed parse is skipped).
+ * rdf-parse does not sniff — it needs an explicit content type — so a generic or
+ * mislabelled type is mapped to a best-effort serialisation rather than rejected
+ * on the header alone: a JSON body is tried as JSON-LD, an XML body as RDF/XML,
+ * and anything else text-ish (`text/plain`, octet-stream, no type) as Turtle
+ * (which also accepts N-Triples). A type rdf-parse already knows passes through
+ * unchanged. The body is then parsed to confirm it really is RDF (see
+ * {@link bodyParsesAsRdf}), so a server that merely *claims* an RDF content type
+ * cannot resolve on the header alone.
  */
-function parsesAsRdf(body: string): boolean {
-  try {
-    return new Parser().parse(body.slice(0, MAX_PARSE_BYTES)).length > 0;
-  } catch {
-    return false;
+function rdfParseContentType(mediaType: string): string | null {
+  if (
+    mediaType.startsWith('image/') ||
+    mediaType.startsWith('video/') ||
+    mediaType.startsWith('audio/') ||
+    mediaType.startsWith('font/') ||
+    mediaType === 'application/pdf' ||
+    mediaType === 'application/zip'
+  ) {
+    return null;
   }
+  if (mediaType === 'application/json' || mediaType.endsWith('+json')) {
+    return 'application/ld+json';
+  }
+  if (
+    mediaType === 'application/xml' ||
+    mediaType === 'text/xml' ||
+    mediaType.endsWith('+xml')
+  ) {
+    return 'application/rdf+xml';
+  }
+  if (
+    mediaType === '' ||
+    mediaType === 'text/plain' ||
+    mediaType === 'application/octet-stream'
+  ) {
+    return 'text/turtle';
+  }
+  return mediaType;
+}
+
+/**
+ * Whether `body` parses as at least one RDF quad under `contentType`, capped at
+ * {@link MAX_PARSE_BYTES}. Uses rdf-parse — the parser behind the project's
+ * `rdf-dereference` — so every serialisation it supports (the Turtle family,
+ * JSON-LD, RDF/XML) is recognised, not just the Turtle family. `baseIri`
+ * resolves relative IRIs (the response's final, redirected URL). A parser error,
+ * or zero quads, means “not RDF”.
+ */
+function bodyParsesAsRdf(
+  body: string,
+  contentType: string,
+  baseIri: string,
+): Promise<boolean> {
+  return new Promise(resolve => {
+    let parsed: Readable;
+    try {
+      parsed = rdfParser.parse(
+        Readable.from([body.slice(0, MAX_PARSE_BYTES)]),
+        {
+          contentType,
+          baseIRI: baseIri,
+        },
+      ) as unknown as Readable;
+    } catch {
+      resolve(false);
+      return;
+    }
+    let found = false;
+    parsed.on('data', () => {
+      found = true;
+      parsed.destroy();
+    });
+    parsed.on('error', () => resolve(false));
+    parsed.on('end', () => resolve(found));
+    parsed.on('close', () => resolve(found));
+  });
 }
 
 /**
@@ -883,21 +922,24 @@ const defaultResolve: ResolveUri = async (uri, signal) => {
       landingPage: body.includes(uri) || body.includes(htmlEscape(uri)),
     };
   }
-  if (RDF_MEDIA_TYPES.has(mediaType)) {
-    return {kind: 'resolved', landingPage: false};
+  // Not HTML: confirm the body parses as RDF. rdf-parse needs the content type,
+  // so a generic or mislabelled one is mapped to a best-effort serialisation
+  // (see rdfParseContentType); a plainly non-RDF binary type is rejected without
+  // a parse. The parse — not the header — is the authority, so a server that only
+  // claims an RDF content type but serves an error/HTML body does not resolve.
+  const parseContentType = rdfParseContentType(mediaType);
+  if (parseContentType === null) {
+    return {kind: 'failed', reason: 'wrong-content-type'};
   }
-  if (AMBIGUOUS_MEDIA_TYPES.has(mediaType)) {
-    let body: string;
-    try {
-      body = await response.text();
-    } catch {
-      return {kind: 'failed', reason: 'network-error'};
-    }
-    if (parsesAsRdf(body)) {
-      return {kind: 'resolved', landingPage: false};
-    }
+  let body: string;
+  try {
+    body = await response.text();
+  } catch {
+    return {kind: 'failed', reason: 'network-error'};
   }
-  return {kind: 'failed', reason: 'wrong-content-type'};
+  return (await bodyParsesAsRdf(body, parseContentType, response.url || uri))
+    ? {kind: 'resolved', landingPage: false}
+    : {kind: 'failed', reason: 'wrong-content-type'};
 };
 
 /**

--- a/src/subjectUriResolution.ts
+++ b/src/subjectUriResolution.ts
@@ -1,4 +1,4 @@
-import {DataFactory} from 'n3';
+import {DataFactory, Parser} from 'n3';
 import pLimit from 'p-limit';
 import {SparqlEndpointFetcher, type IBindings} from 'fetch-sparql-endpoint';
 import type {NamedNode, Quad} from '@rdfjs/types';
@@ -29,14 +29,18 @@ const SUBJECT_RESOLUTION_FAILURE_BASE =
   'https://def.nde.nl/subject-resolution-failure#';
 
 /**
- * Why a sampled subject URI did not resolve to a self-describing landing page.
- * Mirrors the `subject-resolution-failure` concept scheme; a `null` outcome
- * (resolved) is represented out-of-band.
+ * Why a sampled subject URI did not resolve. A subject URI resolves when it
+ * dereferences to a `2xx` response that is either an HTML page or RDF (any
+ * serialisation); {@link Resolution} carries that success out-of-band, so this
+ * enum names only the failures. Whether a resolved HTML page is a *landing page*
+ * (it self-references its own URI) is a separate, non-failing distinction — see
+ * {@link Resolution}. Mirrors the `subject-resolution-failure` concept scheme.
  *
  * Outcomes split into two classes (see {@link isTransientFailure}):
- * - **definitive** — `http-error` (a non-retryable `4xx` such as `404`/`410`),
- *   `wrong-content-type`, `no-self-reference`: a genuine, dataset-attributable
- *   defect. Counted against the ratio and persisted in the PROV trail.
+ * - **definitive** — `http-error` (a non-retryable `4xx` such as `404`/`410`)
+ *   and `wrong-content-type` (a `2xx` that is neither HTML nor RDF, e.g. a JSON
+ *   or plain-text error page): a genuine, dataset-attributable defect. Counted
+ *   against the ratio and persisted in the PROV trail.
  * - **transient** — `timeout`, `network-error`, `server-error` (a retryable HTTP
  *   status: `408`/`425`/`429`/`5xx`): a blip in the multi-hop PID-resolver
  *   chain, not a property of the dataset.
@@ -48,8 +52,7 @@ export type SubjectResolutionFailure =
   | 'network-error'
   | 'server-error'
   | 'http-error'
-  | 'wrong-content-type'
-  | 'no-self-reference';
+  | 'wrong-content-type';
 
 /**
  * Transient failures: a slow or briefly unavailable hop in the resolver chain,
@@ -180,10 +183,23 @@ export type SampleUris = (
 ) => Promise<string[]>;
 
 /**
- * Resolves a sampled URI and classifies the outcome: `null` when it lands on a
- * self-describing page (a `200`, `text/html` response whose body advertises the
- * original URI), otherwise the {@link SubjectResolutionFailure} describing why
- * it did not. The optional `signal` carries the overall
+ * The outcome of dereferencing a sampled URI:
+ * - `resolved` — a `2xx` response that is HTML or RDF. `landingPage` is `true`
+ *   only when it is an HTML page that self-references its own URI (a
+ *   human-readable landing page for the identifier); `false` for RDF, or for
+ *   HTML that does not mention the URI. A resolved URI counts toward
+ *   `subject-uris-resolved` regardless of `landingPage`; the flag only feeds the
+ *   (non-failing) `subject-uris-html-landing-pages` count that promotes HTML
+ *   landing pages.
+ * - `failed` — see {@link SubjectResolutionFailure}.
+ */
+export type Resolution =
+  | {readonly kind: 'resolved'; readonly landingPage: boolean}
+  | {readonly kind: 'failed'; readonly reason: SubjectResolutionFailure};
+
+/**
+ * Dereferences a sampled URI and classifies the outcome (see {@link Resolution}).
+ * The optional `signal` carries the overall
  * {@link DEREFERENCE_PHASE_BUDGET_MS phase budget}; honour it on the underlying
  * request so a flaky chain aborts rather than running its full per-request
  * timeout once the budget is spent.
@@ -191,7 +207,7 @@ export type SampleUris = (
 export type ResolveUri = (
   uri: string,
   signal?: AbortSignal,
-) => Promise<SubjectResolutionFailure | null>;
+) => Promise<Resolution>;
 
 /** Looks up the issuing organisation’s name for an ARK NAAN, if available. */
 export type LookupOrg = (naan: string) => Promise<string | undefined>;
@@ -237,8 +253,10 @@ export interface SubjectUriResolutionOptions {
  *
  * - **declared** facts: `dcterms:conformsTo` a PID scheme (ARK/Handle, only if
  *   recognised) and `dcterms:publisher` the ARK issuing org (non-fatal);
- * - **validated** facts: `subject-uris-sampled` / `subject-uris-resolved` DQV
- *   measurements plus a PROV activity.
+ * - **validated** facts: `subject-uris-sampled` / `subject-uris-resolved` /
+ *   `subject-uris-html-landing-pages` DQV measurements plus a PROV activity.
+ *   A URI resolves when it dereferences to HTML or RDF; the landing-page count
+ *   tracks how many resolved to an HTML page that self-references its own URI.
  * - **durability** facts: a `subject-namespace-durable = false` DQV measurement
  *   when the chosen namespace matches the {@link NON_DURABLE_NAMESPACES}
  *   disallow list — emitted independently of sampling, so it survives an
@@ -336,20 +354,24 @@ export function subjectUriResolution(
         ),
       );
 
-      // Classify each settled outcome. A `null` resolves; a *definitive* reason
-      // is a real defect — counted and persisted. A *transient* reason survived
-      // every retry, so the resolver chain (not the dataset) is at fault: drop
-      // the URI from the sample entirely rather than scoring it as broken.
+      // Classify each settled outcome. A resolution counts toward the ratio,
+      // and toward the HTML-landing-page tally when it is one. A *definitive*
+      // failure is a real defect — counted and persisted. A *transient* failure
+      // survived every retry, so the resolver chain (not the dataset) is at
+      // fault: drop the URI from the sample entirely rather than scoring it as
+      // broken.
       let resolved = 0;
+      let htmlLandingPages = 0;
       const failures: SampleFailure[] = [];
       sampled.forEach((uri, index) => {
-        const reason = outcomes[index];
-        if (reason === null) {
+        const outcome = outcomes[index];
+        if (outcome.kind === 'resolved') {
           resolved++;
-        } else if (!isTransientFailure(reason)) {
+          if (outcome.landingPage) htmlLandingPages++;
+        } else if (!isTransientFailure(outcome.reason)) {
           failures.push({
             url: uri,
-            reasonIri: subjectResolutionFailureIri(reason),
+            reasonIri: subjectResolutionFailureIri(outcome.reason),
           });
         }
       });
@@ -364,6 +386,7 @@ export function subjectUriResolution(
           subset,
           measurable,
           resolved,
+          htmlLandingPages,
           failures,
           software,
         );
@@ -378,9 +401,9 @@ export function subjectUriResolution(
 }
 
 /**
- * Resolve a URI, retrying a {@link isTransientFailure transient} outcome with
- * exponential backoff up to `retries` times. Returns the final outcome: `null`
- * (resolved), a definitive failure, or — once retries are exhausted — the last
+ * Resolve a URI, retrying a {@link isTransientFailure transient} failure with
+ * exponential backoff up to `retries` times. Returns the final outcome: a
+ * resolution, a definitive failure, or — once retries are exhausted — the last
  * transient failure. An unexpected rejection from `resolve` is treated as a
  * transient `network-error`, so a flaky check is retried rather than surfacing a
  * stray non-resolution. Stops early once `signal` (the overall phase budget)
@@ -392,17 +415,17 @@ async function resolveWithRetry(
   retries: number,
   sleep: Sleep,
   signal: AbortSignal,
-): Promise<SubjectResolutionFailure | null> {
-  let outcome: SubjectResolutionFailure | null;
+): Promise<Resolution> {
+  let outcome: Resolution;
   for (let attempt = 0; ; attempt++) {
     try {
       outcome = await resolve(uri, signal);
     } catch {
-      outcome = 'network-error';
+      outcome = {kind: 'failed', reason: 'network-error'};
     }
     if (
-      outcome === null ||
-      !isTransientFailure(outcome) ||
+      outcome.kind === 'resolved' ||
+      !isTransientFailure(outcome.reason) ||
       attempt >= retries ||
       signal.aborted
     ) {
@@ -536,6 +559,7 @@ function* measurementQuads(
   subset: NamedNode,
   sampled: number,
   resolved: number,
+  htmlLandingPages: number,
   failures: readonly SampleFailure[],
   software: NamedNode,
 ): Generator<Quad> {
@@ -547,15 +571,21 @@ function* measurementQuads(
   yield* provActivity(activity, subset, software);
   yield* failureUsageQuads(activity, failures);
 
-  // Validated facts — the sampled/resolved ratio, for any namespace.
+  // Validated facts — the sampled/resolved ratio, for any namespace, plus how
+  // many of the resolved URIs served an HTML landing page (a non-failing signal
+  // that promotes human-readable pages without gating the ratio on them).
   const sampledMeasurement = namedNode(
     skolemIri(subset.value, 'measurement', 'subject-uris-sampled'),
   );
   const resolvedMeasurement = namedNode(
     skolemIri(subset.value, 'measurement', 'subject-uris-resolved'),
   );
+  const htmlLandingPagesMeasurement = namedNode(
+    skolemIri(subset.value, 'measurement', 'subject-uris-html-landing-pages'),
+  );
   yield quad(subset, dqv.hasQualityMeasurement, sampledMeasurement);
   yield quad(subset, dqv.hasQualityMeasurement, resolvedMeasurement);
+  yield quad(subset, dqv.hasQualityMeasurement, htmlLandingPagesMeasurement);
 
   yield* integerMeasurement(
     sampledMeasurement,
@@ -569,6 +599,13 @@ function* measurementQuads(
     subset,
     metric['subject-uris-resolved'],
     resolved,
+    activity,
+  );
+  yield* integerMeasurement(
+    htmlLandingPagesMeasurement,
+    subset,
+    metric['subject-uris-html-landing-pages'],
+    htmlLandingPages,
     activity,
   );
 }
@@ -734,11 +771,83 @@ const defaultSampleUris: SampleUris = async (
 };
 
 /**
- * Default resolution check: follow redirects to the landing page and require a
- * `200`, `text/html` response that advertises the original sampled URI (raw or
- * HTML-entity-escaped) — the permanent link back to the user, which matters
- * because we landed on a different, redirected URL. Returns `null` on success,
- * otherwise the {@link SubjectResolutionFailure} classifying the breakage.
+ * Accept header for dereferencing: HTML is preferred (unweighted, so `q=1`) so a
+ * server that *can* serve a human-readable landing page does — which is what the
+ * `landingPage` signal promotes — with the common RDF serialisations offered as
+ * acceptable fallbacks for a data-only namespace.
+ */
+const RESOLVE_ACCEPT =
+  'text/html,application/ld+json;q=0.9,text/turtle;q=0.9,' +
+  'application/rdf+xml;q=0.8,application/n-triples;q=0.8,' +
+  'application/trig;q=0.8,application/n-quads;q=0.8';
+
+/**
+ * Content types that mark a response as RDF on their own, so it resolves without
+ * parsing the body. Matched on the media type alone (parameters stripped).
+ */
+const RDF_MEDIA_TYPES: ReadonlySet<string> = new Set([
+  'text/turtle',
+  'application/trig',
+  'application/n-triples',
+  'application/n-quads',
+  'application/ld+json',
+  'application/rdf+xml',
+  'text/n3',
+  'application/n3',
+]);
+
+/**
+ * Content types too generic to trust either way — a misconfigured server may
+ * serve Turtle as `text/plain` or send no type at all. These get a best-effort
+ * RDF parse of the body (see {@link parsesAsRdf}) rather than being rejected on
+ * the header alone. Anything outside this set that is neither HTML nor a
+ * {@link RDF_MEDIA_TYPES known RDF type} (e.g. `image/png`) is not RDF, so it is
+ * rejected without the cost of a parse.
+ */
+const AMBIGUOUS_MEDIA_TYPES: ReadonlySet<string> = new Set([
+  '',
+  'text/plain',
+  'application/octet-stream',
+]);
+
+/**
+ * Cap on the body we attempt to parse as RDF, so a large `application/octet-stream`
+ * cannot turn a sample check into a memory or CPU sink. Generous: a few sampled
+ * resources, parsed at most once each.
+ */
+const MAX_PARSE_BYTES = 2_000_000;
+
+/** The media type of a response, lower-cased with any parameters stripped. */
+function mediaTypeOf(response: Response): string {
+  return (response.headers.get('content-type') ?? '')
+    .split(';')[0]
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * Whether `body` parses as RDF. Uses the N3 parser, which covers the Turtle
+ * family (Turtle, TriG, N-Triples, N-Quads, N3) — the serialisations a server is
+ * apt to mislabel as plain text or octet-stream. JSON-LD and RDF/XML are
+ * recognised by their {@link RDF_MEDIA_TYPES content type} instead, so they need
+ * no parse here. A single quad is enough; a syntax error means “not RDF”.
+ */
+function parsesAsRdf(body: string): boolean {
+  try {
+    return new Parser().parse(body.slice(0, MAX_PARSE_BYTES)).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Default resolution check: follow redirects and accept any `2xx` that is HTML
+ * or RDF. An HTML page that advertises the original sampled URI (raw or
+ * HTML-entity-escaped) is a {@link Resolution landing page} — a human-readable
+ * page for the identifier, the permanent link back to the user, which matters
+ * because we may have landed on a different, redirected URL. RDF (or HTML that
+ * does not mention the URI) still resolves; it just is not a landing page. A
+ * `2xx` that is neither HTML nor RDF is a `wrong-content-type` failure.
  */
 const defaultResolve: ResolveUri = async (uri, signal) => {
   // The request aborts on whichever fires first: its own per-request timeout or
@@ -749,26 +858,46 @@ const defaultResolve: ResolveUri = async (uri, signal) => {
   try {
     response = await fetch(uri, {
       redirect: 'follow',
-      headers: {accept: 'text/html'},
+      headers: {accept: RESOLVE_ACCEPT},
       signal: abort,
     });
   } catch (error) {
-    return classifyFetchError(error);
+    return {kind: 'failed', reason: classifyFetchError(error)};
   }
-  if (!response.ok) return classifyHttpStatus(response.status);
-  if (!(response.headers.get('content-type') ?? '').includes('text/html')) {
-    return 'wrong-content-type';
+  if (!response.ok) {
+    return {kind: 'failed', reason: classifyHttpStatus(response.status)};
   }
-  let body: string;
-  try {
-    body = await response.text();
-  } catch {
-    // A `200 text/html` whose body cannot be read is a transport failure.
-    return 'network-error';
+
+  const mediaType = mediaTypeOf(response);
+  if (mediaType === 'text/html') {
+    let body: string;
+    try {
+      body = await response.text();
+    } catch {
+      // A `200 text/html` whose body cannot be read is a transport failure.
+      return {kind: 'failed', reason: 'network-error'};
+    }
+    // A landing page advertises its own URI; HTML that does not still resolves.
+    return {
+      kind: 'resolved',
+      landingPage: body.includes(uri) || body.includes(htmlEscape(uri)),
+    };
   }
-  return body.includes(uri) || body.includes(htmlEscape(uri))
-    ? null
-    : 'no-self-reference';
+  if (RDF_MEDIA_TYPES.has(mediaType)) {
+    return {kind: 'resolved', landingPage: false};
+  }
+  if (AMBIGUOUS_MEDIA_TYPES.has(mediaType)) {
+    let body: string;
+    try {
+      body = await response.text();
+    } catch {
+      return {kind: 'failed', reason: 'network-error'};
+    }
+    if (parsesAsRdf(body)) {
+      return {kind: 'resolved', landingPage: false};
+    }
+  }
+  return {kind: 'failed', reason: 'wrong-content-type'};
 };
 
 /**

--- a/test/subjectUriResolution.test.ts
+++ b/test/subjectUriResolution.test.ts
@@ -36,6 +36,7 @@ const XSD_BOOLEAN = namedNode('http://www.w3.org/2001/XMLSchema#boolean');
 const METRIC_BASE = 'https://def.nde.nl/metric#';
 const SAMPLED_METRIC = `${METRIC_BASE}subject-uris-sampled`;
 const RESOLVED_METRIC = `${METRIC_BASE}subject-uris-resolved`;
+const HTML_LANDING_PAGES_METRIC = `${METRIC_BASE}subject-uris-html-landing-pages`;
 const DURABLE_METRIC = `${METRIC_BASE}subject-namespace-durable`;
 const SAMPLING_FAILED_METRIC = `${METRIC_BASE}subject-uris-sampling-failed`;
 const ARK_SCHEME = namedNode('https://def.nde.nl/pid-scheme#ark');
@@ -135,9 +136,12 @@ const sampleFixed =
   (uris: string[]): SampleUris =>
   async () =>
     uris;
-// `null` means resolved; a non-`good` URI fails with a typed reason.
+// A `good` URI resolves (to RDF, not an HTML landing page); a non-`good` URI
+// fails with a typed reason.
 const resolveByName: ResolveUri = async uri =>
-  uri.includes('good') ? null : 'http-error';
+  uri.includes('good')
+    ? {kind: 'resolved', landingPage: false}
+    : {kind: 'failed', reason: 'http-error'};
 const noOrg: LookupOrg = async () => undefined;
 
 describe('subjectUriResolution', () => {
@@ -164,13 +168,16 @@ describe('subjectUriResolution', () => {
     // Measurements are computed on the subset node, not the dataset.
     expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBe(3);
     expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(2);
+    // Both resolved to RDF, not an HTML landing page, so the landing-page count
+    // is 0 — emitted regardless, so the advisory can tell 0 from absent.
+    expect(measurementValue(out, HTML_LANDING_PAGES_METRIC, ns.node)).toBe(0);
     expect(
       out.filter(
         q =>
           q.subject.equals(ns.node) &&
           q.predicate.equals(DQV_HAS_QUALITY_MEASUREMENT),
       ),
-    ).toHaveLength(2);
+    ).toHaveLength(3);
 
     // Only the failed sample is enumerated, as a qualified usage carrying its
     // typed reason; the two resolved samples are covered by the count alone.
@@ -373,7 +380,7 @@ describe('subjectUriResolution', () => {
       ]),
       resolve: async uri => {
         if (uri.includes('throws')) throw new Error('boom');
-        return null;
+        return {kind: 'resolved', landingPage: false};
       },
       sleep: async () => {},
     });
@@ -397,7 +404,10 @@ describe('subjectUriResolution', () => {
       sampleUris: sampleFixed(['http://example.org/id/flaky']),
       // Times out once, then resolves — exactly the crawl-time blip the retry
       // exists to absorb.
-      resolve: async () => (attempts++ === 0 ? 'timeout' : null),
+      resolve: async () =>
+        attempts++ === 0
+          ? {kind: 'failed', reason: 'timeout'}
+          : {kind: 'resolved', landingPage: false},
       sleep: async () => {},
     });
 
@@ -421,9 +431,9 @@ describe('subjectUriResolution', () => {
         'https://n2t.net/ark:/89268/gone-4',
       ]),
       resolve: async uri => {
-        if (uri.includes('good')) return null;
-        if (uri.includes('blip')) return 'timeout'; // transient, survives retries
-        return 'no-self-reference'; // definitive
+        if (uri.includes('good')) return {kind: 'resolved', landingPage: false};
+        if (uri.includes('blip')) return {kind: 'failed', reason: 'timeout'}; // transient, survives retries
+        return {kind: 'failed', reason: 'wrong-content-type'}; // definitive
       },
       lookupOrg: noOrg,
       sleep: async () => {},
@@ -436,7 +446,7 @@ describe('subjectUriResolution', () => {
     expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBe(3);
     expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(2);
     expect(failureReasonFor(out, 'https://n2t.net/ark:/89268/gone-4')).toBe(
-      `${SUBJECT_RESOLUTION_FAILURE_BASE}no-self-reference`,
+      `${SUBJECT_RESOLUTION_FAILURE_BASE}wrong-content-type`,
     );
     expect(
       failureReasonFor(out, 'https://n2t.net/ark:/89268/blip-3'),
@@ -451,7 +461,7 @@ describe('subjectUriResolution', () => {
         'http://example.org/id/a',
         'http://example.org/id/b',
       ]),
-      resolve: async () => 'timeout',
+      resolve: async () => ({kind: 'failed', reason: 'timeout'}),
       sleep: async () => {},
     });
 
@@ -472,7 +482,7 @@ describe('subjectUriResolution', () => {
     const transform = subjectUriResolution({
       terminologyPrefixes: [],
       sampleUris: sampleFixed(['https://n2t.net/ark:/60537/a']),
-      resolve: async () => 'timeout',
+      resolve: async () => ({kind: 'failed', reason: 'timeout'}),
       lookupOrg: noOrg,
       sleep: async () => {},
     });
@@ -753,14 +763,15 @@ describe('subjectUriResolution', () => {
       expect(measurementValueTerm(out, DURABLE_METRIC, ns.node)?.value).toBe(
         'false',
       );
-      // The subset carries all three measurements.
+      // The subset carries all four measurements (sampled, resolved,
+      // html-landing-pages, durable).
       expect(
         out.filter(
           q =>
             q.subject.equals(ns.node) &&
             q.predicate.equals(DQV_HAS_QUALITY_MEASUREMENT),
         ),
-      ).toHaveLength(3);
+      ).toHaveLength(4);
     });
   });
 
@@ -888,12 +899,58 @@ describe('subjectUriResolution', () => {
       expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBe(1);
     });
 
-    it('classifies a non-HTML content type as wrong-content-type', async () => {
+    it('classifies a 2xx that is neither HTML nor RDF as wrong-content-type', async () => {
+      const ns = subset('http://example.org/id/', 10);
       const out = await runWithFetch(
         async () =>
-          new Response('{}', {
+          new Response('{"error": "not found"}', {
             status: 200,
             headers: {'content-type': 'application/json'},
+          }),
+      );
+      // A JSON error page is neither HTML nor RDF: a definitive failure.
+      expect(failureReasonFor(out, URI)).toBe(
+        `${SUBJECT_RESOLUTION_FAILURE_BASE}wrong-content-type`,
+      );
+      expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBe(1);
+    });
+
+    it('resolves an RDF response, not counting it as a landing page', async () => {
+      const ns = subset('http://example.org/id/', 10);
+      const out = await runWithFetch(
+        async () =>
+          new Response(`<${URI}> <http://schema.org/name> "X" .`, {
+            status: 200,
+            headers: {'content-type': 'text/turtle'},
+          }),
+      );
+      // RDF resolves (counts toward the ratio) but is not an HTML landing page.
+      expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
+      expect(measurementValue(out, HTML_LANDING_PAGES_METRIC, ns.node)).toBe(0);
+      expect(failureReasonFor(out, URI)).toBeUndefined();
+    });
+
+    it('resolves a generically-typed body that parses as RDF', async () => {
+      const ns = subset('http://example.org/id/', 10);
+      const out = await runWithFetch(
+        async () =>
+          new Response(`<${URI}> <http://schema.org/name> "X" .`, {
+            status: 200,
+            headers: {'content-type': 'text/plain'},
+          }),
+      );
+      // A misconfigured server serving Turtle as text/plain still resolves: the
+      // body is parsed as a fallback when the content type is too generic.
+      expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
+      expect(failureReasonFor(out, URI)).toBeUndefined();
+    });
+
+    it('fails a generically-typed body that is not RDF', async () => {
+      const out = await runWithFetch(
+        async () =>
+          new Response('just some plain words', {
+            status: 200,
+            headers: {'content-type': 'text/plain'},
           }),
       );
       expect(failureReasonFor(out, URI)).toBe(
@@ -901,13 +958,16 @@ describe('subjectUriResolution', () => {
       );
     });
 
-    it('classifies HTML without a self-reference as no-self-reference', async () => {
+    it('resolves HTML without a self-reference, not as a landing page', async () => {
+      const ns = subset('http://example.org/id/', 10);
       const out = await runWithFetch(async () =>
         htmlResponse('<html>no link here</html>'),
       );
-      expect(failureReasonFor(out, URI)).toBe(
-        `${SUBJECT_RESOLUTION_FAILURE_BASE}no-self-reference`,
-      );
+      // HTML that does not advertise its own URI still resolves; it is just not
+      // counted as a landing page.
+      expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
+      expect(measurementValue(out, HTML_LANDING_PAGES_METRIC, ns.node)).toBe(0);
+      expect(failureReasonFor(out, URI)).toBeUndefined();
     });
 
     it('excludes an unreadable body as a transient blip', async () => {
@@ -928,12 +988,14 @@ describe('subjectUriResolution', () => {
       expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBeUndefined();
     });
 
-    it('reports a resolving, self-referencing page as resolved', async () => {
+    it('reports a self-referencing HTML page as a resolved landing page', async () => {
       const ns = subset('http://example.org/id/', 10);
       const out = await runWithFetch(async () =>
         htmlResponse(`<html><a href="${URI}">permalink</a></html>`),
       );
       expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
+      // A self-referencing HTML page is the promoted landing page.
+      expect(measurementValue(out, HTML_LANDING_PAGES_METRIC, ns.node)).toBe(1);
       expect(failureReasonFor(out, URI)).toBeUndefined();
       expect(out.some(q => q.predicate.equals(PROV_QUALIFIED_USAGE))).toBe(
         false,

--- a/test/subjectUriResolution.test.ts
+++ b/test/subjectUriResolution.test.ts
@@ -958,6 +958,40 @@ describe('subjectUriResolution', () => {
       );
     });
 
+    it('resolves JSON-LD served under a plain application/json content type', async () => {
+      const ns = subset('http://example.org/id/', 10);
+      const jsonLd = JSON.stringify({
+        '@id': URI,
+        'http://schema.org/name': 'X',
+      });
+      const out = await runWithFetch(
+        async () =>
+          new Response(jsonLd, {
+            status: 200,
+            // A common misconfiguration: JSON-LD served as application/json
+            // rather than application/ld+json. It must still resolve as RDF.
+            headers: {'content-type': 'application/json'},
+          }),
+      );
+      expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
+      expect(failureReasonFor(out, URI)).toBeUndefined();
+    });
+
+    it('fails an RDF content type whose body is not RDF', async () => {
+      const out = await runWithFetch(
+        async () =>
+          // The server claims Turtle but serves an HTML error page; the body is
+          // parsed, not trusted on the header, so this is wrong-content-type.
+          new Response('<html><body>Not found</body></html>', {
+            status: 200,
+            headers: {'content-type': 'text/turtle'},
+          }),
+      );
+      expect(failureReasonFor(out, URI)).toBe(
+        `${SUBJECT_RESOLUTION_FAILURE_BASE}wrong-content-type`,
+      );
+    });
+
     it('resolves HTML without a self-reference, not as a landing page', async () => {
       const ns = subset('http://example.org/id/', 10);
       const out = await runWithFetch(async () =>

--- a/test/subjectUriResolution.test.ts
+++ b/test/subjectUriResolution.test.ts
@@ -4,6 +4,7 @@ import type {NamedNode, Quad} from '@rdfjs/types';
 import {Dataset, Distribution} from '@lde/dataset';
 import type {ExecutorContext} from '@lde/pipeline';
 import {
+  MAX_BODY_BYTES,
   subjectUriResolution,
   type LookupOrg,
   type ResolveUri,
@@ -990,6 +991,41 @@ describe('subjectUriResolution', () => {
       expect(failureReasonFor(out, URI)).toBe(
         `${SUBJECT_RESOLUTION_FAILURE_BASE}wrong-content-type`,
       );
+    });
+
+    it('resolves a large RDF body without reading it all', async () => {
+      const ns = subset('http://example.org/id/', 10);
+      // A valid triple up front, then far more than the read cap of padding. The
+      // parse short-circuits on the first quad, so the whole body is never read.
+      const body =
+        `<${URI}> <http://schema.org/name> "X" .\n` +
+        `# ${'p'.repeat(MAX_BODY_BYTES * 2)}`;
+      const out = await runWithFetch(
+        async () =>
+          new Response(body, {
+            status: 200,
+            headers: {'content-type': 'text/turtle'},
+          }),
+      );
+      expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
+      expect(failureReasonFor(out, URI)).toBeUndefined();
+    });
+
+    it('does not see a self-reference past the body read cap', async () => {
+      const ns = subset('http://example.org/id/', 10);
+      // The self-referencing link sits beyond MAX_BODY_BYTES, so the bounded read
+      // never reaches it: the page still resolves, but not as a landing page.
+      const body = `${'x'.repeat(MAX_BODY_BYTES + 1000)}<a href="${URI}">permalink</a>`;
+      const out = await runWithFetch(
+        async () =>
+          new Response(body, {
+            status: 200,
+            headers: {'content-type': 'text/html'},
+          }),
+      );
+      expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
+      expect(measurementValue(out, HTML_LANDING_PAGES_METRIC, ns.node)).toBe(0);
+      expect(failureReasonFor(out, URI)).toBeUndefined();
     });
 
     it('resolves HTML without a self-reference, not as a landing page', async () => {


### PR DESCRIPTION
## What

Relax the subject-URI resolution check so a sampled URI counts as **resolved** when it dereferences to an HTTP `2xx` that is **HTML or RDF** — not only an HTML page that references its own URI. HTML landing pages are still promoted, now via a separate non-gating signal.

## Why

A dataset that serves perfectly good linked data at its subject URIs was scored as not resolving (`wrong-content-type`), and an HTML page that did not advertise its own URI was scored `no-self-reference`. Both dragged down `subject-uris-resolved`, so resolving-to-RDF datasets showed up red/orange in the register. We no longer want to require an HTML page, let alone that it contain the URI.

## Changes (`src/subjectUriResolution.ts`)

- `defaultResolve` returns a richer `Resolution` (`{kind:'resolved', landingPage}` / `{kind:'failed', reason}`). A `2xx` resolves when it is HTML or RDF; `landingPage` is `true` only for an HTML page that self-references its URI.
- **RDF is confirmed by parsing the body**, not by trusting the Content-Type. The body is parsed with `rdf-parse` (the parser behind the project's `rdf-dereference`), so every serialisation it supports — Turtle family, JSON-LD, RDF/XML — is recognised, and a server that merely *claims* an RDF content type but serves an error/HTML body does not resolve.
- Generic or mislabelled content types are mapped to a best-effort serialisation: JSON (incl. `application/json`) → JSON-LD, XML → RDF/XML, anything else text-ish → Turtle. Plainly non-RDF binary types (`image/*`, …) are rejected without a parse. This replaces the previous `RDF_MEDIA_TYPES` / `AMBIGUOUS_MEDIA_TYPES` allowlists, so an unlisted-but-parseable RDF type is no longer rejected.
- `no-self-reference` is removed as a failure; `wrong-content-type` is redefined as a `2xx` that is neither HTML nor RDF.
- New integer measurement **`https://def.nde.nl/metric#subject-uris-html-landing-pages`** counts the resolved URIs that served a self-referencing HTML landing page (emitted alongside sampled/resolved).
- `rdf-parse` added as a direct dependency (already present transitively via `rdf-dereference`).
- The response body is read with a streamed cap (`MAX_BODY_BYTES`, truncating within a chunk) and the rest of the stream cancelled, so a single sampled URI returning a huge body cannot become a memory sink, and the socket is released for reuse.

The matching vocabulary change is in netwerk-digitaal-erfgoed/definitions, and the register consumes the new metric to show a non-blocking advisory.
