### PR TITLE
fix(iiif)!: drop the transitional dataset-level measurement link

### DIFF
--- a/src/iiifValidationExecutor.ts
+++ b/src/iiifValidationExecutor.ts
@@ -249,16 +249,6 @@ export class IiifValidationExecutor implements Executor {
     yield quad(iiifSubset, dqv.hasQualityMeasurement, sampledMeasurement);
     yield quad(iiifSubset, dqv.hasQualityMeasurement, validatedMeasurement);
 
-    // Backward compatibility: also link the measurements from the dataset, the
-    // path the shipped dataset-register queries still read
-    // (`?dataset dqv:hasQualityMeasurement …`). The new structure only appears
-    // after the next DKG run, so consumers cannot migrate to
-    // `void:subset/dqv:hasQualityMeasurement` before then. Drop these once
-    // dataset-register has migrated (tracked in dataset-register).
-    const datasetNode = namedNode(dataset.iri.toString());
-    yield quad(datasetNode, dqv.hasQualityMeasurement, sampledMeasurement);
-    yield quad(datasetNode, dqv.hasQualityMeasurement, validatedMeasurement);
-
     yield* integerMeasurement(
       sampledMeasurement,
       iiifSubset,

--- a/test/iiifValidationExecutor.test.ts
+++ b/test/iiifValidationExecutor.test.ts
@@ -176,15 +176,16 @@ describe('IiifValidationExecutor', () => {
       ),
     ).toHaveLength(2);
 
-    // Backward compatibility: the dataset also links to both measurements, so
-    // the shipped `?dataset dqv:hasQualityMeasurement` consumer keeps working.
+    // The measurements hang off the IIIF subset only; the dataset no longer
+    // re-links them (the transitional `?dataset dqv:hasQualityMeasurement` path
+    // was dropped once dataset-register migrated to the `void:subset` path).
     expect(
       out.filter(
         q =>
           q.subject.equals(namedNode(DATASET_IRI)) &&
           q.predicate.equals(DQV_HAS_QUALITY_MEASUREMENT),
       ),
-    ).toHaveLength(2);
+    ).toHaveLength(0);
 
     // Only the failed manifest is enumerated, as a qualified usage carrying its
     // reason; the validated one is covered by the count alone.


### PR DESCRIPTION
Removes the transitional dataset-level link for the IIIF validation measurements, leaving them on the IIIF capability subset only.

When IIIF manifest validation landed, the `manifests-sampled` / `manifests-validated` measurements were emitted **twice**: once off the IIIF `void:subset` (the intended structure, alongside `dcterms:conformsTo` + `void:entities`) and once directly off the dataset (`?dataset dqv:hasQualityMeasurement …`), a backward-compat shim so dataset-register kept working until it migrated.

dataset-register has now migrated to the subset path (netwerk-digitaal-erfgoed/dataset-register#2200), so the duplicate dataset-level link can go.

## Changes

- `src/iiifValidationExecutor.ts` — stop emitting the two dataset-level `dqv:hasQualityMeasurement` quads; the measurements hang off the IIIF subset only.
- `test/iiifValidationExecutor.test.ts` — assert the dataset no longer links the measurements.

## ⚠️ Merge ordering

This is a **breaking change** to the published graph and is gated on the consumer migration:

1. netwerk-digitaal-erfgoed/dataset-register#2200 must be merged **and deployed** first (its indexer + browser must read the subset path in production).
2. Only then merge this PR.

Merging before dataset-register#2200 is live would break the IIIF figures in the dataset browser. Kept as a draft until then.

## Breaking change

`manifests-sampled` and `manifests-validated` are no longer reachable via `?dataset dqv:hasQualityMeasurement`. Consumers must navigate via the subset:

```sparql
?dataset void:subset [
  dcterms:conformsTo <http://iiif.io/api/presentation/> ;
  dqv:hasQualityMeasurement [ dqv:isMeasurementOf nde:manifests-validated ; dqv:value ?validated ]
] .
```
