### PR TITLE
fix(deps): adopt @lde/pipeline 0.34.1 to skolemise summary blank nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@lde/dataset-registry-client": "^0.8.6",
         "@lde/distribution-health": "^0.2.6",
         "@lde/iiif-validator": "^0.1.5",
-        "@lde/pipeline": "^0.34.0",
+        "@lde/pipeline": "^0.34.1",
         "@lde/pipeline-console-reporter": "^0.25.0",
         "@lde/pipeline-shacl-sampler": "^0.8.0",
         "@lde/pipeline-shacl-validator": "^0.17.0",
@@ -6003,9 +6003,9 @@
       }
     },
     "node_modules/@lde/pipeline": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@lde/pipeline/-/pipeline-0.34.0.tgz",
-      "integrity": "sha512-Iqt8NZQbqRN9bEHTP0p8r5jByDDvd5yXQq5H32J6XmdMDEThwGMaVXWcEv9pwCju/PD3cOr7xvToy06LoGfrsg==",
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/@lde/pipeline/-/pipeline-0.34.1.tgz",
+      "integrity": "sha512-e3dvv2xOdqMIZQHtRXhTbUKLv1xhrS6Nb/n3mn0Qz3d4+uV+XmqqbIJGkbbeqtNmilfv6P/8rNPRcHFBSnZ1dw==",
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "^0.7.8",
@@ -6023,7 +6023,7 @@
         "fetch-sparql-endpoint": "^7.1.1",
         "filenamify-url": "^4.0.0",
         "is-network-error": "^1.3.2",
-        "n3": "^2.1.0",
+        "n3": "^2.1.1",
         "p-retry": "^8.0.0",
         "rdf-string": "^2.0.1",
         "tslib": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@lde/dataset-registry-client": "^0.8.6",
     "@lde/distribution-health": "^0.2.6",
     "@lde/iiif-validator": "^0.1.5",
-    "@lde/pipeline": "^0.34.0",
+    "@lde/pipeline": "^0.34.1",
     "@lde/pipeline-console-reporter": "^0.25.0",
     "@lde/pipeline-shacl-sampler": "^0.8.0",
     "@lde/pipeline-shacl-validator": "^0.17.0",


### PR DESCRIPTION
## What

Bump `@lde/pipeline` `0.34.0 → 0.34.1`, whose `FileWriter` now skolemises blank nodes to dataset-scoped IRIs when writing n-quads. DKG's summary and validation writers are exactly that (n-quads + per-dataset `graphIri`), so the DQV quality-measurement and PROV activity nodes — minted as blank nodes by `qualityMeasurementsStage` — are now written as distinct IRIs instead of raw blank nodes.

No code change: skolemisation is automatic for n-quads output.

## Why

The served store `cat`-indexes every per-dataset n-quads file into one graph, where document-scoped blank-node labels (`_:b0`…) from different datasets collapse into one node. This fused unrelated measurements, making a dataset appear both `schema-ap-nde-sample-conformance = true` and `= false` at once (e.g. `data.beeldengeluid.nl/id/dataset/0028`'s measurement fused with `vici.org/dataset`'s). VoID partitions escaped it by already being IRIs; the DQV measurements were the only unskolemised blank nodes.

## Effect

The ~154 datasets currently showing a contradictory conformance pair clear on the next full re-run (this dep bump ships in the next DKG release, whose pipeline-version bump reprocesses every dataset).

Fix #420
