### PR TITLE
fix(subject-uri-resolution): exclude skolem namespaces from subject-URI sampling

### DIFF
--- a/src/subjectUriResolution.ts
+++ b/src/subjectUriResolution.ts
@@ -267,8 +267,9 @@ export interface SubjectUriResolutionOptions {
  *
  * It harvests the `void:uriSpace`/`void:entities` subsets from the stage
  * output (passing them through unchanged), picks the single most common
- * non-terminology namespace — the one the dataset mints for its own resources —
- * samples URIs from it, and dereferences them. The outcome is appended,
+ * namespace that is neither a terminology source nor a skolem
+ * (`/.well-known/genid/`) namespace — the one the dataset mints for its own
+ * resources — samples URIs from it, and dereferences them. The outcome is appended,
  * scoped to that namespace’s subset node:
  *
  * - **declared** facts: `dcterms:conformsTo` a PID scheme (ARK/Handle, only if
@@ -476,8 +477,19 @@ async function sampleUrisWithRetry(
 }
 
 /**
- * Pick the subset with the most entities whose namespace is not a terminology
- * source — unless that namespace is itself a recognised ARK/Handle PID scheme.
+ * Pick the subset with the most entities whose namespace is the dataset’s own —
+ * skipping a skolem namespace unconditionally and a terminology source unless
+ * that namespace is itself a recognised ARK/Handle PID scheme.
+ *
+ * A skolem namespace (`/.well-known/genid/`) holds RDF 1.1 skolem IRIs: system-
+ * minted stand-ins for blank nodes (checksum records, geometries, coverage
+ * details) that the publisher’s serializer emits so an anonymous node survives a
+ * round-trip. They are not identifiers the publisher promises to keep resolving,
+ * and they do not dereference — so treating one as the dataset’s self-minted
+ * subject namespace would score every sampled URI as broken. RAZU’s `kranten`
+ * mints 1.5M such nodes, more than any real namespace, so it would otherwise
+ * win. The exclusion is unconditional: a skolem namespace is never a PID, so —
+ * unlike the terminology exclusion below — PID-ness cannot override it.
  *
  * A NAAN registered as a Network of Terms source can also be the publisher’s own
  * persistent-identifier namespace: the Gouda Tijdmachine dataset mints its
@@ -493,6 +505,9 @@ function pickWinner(
 ): {subset: string; uriSpace: string} | undefined {
   let best: {subset: string; uriSpace: string; entities: number} | undefined;
   for (const [subset, uriSpace] of uriSpaceBySubset) {
+    if (isSkolemNamespace(uriSpace)) {
+      continue;
+    }
     if (
       detectPidScheme(uriSpace) === undefined &&
       terminologyPrefixes.some(prefix => uriSpace.startsWith(prefix))
@@ -505,6 +520,16 @@ function pickWinner(
     }
   }
   return best && {subset: best.subset, uriSpace: best.uriSpace};
+}
+
+/**
+ * Whether a namespace holds RDF 1.1 skolem IRIs — minted under the reserved
+ * `/.well-known/genid/` path as stand-ins for blank nodes. Matched on the path,
+ * host-independent and tolerant of `http`/`https`, so any publisher’s skolem
+ * namespace is recognised.
+ */
+function isSkolemNamespace(uriSpace: string): boolean {
+  return stripScheme(uriSpace).includes('/.well-known/genid/');
 }
 
 /** Strip a leading `http://`/`https://` once, so host/path matching is scheme-neutral. */

--- a/test/subjectUriResolution.test.ts
+++ b/test/subjectUriResolution.test.ts
@@ -268,6 +268,51 @@ describe('subjectUriResolution', () => {
     ).toBe(true);
   });
 
+  it('skips a skolem namespace even when it is the most common one', async () => {
+    // RAZU’s `kranten` skolemizes 1.5M blank nodes (checksum records, geometries)
+    // under `/.well-known/genid/` — more than any real namespace. Those skolem
+    // IRIs do not dereference, so picking them would score the whole sample as
+    // broken; the dataset’s own resolvable namespace must win instead.
+    const skolem = subset('https://data.razu.nl/.well-known/genid/', 1527258);
+    const own = subset('https://data.razu.nl/id/object/', 1211597);
+    const seen: string[] = [];
+    const transform = subjectUriResolution({
+      terminologyPrefixes: [],
+      sampleUris: async uriSpace => {
+        seen.push(uriSpace);
+        return [];
+      },
+      resolve: resolveByName,
+    });
+
+    await collect(transform(stream([...skolem.quads, ...own.quads]), context));
+
+    expect(seen).toEqual(['https://data.razu.nl/id/object/']);
+  });
+
+  it('never treats a skolem namespace as a PID scheme', async () => {
+    // The skolem exclusion is unconditional: unlike terminology, PID-ness cannot
+    // override it. With only a skolem namespace, nothing is sampled or emitted.
+    const skolem = subset('https://data.razu.nl/.well-known/genid/', 1527258);
+    const seen: string[] = [];
+    const transform = subjectUriResolution({
+      terminologyPrefixes: [],
+      sampleUris: async uriSpace => {
+        seen.push(uriSpace);
+        return [];
+      },
+      resolve: resolveByName,
+    });
+
+    const out = await collect(transform(stream(skolem.quads), context));
+
+    expect(seen).toEqual([]);
+    expect(out).toHaveLength(skolem.quads.length);
+    expect(out.some(q => q.predicate.equals(DQV_HAS_QUALITY_MEASUREMENT))).toBe(
+      false,
+    );
+  });
+
   it('emits nothing extra when only terminology namespaces survive', async () => {
     const terminology = subset('http://data.rkd.nl/artists/', 900000);
     const transform = subjectUriResolution({


### PR DESCRIPTION
## Problem

The persistent-URI check picks a dataset’s single most-common self-minted subject namespace, samples URIs from it, and dereferences them. For datasets that skolemize blank nodes, the largest namespace can be the skolem namespace itself.

RAZU’s [`kranten`](https://datasetregister.netwerkdigitaalerfgoed.nl/en/dataset?uri=https://data.razu.nl/id/dataset/kranten) mints **1,527,258** nodes under `https://data.razu.nl/.well-known/genid/` — more than any real namespace (`data.razu.nl/id/object/` has 1,211,597). `pickWinner` therefore selected the skolem namespace, and every sampled URI returned an HTTP error, so the check went 🔴.

Those `/.well-known/genid/` URIs are [RDF 1.1 skolem IRIs](https://www.w3.org/TR/rdf11-concepts/#section-skolemization): system-minted stand-ins for blank nodes. Inspecting the live data confirms they are anonymous compound value objects — `ldto:ChecksumGegevens`, `geosparql:Geometry`, `ldto:BeperkingGebruikGegevens`, coverage/retention details — each owned by exactly one parent through a structural predicate. They are not identifiers the publisher promises to keep resolving, and they do not dereference. Penalising a dataset for them is a category error.

## Change

- `pickWinner` now skips any `/.well-known/genid/` namespace, so a skolem namespace can never be chosen as the dataset’s subject namespace.
- The exclusion is **unconditional**: unlike the terminology exclusion, PID-ness cannot override it, because a skolem namespace is never a persistent identifier.
- Selection falls through to the dataset’s real resolvable namespace. Verified live: `data.razu.nl/id/object/` URIs resolve `200` (Turtle and HTML), so RAZU `kranten` would flip to 🟢.

## Tests

Two cases added: a skolem namespace with the most entities is skipped in favour of the dataset’s own namespace, and a skolem-only dataset yields no sampling and no measurements (PID-ness cannot rescue it).
