### PR TITLE
fix(iiif): detect manifests regardless of profile quote style or whitespace

### DIFF
--- a/src/iiifManifestDetection.ts
+++ b/src/iiifManifestDetection.ts
@@ -8,19 +8,33 @@
  * the exclusion exists to prevent).
  *
  * Each helper returns a SPARQL boolean expression over `?{formatVariable}`,
- * ready to drop inside a `FILTER(…)`. Matched with `STRSTARTS`/`STRENDS` rather
+ * ready to drop inside a `FILTER(…)`. Matched with `STRSTARTS`/`CONTAINS` rather
  * than a regex, which is costly on QLever and on remote endpoints alike.
  */
 
 /**
- * The IIIF Presentation profile media type: a JSON-LD type whose `;profile=`
+ * The IIIF Presentation profile media type: a JSON-LD type whose `profile`
  * parameter points at an `iiif.io/api/presentation/{version}` context. The
  * version segment is left unconstrained — intentionally forwards-compatible with
  * future Presentation API versions.
+ *
+ * The match is deliberately serialization-agnostic. The `profile` parameter
+ * names the same context URI however it is written, but real data wraps it two
+ * ways: the SCHEMA-AP-NDE / Linked Art convention uses single quotes and no
+ * space (`;profile='…'`), while the HTTP/MIME- and JSON-LD-conformant form uses
+ * double quotes and may carry whitespace after the `;` (`; profile="…"`). One
+ * dataset can even expose both — RMO serves single quotes from its endpoint but
+ * double quotes in its data dump. So rather than anchoring on the quote or the
+ * whitespace, we anchor on the parts that never vary: the `application/ld+json`
+ * type prefix (cheap, and fails fast on the `image/*` majority) and the two
+ * stable URI substrings on either side of the version segment. This also matches
+ * the unquoted form. `CONTAINS` replaces the previous `STRENDS` for the same
+ * performance reason the helpers avoid `REGEX`.
  */
 export function iiifProfileFormatMatch(formatVariable: string): string {
-  return `STRSTARTS(STR(?${formatVariable}), "application/ld+json;profile='http://iiif.io/api/presentation/")
-        && STRENDS(STR(?${formatVariable}), "/context.json'")`;
+  return `STRSTARTS(STR(?${formatVariable}), "application/ld+json")
+        && CONTAINS(STR(?${formatVariable}), "iiif.io/api/presentation/")
+        && CONTAINS(STR(?${formatVariable}), "/context.json")`;
 }
 
 /**

--- a/test/iiifStage.test.ts
+++ b/test/iiifStage.test.ts
@@ -257,22 +257,46 @@ describe('iiif.rq detection query', () => {
 
   it('does not match near-miss encodingFormat literals', async () => {
     const turtle = `
-      # Different profile URL.
+      # Different IIIF API: the Image context, not Presentation.
       <http://example.org/work/1> schema:encodingFormat
         "application/ld+json;profile='http://iiif.io/api/image/3/context.json'" .
       # Missing the trailing context.json segment.
       <http://example.org/work/2> schema:encodingFormat
         "application/ld+json;profile='http://iiif.io/api/presentation/3/'" .
-      # Malformed: no quotes around the profile URL.
-      <http://example.org/work/3> schema:encodingFormat
-        "application/ld+json;profile=http://iiif.io/api/presentation/3/context.json" .
-      # Extra trailing characters.
-      <http://example.org/work/4> schema:encodingFormat
-        "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json' charset=utf-8" .
     `;
 
     const quads = await runQueryOn(turtle);
     expect(quads).toHaveLength(0);
+  });
+
+  it('matches the profile media type regardless of quote style or whitespace', async () => {
+    // The profile parameter names the same context URI however it is serialized,
+    // so detection must be serialization-agnostic. Real data exposes all of these
+    // forms: the SCHEMA-AP-NDE / Linked Art single-quote convention, the HTTP/MIME-
+    // and JSON-LD-conformant double-quote form (which RMO’s data dump uses), an
+    // optional space after the semicolon, and the unquoted form. (`\\"` is an
+    // escaped double quote inside the Turtle string literal.)
+    const turtle = `
+      <http://example.org/work/1> schema:encodingFormat
+        "application/ld+json;profile='http://iiif.io/api/presentation/3/context.json'" .
+      <http://example.org/work/2> schema:encodingFormat
+        "application/ld+json;profile=\\"http://iiif.io/api/presentation/3/context.json\\"" .
+      <http://example.org/work/3> schema:encodingFormat
+        "application/ld+json; profile=\\"http://iiif.io/api/presentation/3/context.json\\"" .
+      <http://example.org/work/4> schema:encodingFormat
+        "application/ld+json;profile=http://iiif.io/api/presentation/3/context.json" .
+    `;
+
+    const quads = await runQueryOn(turtle);
+
+    const subsetIri = findSubsetIri(quads);
+    expect(subsetIri).toBe(EXPECTED_SUBSET_IRI);
+    // All four serializations counted as four distinct manifests.
+    expect(findEntitiesCount(quads, subsetIri!)).toBe(4);
+    // And all four are profile-conformant — the bare ld+json form is the only
+    // capability-but-not-conformance case, covered by its own test.
+    const conformantIri = findConformantSubsetIri(quads, subsetIri!);
+    expect(findEntitiesCount(quads, conformantIri!)).toBe(4);
   });
 
   it('detects manifests published under https://schema.org/encodingFormat', async () => {


### PR DESCRIPTION
## Problem

IIIF Presentation manifests are detected from `schema:encodingFormat` literals, but the matcher only accepted one serialization of the `profile` media-type parameter: single quotes with no whitespace, `application/ld+json;profile='…/context.json'`. Real-world data uses several equivalent forms:

- **single quotes** (`;profile='…'`) — the SCHEMA-AP-NDE / Linked Art convention, served by e.g. RMO’s SPARQL endpoint;
- **double quotes** (`;profile="…"`) — the HTTP/MIME- and JSON-LD-conformant form (the `profile` value is a quoted-string per RFC 9110, and JSON-LD requires double quotes), served by e.g. RMO’s data dump;
- an optional **space after the semicolon** (`; profile=…`), allowed as OWS by RFC 9110;
- the **unquoted** form.

The same institution can expose more than one of these (RMO serves single quotes from its endpoint but double quotes in its dump), so a dataset’s manifests could go undetected depending on which serialization a source happens to use.

## Change

`iiifProfileFormatMatch` now anchors on the parts of the media type that never vary, instead of on the quote and whitespace:

```sparql
STRSTARTS(STR(?format), "application/ld+json")
&& CONTAINS(STR(?format), "iiif.io/api/presentation/")
&& CONTAINS(STR(?format), "/context.json")
```

- Detects single-quoted, double-quoted, space-after-semicolon and unquoted serializations alike.
- Keeps the version segment unconstrained (forwards-compatible across Presentation API versions).
- No `REGEX` (costly on QLever and remote endpoints); `CONTAINS` replaces the previous `STRENDS`, and the cheap `application/ld+json` prefix check fails fast on the `image/*` majority before the substring checks run.
- The helper is shared by the IIIF criterion (`iiif.rq`) and the subject-URI resolution exclusion, so both stay consistent.

The new matcher is a **strict superset** of the old one: every literal the previous `STRSTARTS`/`STRENDS` pair matched still matches, so nothing that was detected before regresses.

## Validation

- Verified against RMO’s actual data: a local QLever index built from RMO’s data dump (double-quote form) goes from **0 → 217,899** detected manifests with the new matcher, while the single-quote endpoint form is confirmed to still match at the engine level (the live endpoint itself was returning HTTP 502 during testing).
- Tests cover all four serialization variants and assert they are counted as conformant; the near-miss negative test is trimmed to the genuine non-matches (the IIIF Image context, and a profile missing `/context.json`).
