### PR TITLE
perf(iiif): detect manifests in a single encodingFormat scan

### DIFF
--- a/queries/analysis/iiif.rq
+++ b/queries/analysis/iiif.rq
@@ -32,27 +32,30 @@ CONSTRUCT {
 }
 WHERE {
     {
-        # Capability count: every manifest the dataset exposes, conformant or not.
-        # A manifest is detected by its `schema:encodingFormat` literal being
-        # either the SCHEMA-AP-NDE profile media type *or* the bare JSON-LD media
-        # type `application/ld+json` (issue #314: a functional manifest declared
-        # without the `;profile=` parameter must still count). Matched without
-        # REGEX — a regex over every encodingFormat literal is costly on QLever
-        # and on remote endpoints alike; STRSTARTS lets engines prefix-scan.
-        SELECT (COUNT(DISTINCT ?s) AS ?count) {
+        # Capability *and* conformance counts in a SINGLE scan of every
+        # `schema:encodingFormat` literal. A manifest is detected by its format
+        # being either the SCHEMA-AP-NDE profile media type *or* the bare JSON-LD
+        # media type `application/ld+json` (issue #314: a functional manifest
+        # declared without the `;profile=` parameter must still count). Matched
+        # without REGEX — a regex over every encodingFormat literal is costly on
+        # QLever and on remote endpoints alike; STRSTARTS lets engines prefix-scan.
+        #
+        # Because `conformant ⊆ capability`, the capability FILTER gates which
+        # rows are scanned and the stricter conformance test is folded into a
+        # conditional projection instead of a second pass: `?conformantSubject`
+        # is bound to `?s` only for profile-conformant formats and left unbound
+        # otherwise (IF’s else-branch evaluates an unbound variable, so BIND
+        # leaves it unbound), so `COUNT(DISTINCT ?conformantSubject)` counts only
+        # the conformant subjects. The conformance test keeps its own `isLiteral`
+        # guard so it stays self-contained; the version segment (e.g. /2/, /3/) is
+        # left unconstrained, intentionally forwards-compatible.
+        SELECT
+            (COUNT(DISTINCT ?s) AS ?count)
+            (COUNT(DISTINCT ?conformantSubject) AS ?conformantCount) {
             #subjectFilter#
             ?s schema:encodingFormat|<http://schema.org/encodingFormat> ?format .
             FILTER(#manifestFormatFilter#)
-        }
-    }
-    {
-        # Conformance count: only manifests whose encodingFormat carries the full
-        # SCHEMA-AP-NDE profile pattern. The version segment (e.g. /2/, /3/) is
-        # left unconstrained, which is intentionally forwards-compatible.
-        SELECT (COUNT(DISTINCT ?s) AS ?conformantCount) {
-            #subjectFilter#
-            ?s schema:encodingFormat|<http://schema.org/encodingFormat> ?format .
-            FILTER(#conformantFormatFilter#)
+            BIND(IF(#conformantFormatFilter#, ?s, ?unboundConformant) AS ?conformantSubject)
         }
     }
     # OPTIONAL so detection survives an empty sample: if every matched manifest


### PR DESCRIPTION
## What

Fold the two `COUNT` sub-selects in `iiif.rq` (capability count + conformance count) into a **single** scan of every `schema:encodingFormat` literal.

Because `conformant ⊆ capability`, the capability `FILTER` already gates which rows are scanned, so the stricter conformance test no longer needs its own pass — it becomes a conditional projection:

```sparql
SELECT
    (COUNT(DISTINCT ?s) AS ?count)
    (COUNT(DISTINCT ?conformantSubject) AS ?conformantCount) {
  ?s schema:encodingFormat|<http://schema.org/encodingFormat> ?format .
  FILTER(#manifestFormatFilter#)
  BIND(IF(#conformantFormatFilter#, ?s, ?unboundConformant) AS ?conformantSubject)
}
```

`?conformantSubject` is bound to `?s` only for profile-conformant formats and left unbound otherwise (the `IF` else-branch evaluates an unbound variable, so `BIND` leaves it unbound), so `COUNT(DISTINCT ?conformantSubject)` yields the conformant count from the same pass. The sample sub-select is left separate — it needs its own `LIMIT` and `contentUrl`/blank-node handling, which do not compose with the aggregates.

## Why

This halves the passes over every `encodingFormat` literal. It matters most on the remote endpoints the query usually runs against, where each scan is a separate round-trip cost on the provider’s engine.

Detection behaviour is unchanged, including the issue #314 decoupling: the capability marker `dcterms:conformsTo <http://iiif.io/api/presentation/>` is still always emitted when `?count > 0`, and the conformant subset (`dcterms:conformsTo <https://docs.nde.nl/schema-profile/>`) still nests under it with its own count (including the zero-conformance case).

## Verification

Confirmed the new query returns counts identical to the previous two-scan version on every engine reachable:

- **QLever** (local dump-imported index) – synthetic data covering blank-node and multi-format subjects.
- **Virtuoso** (DBpedia) and **Blazegraph** (Wikidata) – remote, via a data-independent `VALUES` probe of the `COUNT(DISTINCT IF(cond, ?s, ?unbound))` idiom.
- **Comunica** – the existing behavioural test suite (`test/iiifStage.test.ts`), which already pins the capability-vs-conformance distinction and the zero-conformance edge case.

The only correctness risk — `COUNT(DISTINCT)` over an `IF`-unbound variable — yields `0` (not an error or a missing triple) when no row is conformant, on all of the above.
