### PR TITLE
feat(subject-uri-resolution)!: persist every sampled URI outcome and resolve HTML-first

### DIFF
--- a/src/failureUsage.ts
+++ b/src/failureUsage.ts
@@ -2,7 +2,7 @@ import {DataFactory} from 'n3';
 import type {NamedNode, Quad} from '@rdfjs/types';
 import {prov, rdf} from '@tpluscode/rdf-ns-builders';
 import {hashSuffix, skolemIri} from '@lde/dataset';
-import {failure} from './namespaces.js';
+import {failure, resolution} from './namespaces.js';
 
 const {namedNode, quad} = DataFactory;
 
@@ -60,21 +60,68 @@ export function* failureUsageQuads(
   failures: readonly SampleFailure[],
 ): Generator<Quad> {
   for (const {url, reasonIri, message} of failures) {
-    const entity = namedNode(url);
-    const usage = namedNode(
-      skolemIri(activity.value, 'usage', hashSuffix(url)),
-    );
-
-    // `prov:used` accompanies each qualified usage, per PROV convention; the
-    // used-set lists only the failed resources, which PROV permits.
-    yield quad(activity, prov.used, entity);
-    yield quad(activity, prov.qualifiedUsage, usage);
-
-    yield quad(usage, rdf.type, prov.Usage);
-    yield quad(usage, prov.entity, entity);
+    const usage = yield* qualifiedUsage(activity, url);
     yield quad(usage, failure.reason, reasonIri);
     if (message !== undefined) {
       yield quad(usage, failure.message, DataFactory.literal(message));
     }
   }
+}
+
+/** A sampled resource paired with the typed concept describing how it resolved. */
+export interface SampleOutcome {
+  /** The sampled resource’s URI/URL. */
+  url: string;
+  /** SKOS concept naming the outcome (the value of `resolution:outcome`). */
+  outcomeIri: NamedNode;
+}
+
+/**
+ * Emit a `prov:Usage` per sampled resource recording its resolution outcome —
+ * the generalisation of {@link failureUsageQuads} from failures-only to *every*
+ * sampled URI. For each resource the activity `prov:used` it and
+ * `prov:qualifiedUsage` a `prov:Usage` carrying `prov:entity` (the URI) and a
+ * single `resolution:outcome` (a SKOS concept: resolved, an HTML landing page,
+ * or a definitive failure reason). Unlike the failure shape, the presence of a
+ * usage no longer implies failure — the outcome concept carries that — so a
+ * consumer reads the outcome of each sampled URI, not just the broken ones.
+ *
+ * Shares the {@link qualifiedUsage} scaffolding with {@link failureUsageQuads},
+ * so both shapes stay byte-for-byte aligned on the PROV structure consumers
+ * traverse. Emits nothing for an empty list.
+ */
+export function* outcomeUsageQuads(
+  activity: NamedNode,
+  outcomes: readonly SampleOutcome[],
+): Generator<Quad> {
+  for (const {url, outcomeIri} of outcomes) {
+    const usage = yield* qualifiedUsage(activity, url);
+    yield quad(usage, resolution.outcome, outcomeIri);
+  }
+}
+
+/**
+ * Common PROV scaffolding for one per-resource qualified usage: the activity
+ * `prov:used` the resource and `prov:qualifiedUsage` a typed `prov:Usage` whose
+ * `prov:entity` is the resource. Yields those four quads and returns the usage
+ * node so the caller can attach its own typed statement (`failure:reason` or
+ * `resolution:outcome`). The usage is a skolem IRI derived from the activity and
+ * keyed on the URL, so usages from different stages cannot collide once merged
+ * (see issue #352).
+ */
+function* qualifiedUsage(
+  activity: NamedNode,
+  url: string,
+): Generator<Quad, NamedNode> {
+  const entity = namedNode(url);
+  const usage = namedNode(skolemIri(activity.value, 'usage', hashSuffix(url)));
+
+  // `prov:used` accompanies each qualified usage, per PROV convention; the
+  // used-set lists only the sampled resources, which PROV permits.
+  yield quad(activity, prov.used, entity);
+  yield quad(activity, prov.qualifiedUsage, usage);
+
+  yield quad(usage, rdf.type, prov.Usage);
+  yield quad(usage, prov.entity, entity);
+  return usage;
 }

--- a/src/namespaces.ts
+++ b/src/namespaces.ts
@@ -8,3 +8,4 @@ import namespace from '@rdfjs/namespace';
 export const metric = namespace('https://def.nde.nl/metric#');
 export const probe = namespace('https://def.nde.nl/probe#');
 export const failure = namespace('https://def.nde.nl/failure#');
+export const resolution = namespace('https://def.nde.nl/resolution#');

--- a/src/subjectUriResolution.ts
+++ b/src/subjectUriResolution.ts
@@ -12,11 +12,7 @@ import {
   type Distribution,
 } from '@lde/dataset';
 import type {ExecutorContext, QuadTransform} from '@lde/pipeline';
-import {
-  failureReasonIri,
-  failureUsageQuads,
-  type SampleFailure,
-} from './failureUsage.js';
+import {outcomeUsageQuads, type SampleOutcome} from './failureUsage.js';
 import {metric} from './namespaces.js';
 import {
   booleanMeasurement,
@@ -27,8 +23,15 @@ import {iiifManifestFormatFilter} from './iiifManifestDetection.js';
 
 const {namedNode, literal, quad} = DataFactory;
 
-const SUBJECT_RESOLUTION_FAILURE_BASE =
-  'https://def.nde.nl/subject-resolution-failure#';
+/**
+ * Concept scheme for the outcome of dereferencing a sampled subject URI,
+ * recorded per URI as `resolution:outcome` (see {@link outcomeUsageQuads}). The
+ * success states (`resolved`, `html-landing-page`) and the definitive failure
+ * reasons (`http-error`, `wrong-content-type`) share one scheme, so a consumer
+ * reads a single, uniform outcome for every measurable sampled URI.
+ */
+const SUBJECT_RESOLUTION_OUTCOME_BASE =
+  'https://def.nde.nl/subject-resolution-outcome#';
 
 /**
  * Why a sampled subject URI did not resolve. A subject URI resolves when it
@@ -36,13 +39,15 @@ const SUBJECT_RESOLUTION_FAILURE_BASE =
  * serialisation); {@link Resolution} carries that success out-of-band, so this
  * enum names only the failures. Whether a resolved HTML page is a *landing page*
  * (it self-references its own URI) is a separate, non-failing distinction — see
- * {@link Resolution}. Mirrors the `subject-resolution-failure` concept scheme.
+ * {@link Resolution}. The definitive reasons surface as
+ * `subject-resolution-outcome#` concepts (see {@link outcomeIriFor}).
  *
  * Outcomes split into two classes (see {@link isTransientFailure}):
  * - **definitive** — `http-error` (a non-retryable `4xx` such as `404`/`410`)
  *   and `wrong-content-type` (a `2xx` that is neither HTML nor RDF, e.g. a JSON
  *   or plain-text error page): a genuine, dataset-attributable defect. Counted
- *   against the ratio and persisted in the PROV trail.
+ *   against the ratio and persisted in the PROV trail as a
+ *   `subject-resolution-outcome#` concept.
  * - **transient** — `timeout`, `network-error`, `server-error` (a retryable HTTP
  *   status: `408`/`425`/`429`/`5xx`): a blip in the multi-hop PID-resolver
  *   chain, not a property of the dataset.
@@ -72,9 +77,22 @@ function isTransientFailure(reason: SubjectResolutionFailure): boolean {
   return TRANSIENT_FAILURES.has(reason);
 }
 
-/** Map a failure reason to its `subject-resolution-failure#` concept IRI. */
-function subjectResolutionFailureIri(reason: SubjectResolutionFailure) {
-  return failureReasonIri(SUBJECT_RESOLUTION_FAILURE_BASE, reason);
+/**
+ * Map a settled {@link Resolution} to its `subject-resolution-outcome#` concept:
+ * `html-landing-page` or `resolved` for a success (the landing-page flag
+ * promotes the human-readable page), else the definitive failure reason itself
+ * (`http-error`/`wrong-content-type`). Only ever called for a *measurable*
+ * outcome — a resolution or a definitive failure — so a transient reason never
+ * reaches it.
+ */
+function outcomeIriFor(resolution: Resolution): NamedNode {
+  const localName =
+    resolution.kind === 'resolved'
+      ? resolution.landingPage
+        ? 'html-landing-page'
+        : 'resolved'
+      : resolution.reason;
+  return namedNode(`${SUBJECT_RESOLUTION_OUTCOME_BASE}${localName}`);
 }
 
 const PID_SCHEME_BASE = 'https://def.nde.nl/pid-scheme#';
@@ -348,7 +366,7 @@ export function subjectUriResolution(
       // One budget shared across every dereference: once it elapses, in-flight
       // fetches abort and resolveWithRetry stops scheduling retries.
       const phaseSignal = AbortSignal.timeout(DEREFERENCE_PHASE_BUDGET_MS);
-      const outcomes = await Promise.all(
+      const resolutions = await Promise.all(
         sampled.map(uri =>
           limit(() =>
             resolveWithRetry(uri, resolve, retries, sleep, phaseSignal),
@@ -358,38 +376,36 @@ export function subjectUriResolution(
 
       // Classify each settled outcome. A resolution counts toward the ratio,
       // and toward the HTML-landing-page tally when it is one. A *definitive*
-      // failure is a real defect — counted and persisted. A *transient* failure
-      // survived every retry, so the resolver chain (not the dataset) is at
-      // fault: drop the URI from the sample entirely rather than scoring it as
-      // broken.
+      // failure is a real defect. Both are *measurable*, so each is persisted as
+      // a per-URI outcome usage. A *transient* failure survived every retry, so
+      // the resolver chain (not the dataset) is at fault: drop the URI from the
+      // sample entirely rather than scoring it as broken — it gets no usage.
       let resolved = 0;
       let htmlLandingPages = 0;
-      const failures: SampleFailure[] = [];
+      const outcomes: SampleOutcome[] = [];
       sampled.forEach((uri, index) => {
-        const outcome = outcomes[index];
-        if (outcome.kind === 'resolved') {
+        const resolution = resolutions[index];
+        if (resolution.kind === 'resolved') {
           resolved++;
-          if (outcome.landingPage) htmlLandingPages++;
-        } else if (!isTransientFailure(outcome.reason)) {
-          failures.push({
-            url: uri,
-            reasonIri: subjectResolutionFailureIri(outcome.reason),
-          });
+          if (resolution.landingPage) htmlLandingPages++;
+        } else if (isTransientFailure(resolution.reason)) {
+          return;
         }
+        outcomes.push({url: uri, outcomeIri: outcomeIriFor(resolution)});
       });
       // The denominator counts only definitively-judged URIs; transient ones are
-      // excluded. With nothing measurable — an empty sample, or every URI
-      // transiently unreachable — the declared facts above stand on their own,
-      // so append no misleading 0/0 ratio (and no failure marker: the sample
-      // query itself succeeded).
-      const measurable = resolved + failures.length;
+      // excluded, so every persisted outcome is one measurable URI. With nothing
+      // measurable — an empty sample, or every URI transiently unreachable — the
+      // declared facts above stand on their own, so append no misleading 0/0
+      // ratio (and no failure marker: the sample query itself succeeded).
+      const measurable = outcomes.length;
       if (measurable > 0) {
         yield* measurementQuads(
           subset,
           measurable,
           resolved,
           htmlLandingPages,
-          failures,
+          outcomes,
           software,
         );
       }
@@ -562,16 +578,17 @@ function* measurementQuads(
   sampled: number,
   resolved: number,
   htmlLandingPages: number,
-  failures: readonly SampleFailure[],
+  outcomes: readonly SampleOutcome[],
   software: NamedNode,
 ): Generator<Quad> {
   // PROV: the sampling/dereferencing activity, with a qualified usage per
-  // failed sample naming the URI and why it did not resolve. Every structural
-  // node is a skolem IRI derived from the (unique) subset, not a blank node, so
-  // it cannot collide with another stage’s nodes in the dataset graph (#352).
+  // measurable sample naming the URI and its resolution outcome. Every
+  // structural node is a skolem IRI derived from the (unique) subset, not a
+  // blank node, so it cannot collide with another stage’s nodes in the dataset
+  // graph (#352).
   const activity = namedNode(skolemIri(subset.value, 'resolution-activity'));
   yield* provActivity(activity, subset, software);
-  yield* failureUsageQuads(activity, failures);
+  yield* outcomeUsageQuads(activity, outcomes);
 
   // Validated facts — the sampled/resolved ratio, for any namespace, plus how
   // many of the resolved URIs served an HTML landing page (a non-failing signal
@@ -773,15 +790,25 @@ const defaultSampleUris: SampleUris = async (
 };
 
 /**
- * Accept header for dereferencing: HTML is preferred (unweighted, so `q=1`) so a
- * server that *can* serve a human-readable landing page does — which is what the
- * `landingPage` signal promotes — with the common RDF serialisations offered as
- * acceptable fallbacks for a data-only namespace.
+ * Accept header for the first dereference probe: HTML and nothing else. A
+ * combined header that also lists RDF types cannot discover a human-readable
+ * landing page, because a large class of servers (Omeka-S among them) ignore
+ * Accept `q`-values and serve their default RDF serialisation whenever *any* RDF
+ * type is acceptable — so HTML at `q=1` still loses to RDF at `q=0.8`. Offering
+ * `text/html` alone is the only way to see the page a browser would get, which
+ * is exactly what the `landingPage` signal promotes.
  */
-const RESOLVE_ACCEPT =
-  'text/html,application/ld+json;q=0.9,text/turtle;q=0.9,' +
-  'application/rdf+xml;q=0.8,application/n-triples;q=0.8,' +
-  'application/trig;q=0.8,application/n-quads;q=0.8';
+const HTML_ACCEPT = 'text/html';
+
+/**
+ * Accept header for the second (fallback) probe: the RDF serialisations only,
+ * no HTML. Sent only when the {@link HTML_ACCEPT} probe definitively yields no
+ * HTML page (e.g. a `406 Not Acceptable` from a data-only namespace), to confirm
+ * the URI still resolves as data.
+ */
+const RDF_ACCEPT =
+  'application/ld+json,text/turtle,application/rdf+xml,' +
+  'application/n-triples,application/trig,application/n-quads';
 
 /**
  * Cap on how many bytes of a response body we read, so a single sampled URI that
@@ -915,55 +942,32 @@ function bodyParsesAsRdf(
   });
 }
 
-/**
- * Default resolution check: follow redirects and accept any `2xx` that is HTML
- * or RDF. An HTML page that advertises the original sampled URI (raw or
- * HTML-entity-escaped) is a {@link Resolution landing page} — a human-readable
- * page for the identifier, the permanent link back to the user, which matters
- * because we may have landed on a different, redirected URL. RDF (or HTML that
- * does not mention the URI) still resolves; it just is not a landing page. A
- * `2xx` that is neither HTML nor RDF is a `wrong-content-type` failure.
- */
-const defaultResolve: ResolveUri = async (uri, signal) => {
+/** Fetch `uri` with the given `accept` header, following redirects. */
+function fetchWithAccept(
+  uri: string,
+  accept: string,
+  signal?: AbortSignal,
+): Promise<Response> {
   // The request aborts on whichever fires first: its own per-request timeout or
   // the overall phase budget carried by `signal`.
   const timeout = AbortSignal.timeout(DEREFERENCE_TIMEOUT_MS);
   const abort = signal ? AbortSignal.any([timeout, signal]) : timeout;
-  let response: Response;
-  try {
-    response = await fetch(uri, {
-      redirect: 'follow',
-      headers: {accept: RESOLVE_ACCEPT},
-      signal: abort,
-    });
-  } catch (error) {
-    return {kind: 'failed', reason: classifyFetchError(error)};
-  }
-  if (!response.ok) {
-    return {kind: 'failed', reason: classifyHttpStatus(response.status)};
-  }
+  return fetch(uri, {redirect: 'follow', headers: {accept}, signal: abort});
+}
 
-  const mediaType = mediaTypeOf(response);
-  if (mediaType === 'text/html') {
-    let body: string;
-    try {
-      body = await readBoundedText(response);
-    } catch {
-      // A `200 text/html` whose body cannot be read is a transport failure.
-      return {kind: 'failed', reason: 'network-error'};
-    }
-    // A landing page advertises its own URI; HTML that does not still resolves.
-    return {
-      kind: 'resolved',
-      landingPage: body.includes(uri) || body.includes(htmlEscape(uri)),
-    };
-  }
-  // Not HTML: confirm the body parses as RDF. rdf-parse needs the content type,
-  // so a generic or mislabelled one is mapped to a best-effort serialisation
-  // (see rdfParseContentType); a plainly non-RDF binary type is rejected without
-  // a parse. The parse — not the header — is the authority, so a server that only
-  // claims an RDF content type but serves an error/HTML body does not resolve.
-  const parseContentType = rdfParseContentType(mediaType);
+/**
+ * Classify a `2xx` response as RDF: confirm the body parses as RDF. rdf-parse
+ * needs the content type, so a generic or mislabelled one is mapped to a
+ * best-effort serialisation (see {@link rdfParseContentType}); a plainly non-RDF
+ * binary type is rejected without a parse. The parse — not the header — is the
+ * authority, so a server that only *claims* an RDF content type but serves an
+ * error/HTML body does not resolve. An RDF body is never a landing page.
+ */
+async function classifyRdfResponse(
+  response: Response,
+  uri: string,
+): Promise<Resolution> {
+  const parseContentType = rdfParseContentType(mediaTypeOf(response));
   if (parseContentType === null) {
     return {kind: 'failed', reason: 'wrong-content-type'};
   }
@@ -976,6 +980,72 @@ const defaultResolve: ResolveUri = async (uri, signal) => {
   return (await bodyParsesAsRdf(body, parseContentType, response.url || uri))
     ? {kind: 'resolved', landingPage: false}
     : {kind: 'failed', reason: 'wrong-content-type'};
+}
+
+/**
+ * Default resolution check: an HTML-first, two-probe dereference (see
+ * {@link HTML_ACCEPT}/{@link RDF_ACCEPT} for why a single combined header cannot
+ * see a landing page on a `q`-value-ignoring server).
+ *
+ * 1. Probe `Accept: text/html`. A `2xx text/html` resolves; it is a
+ *    {@link Resolution landing page} when its body advertises the original
+ *    sampled URI (raw or HTML-entity-escaped) — the permanent link back to the
+ *    user, which matters because we may have landed on a redirected URL. A `2xx`
+ *    that is some other representation (a server ignoring the html-only request)
+ *    is classified from the bytes already in hand as RDF, with no second probe.
+ * 2. Only when the HTML probe is a *definitive* non-2xx (e.g. `406 Not
+ *    Acceptable` from a data-only namespace, or a `404`) fall back to an
+ *    `Accept: <RDF>` probe and classify that as RDF. A *transient* non-2xx is
+ *    returned as-is for the retry loop rather than spending a fallback probe a
+ *    blip would likely fail too.
+ */
+const defaultResolve: ResolveUri = async (uri, signal) => {
+  let response: Response;
+  try {
+    response = await fetchWithAccept(uri, HTML_ACCEPT, signal);
+  } catch (error) {
+    return {kind: 'failed', reason: classifyFetchError(error)};
+  }
+  if (response.ok) {
+    if (mediaTypeOf(response) === 'text/html') {
+      let body: string;
+      try {
+        body = await readBoundedText(response);
+      } catch {
+        // A `200 text/html` whose body cannot be read is a transport failure.
+        return {kind: 'failed', reason: 'network-error'};
+      }
+      // A landing page advertises its own URI; HTML that does not still resolves.
+      return {
+        kind: 'resolved',
+        landingPage: body.includes(uri) || body.includes(htmlEscape(uri)),
+      };
+    }
+    // The server ignored the html-only request and served another
+    // representation; we already have the bytes, so classify them as RDF
+    // without a redundant second probe.
+    return classifyRdfResponse(response, uri);
+  }
+
+  // Non-2xx to the HTML probe. A transient status is the resolver chain
+  // blipping, not a missing HTML page, so return it for the retry loop rather
+  // than spending a fallback probe it would likely fail too.
+  const htmlFailure = classifyHttpStatus(response.status);
+  if (isTransientFailure(htmlFailure)) {
+    return {kind: 'failed', reason: htmlFailure};
+  }
+  // Definitive: the resource offers no HTML (e.g. 406) or is gone (404/410).
+  // Fall back to an RDF-only probe to see whether it still resolves as data.
+  let rdfResponse: Response;
+  try {
+    rdfResponse = await fetchWithAccept(uri, RDF_ACCEPT, signal);
+  } catch (error) {
+    return {kind: 'failed', reason: classifyFetchError(error)};
+  }
+  if (!rdfResponse.ok) {
+    return {kind: 'failed', reason: classifyHttpStatus(rdfResponse.status)};
+  }
+  return classifyRdfResponse(rdfResponse, uri);
 };
 
 /**

--- a/test/subjectUriResolution.test.ts
+++ b/test/subjectUriResolution.test.ts
@@ -127,11 +127,27 @@ function measurementValueTerm(
   )?.object;
 }
 
-const SUBJECT_RESOLUTION_FAILURE_BASE =
-  'https://def.nde.nl/subject-resolution-failure#';
 const PROV_QUALIFIED_USAGE = namedNode(
   'http://www.w3.org/ns/prov#qualifiedUsage',
 );
+const PROV_ENTITY = namedNode('http://www.w3.org/ns/prov#entity');
+const RESOLUTION_OUTCOME = namedNode('https://def.nde.nl/resolution#outcome');
+const OUTCOME_BASE = 'https://def.nde.nl/subject-resolution-outcome#';
+
+/**
+ * The `resolution:outcome` concept IRI of the qualified usage whose
+ * `prov:entity` is `url`, or `undefined` when no usage for `url` was emitted.
+ * Every measurable sampled URI — resolved or definitively failed — carries one.
+ */
+function outcomeFor(quads: Quad[], url: string): string | undefined {
+  const usage = quads.find(
+    q => q.predicate.equals(PROV_ENTITY) && q.object.value === url,
+  )?.subject;
+  if (!usage) return undefined;
+  return quads.find(
+    q => q.subject.equals(usage) && q.predicate.equals(RESOLUTION_OUTCOME),
+  )?.object.value;
+}
 
 const sampleFixed =
   (uris: string[]): SampleUris =>
@@ -180,17 +196,17 @@ describe('subjectUriResolution', () => {
       ),
     ).toHaveLength(3);
 
-    // Only the failed sample is enumerated, as a qualified usage carrying its
-    // typed reason; the two resolved samples are covered by the count alone.
+    // Every measurable sample is enumerated as a qualified usage carrying its
+    // outcome — the two resolved and the one failed alike.
     expect(
       out.filter(q => q.predicate.equals(PROV_QUALIFIED_USAGE)),
-    ).toHaveLength(1);
-    expect(failureReasonFor(out, 'http://example.org/id/bad-3')).toBe(
-      `${SUBJECT_RESOLUTION_FAILURE_BASE}http-error`,
+    ).toHaveLength(3);
+    expect(outcomeFor(out, 'http://example.org/id/bad-3')).toBe(
+      `${OUTCOME_BASE}http-error`,
     );
-    expect(
-      failureReasonFor(out, 'http://example.org/id/good-1'),
-    ).toBeUndefined();
+    expect(outcomeFor(out, 'http://example.org/id/good-1')).toBe(
+      `${OUTCOME_BASE}resolved`,
+    );
   });
 
   it('picks the most common non-terminology namespace', async () => {
@@ -392,9 +408,7 @@ describe('subjectUriResolution', () => {
     // dropped from the denominator rather than dragging the ratio down.
     expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBe(1);
     expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
-    expect(
-      failureReasonFor(out, 'http://example.org/id/throws'),
-    ).toBeUndefined();
+    expect(outcomeFor(out, 'http://example.org/id/throws')).toBeUndefined();
   });
 
   it('retries a transient failure and counts the eventual success', async () => {
@@ -446,11 +460,11 @@ describe('subjectUriResolution', () => {
     // excluded from the denominator entirely.
     expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBe(3);
     expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(2);
-    expect(failureReasonFor(out, 'https://n2t.net/ark:/89268/gone-4')).toBe(
-      `${SUBJECT_RESOLUTION_FAILURE_BASE}wrong-content-type`,
+    expect(outcomeFor(out, 'https://n2t.net/ark:/89268/gone-4')).toBe(
+      `${OUTCOME_BASE}wrong-content-type`,
     );
     expect(
-      failureReasonFor(out, 'https://n2t.net/ark:/89268/blip-3'),
+      outcomeFor(out, 'https://n2t.net/ark:/89268/blip-3'),
     ).toBeUndefined();
   });
 
@@ -602,6 +616,95 @@ describe('subjectUriResolution', () => {
       measurementValueTerm(out, SAMPLING_FAILED_METRIC, ns.node)?.value,
     ).toBe('true');
     expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBeUndefined();
+  });
+
+  describe('per-URI resolution outcomes', () => {
+    it('records a resolved RDF URI as a resolved outcome usage', async () => {
+      const ns = subset('http://example.org/id/', 10);
+      const transform = subjectUriResolution({
+        terminologyPrefixes: [],
+        sampleUris: sampleFixed(['http://example.org/id/good']),
+        resolve: resolveByName,
+      });
+
+      const out = await collect(transform(stream(ns.quads), context));
+
+      expect(outcomeFor(out, 'http://example.org/id/good')).toBe(
+        `${OUTCOME_BASE}resolved`,
+      );
+    });
+
+    it('records a self-referencing HTML page as an html-landing-page outcome', async () => {
+      const ns = subset('http://example.org/id/', 10);
+      const transform = subjectUriResolution({
+        terminologyPrefixes: [],
+        sampleUris: sampleFixed(['http://example.org/id/page']),
+        resolve: async () => ({kind: 'resolved', landingPage: true}),
+      });
+
+      const out = await collect(transform(stream(ns.quads), context));
+
+      expect(outcomeFor(out, 'http://example.org/id/page')).toBe(
+        `${OUTCOME_BASE}html-landing-page`,
+      );
+    });
+
+    it('records a definitive failure as its reason outcome, without failure:reason', async () => {
+      const ns = subset('http://example.org/id/', 10);
+      const transform = subjectUriResolution({
+        terminologyPrefixes: [],
+        sampleUris: sampleFixed([
+          'http://example.org/id/gone',
+          'http://example.org/id/junk',
+        ]),
+        resolve: async uri =>
+          uri.endsWith('gone')
+            ? {kind: 'failed', reason: 'http-error'}
+            : {kind: 'failed', reason: 'wrong-content-type'},
+        sleep: async () => {},
+      });
+
+      const out = await collect(transform(stream(ns.quads), context));
+
+      expect(outcomeFor(out, 'http://example.org/id/gone')).toBe(
+        `${OUTCOME_BASE}http-error`,
+      );
+      expect(outcomeFor(out, 'http://example.org/id/junk')).toBe(
+        `${OUTCOME_BASE}wrong-content-type`,
+      );
+      // The unified outcome replaces the old failure:reason shape entirely.
+      expect(
+        failureReasonFor(out, 'http://example.org/id/gone'),
+      ).toBeUndefined();
+    });
+
+    it('leaves no usage for a transiently-excluded URI', async () => {
+      const ns = subset('http://example.org/id/', 10);
+      const transform = subjectUriResolution({
+        terminologyPrefixes: [],
+        sampleUris: sampleFixed([
+          'http://example.org/id/good',
+          'http://example.org/id/blip',
+        ]),
+        resolve: async uri =>
+          uri.endsWith('blip')
+            ? {kind: 'failed', reason: 'timeout'}
+            : {kind: 'resolved', landingPage: false},
+        sleep: async () => {},
+      });
+
+      const out = await collect(transform(stream(ns.quads), context));
+
+      // The transient URI is dropped from the sample: no outcome usage at all.
+      expect(outcomeFor(out, 'http://example.org/id/blip')).toBeUndefined();
+      expect(outcomeFor(out, 'http://example.org/id/good')).toBe(
+        `${OUTCOME_BASE}resolved`,
+      );
+      // One usage per measurable URI — here just the one resolved URI.
+      expect(
+        out.filter(q => q.predicate.equals(PROV_QUALIFIED_USAGE)),
+      ).toHaveLength(1);
+    });
   });
 
   describe('non-durable subject namespaces', () => {
@@ -853,7 +956,7 @@ describe('subjectUriResolution', () => {
       });
       // A network error is transient: retried, then dropped from the sample
       // entirely rather than scored as a non-resolution.
-      expect(failureReasonFor(out, URI)).toBeUndefined();
+      expect(outcomeFor(out, URI)).toBeUndefined();
       expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBeUndefined();
     });
 
@@ -864,7 +967,7 @@ describe('subjectUriResolution', () => {
         error.name = 'TimeoutError';
         throw error;
       });
-      expect(failureReasonFor(out, URI)).toBeUndefined();
+      expect(outcomeFor(out, URI)).toBeUndefined();
       expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBeUndefined();
     });
 
@@ -873,7 +976,7 @@ describe('subjectUriResolution', () => {
       const out = await runWithFetch(
         async () => new Response('', {status: 503}),
       );
-      expect(failureReasonFor(out, URI)).toBeUndefined();
+      expect(outcomeFor(out, URI)).toBeUndefined();
       expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBeUndefined();
     });
 
@@ -884,7 +987,7 @@ describe('subjectUriResolution', () => {
       const out = await runWithFetch(
         async () => new Response('', {status: 408}),
       );
-      expect(failureReasonFor(out, URI)).toBeUndefined();
+      expect(outcomeFor(out, URI)).toBeUndefined();
       expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBeUndefined();
     });
 
@@ -894,9 +997,7 @@ describe('subjectUriResolution', () => {
         async () => new Response('', {status: 404}),
       );
       // A 404 is definitive: counted against the ratio and persisted.
-      expect(failureReasonFor(out, URI)).toBe(
-        `${SUBJECT_RESOLUTION_FAILURE_BASE}http-error`,
-      );
+      expect(outcomeFor(out, URI)).toBe(`${OUTCOME_BASE}http-error`);
       expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBe(1);
     });
 
@@ -910,9 +1011,7 @@ describe('subjectUriResolution', () => {
           }),
       );
       // A JSON error page is neither HTML nor RDF: a definitive failure.
-      expect(failureReasonFor(out, URI)).toBe(
-        `${SUBJECT_RESOLUTION_FAILURE_BASE}wrong-content-type`,
-      );
+      expect(outcomeFor(out, URI)).toBe(`${OUTCOME_BASE}wrong-content-type`);
       expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBe(1);
     });
 
@@ -928,7 +1027,7 @@ describe('subjectUriResolution', () => {
       // RDF resolves (counts toward the ratio) but is not an HTML landing page.
       expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
       expect(measurementValue(out, HTML_LANDING_PAGES_METRIC, ns.node)).toBe(0);
-      expect(failureReasonFor(out, URI)).toBeUndefined();
+      expect(outcomeFor(out, URI)).toBe(`${OUTCOME_BASE}resolved`);
     });
 
     it('resolves a generically-typed body that parses as RDF', async () => {
@@ -943,7 +1042,7 @@ describe('subjectUriResolution', () => {
       // A misconfigured server serving Turtle as text/plain still resolves: the
       // body is parsed as a fallback when the content type is too generic.
       expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
-      expect(failureReasonFor(out, URI)).toBeUndefined();
+      expect(outcomeFor(out, URI)).toBe(`${OUTCOME_BASE}resolved`);
     });
 
     it('fails a generically-typed body that is not RDF', async () => {
@@ -954,9 +1053,7 @@ describe('subjectUriResolution', () => {
             headers: {'content-type': 'text/plain'},
           }),
       );
-      expect(failureReasonFor(out, URI)).toBe(
-        `${SUBJECT_RESOLUTION_FAILURE_BASE}wrong-content-type`,
-      );
+      expect(outcomeFor(out, URI)).toBe(`${OUTCOME_BASE}wrong-content-type`);
     });
 
     it('resolves JSON-LD served under a plain application/json content type', async () => {
@@ -975,7 +1072,7 @@ describe('subjectUriResolution', () => {
           }),
       );
       expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
-      expect(failureReasonFor(out, URI)).toBeUndefined();
+      expect(outcomeFor(out, URI)).toBe(`${OUTCOME_BASE}resolved`);
     });
 
     it('fails an RDF content type whose body is not RDF', async () => {
@@ -988,9 +1085,7 @@ describe('subjectUriResolution', () => {
             headers: {'content-type': 'text/turtle'},
           }),
       );
-      expect(failureReasonFor(out, URI)).toBe(
-        `${SUBJECT_RESOLUTION_FAILURE_BASE}wrong-content-type`,
-      );
+      expect(outcomeFor(out, URI)).toBe(`${OUTCOME_BASE}wrong-content-type`);
     });
 
     it('resolves a large RDF body without reading it all', async () => {
@@ -1008,7 +1103,7 @@ describe('subjectUriResolution', () => {
           }),
       );
       expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
-      expect(failureReasonFor(out, URI)).toBeUndefined();
+      expect(outcomeFor(out, URI)).toBe(`${OUTCOME_BASE}resolved`);
     });
 
     it('does not see a self-reference past the body read cap', async () => {
@@ -1025,7 +1120,7 @@ describe('subjectUriResolution', () => {
       );
       expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
       expect(measurementValue(out, HTML_LANDING_PAGES_METRIC, ns.node)).toBe(0);
-      expect(failureReasonFor(out, URI)).toBeUndefined();
+      expect(outcomeFor(out, URI)).toBe(`${OUTCOME_BASE}resolved`);
     });
 
     it('resolves HTML without a self-reference, not as a landing page', async () => {
@@ -1037,7 +1132,7 @@ describe('subjectUriResolution', () => {
       // counted as a landing page.
       expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
       expect(measurementValue(out, HTML_LANDING_PAGES_METRIC, ns.node)).toBe(0);
-      expect(failureReasonFor(out, URI)).toBeUndefined();
+      expect(outcomeFor(out, URI)).toBe(`${OUTCOME_BASE}resolved`);
     });
 
     it('excludes an unreadable body as a transient blip', async () => {
@@ -1054,7 +1149,7 @@ describe('subjectUriResolution', () => {
       );
       // A `200 text/html` whose body cannot be read is a transport failure
       // (network-error): retried, then excluded rather than scored.
-      expect(failureReasonFor(out, URI)).toBeUndefined();
+      expect(outcomeFor(out, URI)).toBeUndefined();
       expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBeUndefined();
     });
 
@@ -1066,10 +1161,111 @@ describe('subjectUriResolution', () => {
       expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
       // A self-referencing HTML page is the promoted landing page.
       expect(measurementValue(out, HTML_LANDING_PAGES_METRIC, ns.node)).toBe(1);
-      expect(failureReasonFor(out, URI)).toBeUndefined();
-      expect(out.some(q => q.predicate.equals(PROV_QUALIFIED_USAGE))).toBe(
-        false,
-      );
+      // It is persisted as a single html-landing-page outcome usage.
+      expect(outcomeFor(out, URI)).toBe(`${OUTCOME_BASE}html-landing-page`);
+      expect(
+        out.filter(q => q.predicate.equals(PROV_QUALIFIED_USAGE)),
+      ).toHaveLength(1);
+    });
+
+    /** The `Accept` header sent on a stubbed fetch call. */
+    function acceptOf(init: RequestInit | undefined): string {
+      return String((init?.headers as Record<string, string>)?.accept ?? '');
+    }
+
+    describe('html-first two-probe resolution', () => {
+      it('detects a landing page on a conneg server that serves RDF under a combined Accept header', async () => {
+        // The bD64Hu / Omeka-S case: the server ignores Accept q-values and
+        // returns RDF whenever any RDF type is acceptable, but serves the
+        // human-readable HTML page when only text/html is offered. Probing
+        // html-first must find the landing page instead of stopping at the RDF
+        // a combined header would yield.
+        const ns = subset('http://example.org/id/', 10);
+        const accepts: string[] = [];
+        const out = await runWithFetch(async (_input, init) => {
+          const accept = acceptOf(init);
+          accepts.push(accept);
+          if (accept === 'text/html') {
+            return htmlResponse(`<html><a href="${URI}">permalink</a></html>`);
+          }
+          // Any RDF-accepting request: the server serves its default RDF.
+          return new Response(`<${URI}> <http://schema.org/name> "X" .`, {
+            status: 200,
+            headers: {'content-type': 'application/n-triples'},
+          });
+        });
+
+        expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
+        expect(measurementValue(out, HTML_LANDING_PAGES_METRIC, ns.node)).toBe(
+          1,
+        );
+        // The html-only probe must have been sent.
+        expect(accepts).toContain('text/html');
+      });
+
+      it('classifies a 2xx RDF body from the html probe without a second probe', async () => {
+        // A server that ignores the html-only request and serves RDF anyway: we
+        // already hold the bytes, so it resolves as data from the first probe —
+        // no redundant RDF probe.
+        const ns = subset('http://example.org/id/', 10);
+        const accepts: string[] = [];
+        const out = await runWithFetch(async (_input, init) => {
+          accepts.push(acceptOf(init));
+          return new Response(`<${URI}> <http://schema.org/name> "X" .`, {
+            status: 200,
+            headers: {'content-type': 'text/turtle'},
+          });
+        });
+
+        expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
+        expect(measurementValue(out, HTML_LANDING_PAGES_METRIC, ns.node)).toBe(
+          0,
+        );
+        // Exactly one probe, and it was the html-only one.
+        expect(accepts).toEqual(['text/html']);
+      });
+
+      it('falls back to an RDF probe when the html probe is 406 Not Acceptable', async () => {
+        // A data-only namespace with correct conneg: no HTML representation, so
+        // text/html gets a definitive 406. The RDF fallback then resolves it.
+        const ns = subset('http://example.org/id/', 10);
+        const accepts: string[] = [];
+        const out = await runWithFetch(async (_input, init) => {
+          const accept = acceptOf(init);
+          accepts.push(accept);
+          if (accept === 'text/html') {
+            return new Response('', {status: 406});
+          }
+          return new Response(`<${URI}> <http://schema.org/name> "X" .`, {
+            status: 200,
+            headers: {'content-type': 'text/turtle'},
+          });
+        });
+
+        expect(measurementValue(out, RESOLVED_METRIC, ns.node)).toBe(1);
+        expect(measurementValue(out, HTML_LANDING_PAGES_METRIC, ns.node)).toBe(
+          0,
+        );
+        // The html probe failed definitively, so the RDF probe fired after it.
+        expect(accepts[0]).toBe('text/html');
+        expect(accepts.some(accept => accept !== 'text/html')).toBe(true);
+      });
+
+      it('does not spend an RDF probe on a transient html-probe failure', async () => {
+        // A 503 to the html probe is a resolver-chain blip, not a missing HTML
+        // page: it is excluded as transient and no RDF fallback is attempted.
+        const ns = subset('http://example.org/id/', 10);
+        const accepts: string[] = [];
+        const out = await runWithFetch(async (_input, init) => {
+          accepts.push(acceptOf(init));
+          return new Response('', {status: 503});
+        });
+
+        // Transient: dropped from the sample, no ratio.
+        expect(measurementValue(out, SAMPLED_METRIC, ns.node)).toBeUndefined();
+        // Every probe sent was the html-only one — never the RDF fallback.
+        expect(accepts.every(accept => accept === 'text/html')).toBe(true);
+      });
     });
   });
 });


### PR DESCRIPTION
## What

Reworks subject-URI resolution to **persist every sampled URI with its outcome** and to **measure HTML landing pages accurately** on servers that ignore `Accept` q-values.

### Persist every sampled URI (unified outcome)

Previously only *failed* sampled URIs left a per-URI record (`failure:reason`); resolved ones were discarded, leaving counts but no recoverable URIs. Now every *measurable* sampled URI gets a `prov:Usage` carrying a single `resolution:outcome` concept:

- `resolution:outcome` = `https://def.nde.nl/resolution#outcome`
- concepts in `https://def.nde.nl/subject-resolution-outcome#`: `resolved`, `html-landing-page`, `http-error`, `wrong-content-type`

Transient-excluded URIs still get no usage. `failureUsageQuads` (IIIF validation) is unchanged; both emitters now share one `qualifiedUsage` scaffolding so the PROV shape consumers traverse cannot drift.

### HTML-first two-probe resolution

A combined `Accept` header could never discover a human-readable landing page on servers that ignore q-values: Omeka-S (and others) serve their default RDF whenever *any* RDF type is acceptable, so `text/html;q=1.0` still loses to n-triples at `q=0.8`. The probe now:

1. requests `Accept: text/html` (no RDF) — a `2xx text/html` resolves, and is a landing page when its body self-references the URI; a `2xx` other representation is classified from the bytes in hand as RDF (no second probe);
2. falls back to an RDF-only probe **only** on a definitive non-2xx (e.g. `406` from a data-only namespace). A transient blip is returned for the retry loop rather than spending a fallback probe.

This makes `subject-uris-html-landing-pages` reflect what a browser actually receives. Verified against `https://n2t.net/ark:/60537/bD64Hu` (Gouda Tijdmachine, Omeka-S): the combined header returns n-triples, while `Accept: text/html` returns the HTML item page.

## Breaking change

Per-sampled-URI PROV usages now carry `resolution:outcome` (`subject-resolution-outcome#`) instead of `failure:reason` (`subject-resolution-failure#`). Consumers reading subject-URI failures — notably the dataset-register browser `fetchPersistentUriFailures` — must migrate to read `resolution:outcome`. A follow-up makes the browser forward-compatible.

## Follow-ups

- dataset-register browser: read `resolution:outcome`; surface the now-retained resolved URIs.
- def.nde.nl: define the `resolution#outcome` predicate and `subject-resolution-outcome#` SKOS concepts in the `definitions` repo.
- DKG docs chapter under `docs/docs/services`.
